### PR TITLE
Fix BaseModel type hints

### DIFF
--- a/pydantic/__init__.py
+++ b/pydantic/__init__.py
@@ -1,4 +1,7 @@
+from typing import Any
+
+
 class BaseModel:
-    def __init__(self, **data):
+    def __init__(self, **data: Any) -> None:
         for k, v in data.items():
             setattr(self, k, v)


### PR DESCRIPTION
## Summary
- add typing to `pydantic.BaseModel`

## Testing
- `pytest -q`
- `mypy pydantic/__init__.py --strict`

------
https://chatgpt.com/codex/tasks/task_e_68586c9f20488324a1e5ae7c35041bc3