### PR TITLE
Update Tauri CLI to 2.5.0

### DIFF
--- a/desktop_ui/package.json
+++ b/desktop_ui/package.json
@@ -10,6 +10,6 @@
     "tauri:start": "npm run build && tauri dev"
   },
   "devDependencies": {
-    "@tauri-apps/cli": "^1.5.0"
+    "@tauri-apps/cli": "^2.5.0"
   }
 }


### PR DESCRIPTION
## Summary
- bump `@tauri-apps/cli` to 2.5.0 in desktop UI

## Testing
- `pytest -q`
- `npm run tauri dev` *(fails: `tauri: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68632b77a19083249e71c594da91c00e