### PR TITLE
Add tokenizer manager with byte-level support

### DIFF
--- a/core/orchestration/model_router.py
+++ b/core/orchestration/model_router.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from typing import Any
+
+from src.integrations.llm_registry import registry
+
+
+def route_input(model: Any, text: str) -> Any:
+    """Encode ``text`` according to model metadata."""
+    tokenizer_type = getattr(model, "tokenizer_type", "bpe")
+    if tokenizer_type == "byte":
+        return text.encode("utf-8")
+    if hasattr(model, "tokenizer") and model.tokenizer is not None:
+        return model.tokenizer.encode(text)
+    return text.split()

--- a/models/llm_registry.json
+++ b/models/llm_registry.json
@@ -1,0 +1,14 @@
+{
+  "llama3": {
+    "model_name": "llama3-8b",
+    "provider": "ollama",
+    "tokenizer_type": "bpe",
+    "prompt_limit_bytes": 32768
+  },
+  "echo_byte_llm": {
+    "model_name": "echo_byte_v1",
+    "provider": "local",
+    "tokenizer_type": "byte",
+    "prompt_limit_bytes": 65536
+  }
+}

--- a/src/ai_karen_engine/clients/embedding/embedding_client.py
+++ b/src/ai_karen_engine/clients/embedding/embedding_client.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import hashlib
+from typing import List
+
+from core.embedding_manager import EmbeddingManager
+
+
+def _byte_embedding_model(byte_input: bytes, dim: int = 8) -> List[float]:
+    h = hashlib.sha256(byte_input).digest()
+    return [b / 255 for b in h[:dim]]
+
+
+def get_embedding(text: str, model_type: str = "default") -> List[float]:
+    """Return an embedding using byte or token mode."""
+    if model_type == "byte":
+        return _byte_embedding_model(text.encode("utf-8"))
+    manager = EmbeddingManager()
+    return manager.embed(text)

--- a/src/ai_karen_engine/core/__init__.py
+++ b/src/ai_karen_engine/core/__init__.py
@@ -1,0 +1,1 @@
+"""Core utilities for AI Karen engine."""

--- a/src/ai_karen_engine/core/tokenizer_manager.py
+++ b/src/ai_karen_engine/core/tokenizer_manager.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+class TokenizerManager:
+    """Switch between byte and BPE tokenization."""
+
+    def __init__(self, model_metadata: Dict[str, Any]) -> None:
+        self.metadata = model_metadata
+        self.tokenizer_type = model_metadata.get("tokenizer_type", "bpe")
+
+    def encode(self, text: str) -> Any:
+        """Return encoded text depending on ``tokenizer_type``."""
+        if self.tokenizer_type == "byte":
+            return text.encode("utf-8")
+        if self.tokenizer_type == "bpe":
+            try:  # pragma: no cover - optional dependency
+                from transformers import AutoTokenizer  # type: ignore
+
+                tokenizer = AutoTokenizer.from_pretrained(
+                    self.metadata["model_name"]
+                )
+                return tokenizer.encode(text, return_tensors="pt")
+            except Exception:
+                return text.split()
+        raise NotImplementedError(f"Unknown tokenizer type: {self.tokenizer_type}")

--- a/tests/test_embedding_client.py
+++ b/tests/test_embedding_client.py
@@ -1,0 +1,8 @@
+from src.ai_karen_engine.clients.embedding.embedding_client import get_embedding
+
+
+def test_get_embedding_byte_and_default():
+    default_vec = get_embedding("hello")
+    byte_vec = get_embedding("hello", model_type="byte")
+    assert len(default_vec) == len(byte_vec)
+

--- a/tests/test_tokenizer_manager.py
+++ b/tests/test_tokenizer_manager.py
@@ -1,0 +1,12 @@
+from src.ai_karen_engine.core.tokenizer_manager import TokenizerManager
+
+
+def test_byte_encoding():
+    manager = TokenizerManager({"tokenizer_type": "byte"})
+    assert manager.encode("hi") == b"hi"
+
+
+def test_bpe_fallback():
+    manager = TokenizerManager({"tokenizer_type": "bpe", "model_name": "dummy"})
+    tokens = manager.encode("hello world")
+    assert tokens


### PR DESCRIPTION
## Summary
- introduce `TokenizerManager` to handle byte and BPE encodings
- include a small embedding client that works in byte mode
- add model metadata registry with tokenizer types
- simple model router helper for encoding input
- tests for tokenizer manager and embedding client

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685dbee00ec0832487517adad28324b6