### PR TITLE
Improve Control Room setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,15 +110,18 @@ docs/          # architecture docs (mesh_arch.md, …)
 ./scripts/install.sh
 
 # 2 · Install Control Room packages
-cd desktop_ui/frontend && npm install && cd ../..
+cd desktop_ui && npm install
+cd frontend && npm install && cd ../..
 
 # 3 · Launch backend API + dependencies
 ./scripts/start.sh
 
 # 4 · Run desktop Control Room (dev mode)
 cd desktop_ui && npx tauri dev  # uses src-tauri/tauri.conf.json
-
 ```
+
+# Optional: run everything with one command
+./scripts/bootstrap_ui.sh
 
 **Full stack (API + Milvus + Redis + Prometheus):**
 
@@ -259,6 +262,7 @@ Additional guides:
 - [Event Bus](docs/event_bus.md)
 - [Observability](docs/observability.md)
 - [UI Handbook](docs/ui_handbook.md)
+- [Development Guide](docs/development_guide.md)
  
 - [ICE Wrapper](docs/ice_wrapper.md)
 

--- a/desktop_ui/README.md
+++ b/desktop_ui/README.md
@@ -5,5 +5,7 @@ The frontend is a small Vite application inside `frontend/`.
 The Tauri shell lives in `src-tauri/` and launches the UI
 pointing at the FastAPI backend running on `localhost:8000`.
 
-Run the backend with `uvicorn main:app` and start the UI using
-`npx tauri dev` from within this folder.
+1. Install dependencies with `npm install` in this directory.
+2. Install frontend packages: `npm --prefix frontend install`.
+3. Start the backend with `uvicorn main:app`.
+4. Launch the UI using `npx tauri dev`.

--- a/docs/development_guide.md
+++ b/docs/development_guide.md
@@ -1,0 +1,44 @@
+# Development Guide
+
+This guide explains two common workflows for running Kari during development and when building a production desktop app.
+
+## Development Mode (Python UI)
+
+Use this path for rapid iteration without packaging.
+
+```bash
+# start Kari's API backend
+uvicorn main:app --reload --port 8000
+
+# open docs in the browser
+xdg-open http://localhost:8000/docs
+
+# run the UI directly (e.g. Streamlit or PySide)
+python desktop_ui/main.py
+```
+
+## Build Mode (Tauri App)
+
+Use this path to compile the full Tauri desktop application.
+
+```bash
+# ensure Rust and the Tauri CLI are available
+source "$HOME/.cargo/env"
+cargo install tauri-cli
+
+# run in development mode with hot reload
+cargo tauri dev
+
+# or build a release binary
+cargo tauri build
+```
+
+## Summary
+
+| Mode          | Command                             | Description                         |
+| ------------- | ----------------------------------- | ----------------------------------- |
+| Dev (API)     | `uvicorn main:app --reload`         | Hot reload the backend              |
+| Dev (UI)      | `python desktop_ui/main.py`         | Python UI for quick tests           |
+| Tauri Dev     | `cargo tauri dev`                   | Desktop shell with live reload      |
+| Build         | `cargo tauri build`                 | Create installable binaries         |
+

--- a/scripts/bootstrap_ui.sh
+++ b/scripts/bootstrap_ui.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+set -e
+
+echo "🔧 Bootstrapping Kari Desktop UI..."
+
+# Step 1: Install Rust + Cargo if missing
+if ! command -v cargo >/dev/null 2>&1; then
+    echo "🦀 Installing Rust toolchain..."
+    curl https://sh.rustup.rs -sSf | sh -s -- -y
+    source "$HOME/.cargo/env"
+else
+    echo "✅ Rust already installed."
+fi
+
+# Step 2: Install Tauri CLI
+echo "🚀 Installing Tauri CLI..."
+cargo install tauri-cli || true
+
+# Step 3: Add alias if tauri command doesn't exist
+if ! command -v tauri >/dev/null 2>&1; then
+    echo "🔗 Creating alias: tauri='cargo tauri'"
+    SHELL_RC="$HOME/.bashrc"
+    [[ $SHELL == *zsh* ]] && SHELL_RC="$HOME/.zshrc"
+    grep -qxF 'alias tauri="cargo tauri"' "$SHELL_RC" || echo 'alias tauri="cargo tauri"' >> "$SHELL_RC"
+    source "$SHELL_RC"
+else
+    echo "✅ Tauri CLI available as 'tauri'"
+fi
+
+# Step 4: NPM dependencies
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+UI_DIR="$SCRIPT_DIR/../desktop_ui"
+cd "$UI_DIR"
+
+echo "📦 Installing desktop_ui dependencies..."
+npm install
+
+cd frontend
+npm install
+cd ..
+
+# Step 5: Launch dev
+echo "🖥️  Launching Kari UI in dev mode..."
+tauri dev


### PR DESCRIPTION
## Summary
- install desktop_ui dependencies in README quick-start
- show optional bootstrap script usage
- document UI setup steps in `desktop_ui/README.md`
- add `scripts/bootstrap_ui.sh` helper
- create `docs/development_guide.md` describing dev vs build workflows

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f18435d2c8324b4b318611ad2cdc3