### PR TITLE
Add SLM orchestration components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 __pycache__/
+logs/

--- a/src/ai_karen_engine/__init__.py
+++ b/src/ai_karen_engine/__init__.py
@@ -1,0 +1,7 @@
+"""Core runtime components for Kari."""
+
+from .clients.slm_pool import SLMPool
+from .llm_orchestrator import LLMOrchestrator
+from .echocore.fine_tuner import NightlyFineTuner
+
+__all__ = ["SLMPool", "LLMOrchestrator", "NightlyFineTuner"]

--- a/src/ai_karen_engine/clients/slm_pool.py
+++ b/src/ai_karen_engine/clients/slm_pool.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from typing import Dict, Iterable, Optional
+
+from src.integrations.llm_utils import LLMUtils
+
+
+class SLMPool:
+    """Manage a set of small language models keyed by skill."""
+
+    def __init__(self) -> None:
+        self._models: Dict[str, LLMUtils] = {}
+
+    def register(self, skill: str, model: LLMUtils) -> None:
+        """Register a model for a given skill."""
+        self._models[skill] = model
+
+    def get(self, skill: str) -> Optional[LLMUtils]:
+        """Return the model registered for ``skill`` if present."""
+        return self._models.get(skill)
+
+    def skills(self) -> Iterable[str]:
+        """Return all known skills."""
+        return self._models.keys()

--- a/src/ai_karen_engine/echocore/fine_tuner.py
+++ b/src/ai_karen_engine/echocore/fine_tuner.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Iterable
+
+
+class NightlyFineTuner:
+    """Sketch of a nightly fine-tuning loop using NeuroVault logs."""
+
+    def __init__(self, logs_path: Path) -> None:
+        self.logs_path = Path(logs_path)
+
+    def _load_logs(self) -> Iterable[str]:
+        if not self.logs_path.exists():
+            return []
+        for line in self.logs_path.read_text().splitlines():
+            try:
+                item = json.loads(line)
+                yield item.get("text", "")
+            except Exception:
+                continue
+
+    def run(self, model_path: Path) -> None:
+        """Collect logs and (conceptually) fine-tune the given model."""
+        dataset = list(self._load_logs())
+        # Placeholder for the actual training procedure
+        print(f"Fine-tuning {model_path} on {len(dataset)} samples from {self.logs_path}")

--- a/src/ai_karen_engine/llm_orchestrator.py
+++ b/src/ai_karen_engine/llm_orchestrator.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from src.integrations.llm_registry import registry
+from .clients.slm_pool import SLMPool
+
+
+class LLMOrchestrator:
+    """Route text generation to the smallest capable model."""
+
+    def __init__(self, pool: SLMPool | None = None) -> None:
+        self.pool = pool or SLMPool()
+        self.default_llm = registry.get_active()
+
+    def generate_text(self, prompt: str, *, skill: Optional[str] = None, max_tokens: int = 128) -> str:
+        # first attempt: use a skill-specific SLM if available
+        if skill:
+            slm = self.pool.get(skill)
+            if slm:
+                return slm.generate_text(prompt, max_tokens=max_tokens)
+
+        # otherwise pick any SLM that seems capable (naive length check)
+        for slm in self.pool._models.values():
+            if len(prompt.split()) <= max_tokens * 2:
+                return slm.generate_text(prompt, max_tokens=max_tokens)
+
+        if hasattr(self.default_llm, "generate_text"):
+            return self.default_llm.generate_text(prompt, max_tokens=max_tokens)
+        raise RuntimeError("No language model available")

--- a/tests/test_llm_orchestrator.py
+++ b/tests/test_llm_orchestrator.py
@@ -1,0 +1,17 @@
+from src.ai_karen_engine import SLMPool, LLMOrchestrator
+from src.integrations.llm_utils import LLMUtils
+
+
+def test_orchestrator_uses_skill_model():
+    pool = SLMPool()
+    model = LLMUtils(model_name="nonexistent-model")
+    pool.register("sentiment", model)
+    orch = LLMOrchestrator(pool)
+    out = orch.generate_text("hello", skill="sentiment")
+    assert "hello" in out
+
+
+def test_orchestrator_fallback_to_default():
+    orch = LLMOrchestrator(SLMPool())
+    out = orch.generate_text("fallback works")
+    assert "fallback works" in out

--- a/tests/test_slm_pool.py
+++ b/tests/test_slm_pool.py
@@ -1,0 +1,10 @@
+from src.ai_karen_engine.clients.slm_pool import SLMPool
+from src.integrations.llm_utils import LLMUtils
+
+
+def test_slm_pool_register_and_get():
+    pool = SLMPool()
+    model = LLMUtils(model_name="nonexistent-model")
+    pool.register("summarizer", model)
+    assert pool.get("summarizer") is model
+    assert "summarizer" in list(pool.skills())


### PR DESCRIPTION
## Summary
- add `SLMPool` manager for skill-specific small models
- implement `LLMOrchestrator` for SLM-aware generation
- sketch `NightlyFineTuner` using NeuroVault logs
- test the new modules
- ignore runtime logs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857a430f07c83249de5932b89150299