### PR TITLE
Add fastapi guard and server CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,17 @@ cd backend
 uvicorn main:app --reload
 ```
 
+You can also manage the API server via a small CLI:
+
+```bash
+python scripts/server_cli.py start --reload  # start
+python scripts/server_cli.py stop            # stop if running
+```
+
+If you encounter `ImportError: cannot import name 'FastAPI'`, check for a
+directory named `fastapi` in the project root. It will shadow the installed
+package. The server now exits with an error if such a folder exists.
+
 ### 3. Start Frontend (optional)
 
 ```bash

--- a/fastapi_stub/__init__.py
+++ b/fastapi_stub/__init__.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import re
+import sys
 from types import SimpleNamespace
 from urllib.parse import parse_qs
 
@@ -34,6 +35,11 @@ class FastAPI:
     def post(self, path):
         def decorator(func):
             self.routes.append(_Route("POST", path, func))
+            return func
+        return decorator
+
+    def exception_handler(self, exc):
+        def decorator(func):
             return func
         return decorator
 
@@ -112,6 +118,18 @@ class Response:
         if isinstance(self._data, list):
             return [vars(x) if hasattr(x, "__dict__") else x for x in self._data]
         return self._data
+
+
+class JSONResponse(Response):
+    pass
+
+
+responses = SimpleNamespace(JSONResponse=JSONResponse)
+sys.modules["fastapi.responses"] = responses
+
+
+class Request:
+    pass
 
 class TestClient:
     def __init__(self, app):

--- a/fastapi_stub/testclient.py
+++ b/fastapi_stub/testclient.py
@@ -18,3 +18,5 @@ class TestClient:
         data = asyncio.run(self.app("GET", path))
         if isinstance(data, Response):
             return data
+        return Response(data)
+

--- a/main.py
+++ b/main.py
@@ -1,14 +1,32 @@
 from typing import Any, Dict, List
+from pathlib import Path
+import sys
 
 from core.cortex.dispatch import CortexDispatcher
 from core.embedding_manager import _METRICS as METRICS
 from core.soft_reasoning_engine import SoftReasoningEngine
-from fastapi import FastAPI, HTTPException
+if (Path(__file__).resolve().parent / "fastapi").is_dir():
+    sys.stderr.write(
+        "Error: A local 'fastapi' directory exists. It shadows the installed FastAPI package.\n"
+    )
+    sys.exit(1)
+
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 import asyncio
+import logging
 from src.integrations.llm_registry import registry as llm_registry
 
 app = FastAPI()
+
+logger = logging.getLogger("kari")
+
+
+@app.exception_handler(Exception)
+async def handle_unexpected(request: Request, exc: Exception):
+    logger.exception("Unhandled error")
+    return JSONResponse({"detail": str(exc)}, status_code=500)
 
 dispatcher = CortexDispatcher()
 engine = SoftReasoningEngine()

--- a/scripts/server_cli.py
+++ b/scripts/server_cli.py
@@ -1,0 +1,82 @@
+import argparse
+import asyncio
+import os
+import signal
+import sys
+from pathlib import Path
+
+try:
+    import uvicorn
+except ModuleNotFoundError:  # pragma: no cover - runtime guard
+    print(
+        "Error: uvicorn is not installed. Install it with 'pip install uvicorn'",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+PID_FILE = Path("server.pid")
+
+
+def run_server(host: str, port: int, reload: bool = False) -> None:
+    """Run the FastAPI server with graceful shutdown."""
+    local_pkg = Path("fastapi")
+    if local_pkg.exists() and local_pkg.is_dir():
+        print(
+            "Error: a local 'fastapi' directory shadows the FastAPI package.\n"
+            "Rename or remove it before starting the server.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    config = uvicorn.Config("main:app", host=host, port=port, reload=reload)
+    server = uvicorn.Server(config)
+
+    def handle_sig(_sig, _frame):
+        server.should_exit = True
+
+    signal.signal(signal.SIGTERM, handle_sig)
+    signal.signal(signal.SIGINT, handle_sig)
+
+    PID_FILE.write_text(str(os.getpid()))
+    try:
+        asyncio.run(server.serve())
+    finally:
+        PID_FILE.unlink(missing_ok=True)
+
+
+def stop_server() -> None:
+    """Stop the running server if the pid file exists."""
+    if not PID_FILE.exists():
+        print("No running server found")
+        return
+    pid = int(PID_FILE.read_text())
+    try:
+        os.kill(pid, signal.SIGTERM)
+        print(f"Sent SIGTERM to {pid}")
+    except ProcessLookupError:
+        print("Server process not running")
+    PID_FILE.unlink(missing_ok=True)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Manage the Kari backend server")
+    sub = parser.add_subparsers(dest="cmd")
+
+    start = sub.add_parser("start", help="start the server")
+    start.add_argument("--host", default="0.0.0.0")
+    start.add_argument("--port", type=int, default=8000)
+    start.add_argument("--reload", action="store_true")
+
+    sub.add_parser("stop", help="stop the server")
+
+    args = parser.parse_args()
+    if args.cmd == "start":
+        run_server(args.host, args.port, args.reload)
+    elif args.cmd == "stop":
+        stop_server()
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- fail fast if a local `fastapi` directory is detected
- provide CLI to start and stop the server with graceful shutdown
- stub TestClient returns Response objects correctly
- document CLI usage and shadowing issue
- handle missing `uvicorn` dependency gracefully

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685fe8b279208324b6d9e16fe8c9bc7f