### PR TITLE
Fix FastAPI stub TestClient

### DIFF
--- a/fastapi_stub/testclient.py
+++ b/fastapi_stub/testclient.py
@@ -18,3 +18,5 @@ class TestClient:
         data = asyncio.run(self.app("GET", path))
         if isinstance(data, Response):
             return data
+        return Response(data)
+


### PR DESCRIPTION
## Summary
- repair the `fastapi_stub.TestClient.get` function so it returns a Response

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685fe8b279208324b6d9e16fe8c9bc7f