### PR TITLE
Add modular Streamlit mobile UI

### DIFF
--- a/mobile_ui/app.py
+++ b/mobile_ui/app.py
@@ -1,44 +1,29 @@
-import os
 import streamlit as st
-from components import (
-    render_sidebar,
-    select_provider,
-    select_model,
-    key_input,
-    memory_config,
-)
+from components.sidebar import render_sidebar
+from components.chat import render_chat
+from components.configuration import render_configuration
+from components.memory import render_memory
+from components.models import render_models
+from components.diagnostics import render_diagnostics
 
-st.set_page_config(layout="wide", page_title="Kari AI – Mobile Control")
+st.set_page_config(layout="wide", page_title="Kari AI – Mobile UI")
 
-# Load CSS safely
-css_path = os.path.join(os.path.dirname(__file__), "styles", "styles.css")
-if os.path.exists(css_path):
-    with open(css_path) as f:
+try:
+    with open("styles/styles.css") as f:
         st.markdown(f"<style>{f.read()}</style>", unsafe_allow_html=True)
-else:
-    st.warning("No styles.css found in styles/. Using default Streamlit theme.")
+except FileNotFoundError:
+    st.warning("styles.css not found. Skipping custom styles.")
 
 selection = render_sidebar()
 
-st.title("⚙️ Kari Configuration")
+if selection == "Home":
+    render_chat()
+elif selection == "Settings":
+    render_configuration()
+elif selection == "Models":
+    render_models()
+elif selection == "Memory":
+    render_memory()
+elif selection == "Diagnostics":
+    render_diagnostics()
 
-provider = select_provider()
-model = select_model(provider)
-api_key = key_input(provider)
-use_memory, context_len, decay = memory_config()
-
-col1, col2 = st.columns([1, 1])
-
-with col1:
-    if st.button("🔌 Test Connection"):
-        if provider and model:
-            st.info(f"Testing connection to {provider} - {model}...")
-            # TODO: validate connection to provider/model
-            st.success("Connection successful!")  # placeholder
-        else:
-            st.error("Please select a provider and model first.")
-
-with col2:
-    if st.button("💾 Save Configuration"):
-        st.success("Settings saved to secure memory vault.")
-        # TODO: persist to DuckDB or Kari's config handler

--- a/mobile_ui/components/__init__.py
+++ b/mobile_ui/components/__init__.py
@@ -1,13 +1,20 @@
 from .sidebar import render_sidebar
-from .provider_selector import select_provider
-from .model_selector import select_model
-from .key_manager import key_input
-from .memory_settings import memory_config
+from .chat import render_chat
+from .configuration import render_configuration
+from .memory import render_memory, memory_config
+from .models import render_models, select_model
+from .provider import select_provider
+from .diagnostics import render_diagnostics
 
 __all__ = [
     "render_sidebar",
-    "select_provider",
-    "select_model",
-    "key_input",
+    "render_chat",
+    "render_configuration",
+    "render_memory",
     "memory_config",
+    "render_models",
+    "select_model",
+    "select_provider",
+    "render_diagnostics",
 ]
+

--- a/mobile_ui/components/chat.py
+++ b/mobile_ui/components/chat.py
@@ -1,0 +1,11 @@
+import streamlit as st
+
+
+def render_chat():
+    st.title("\U0001F4AC Chat with Kari")
+    user_input = st.chat_input("Type your message")
+    if user_input:
+        st.chat_message("user").write(user_input)
+        # TODO: replace with real call to Kari’s brain
+        st.chat_message("assistant").write("\u26A1 Response from Kari goes here.")
+

--- a/mobile_ui/components/configuration.py
+++ b/mobile_ui/components/configuration.py
@@ -1,0 +1,27 @@
+import streamlit as st
+from .provider import select_provider
+from .models import select_model
+from .memory import memory_config
+from utils.api_client import persist_config
+
+
+def render_configuration():
+    st.title("\u2699\ufe0f Kari Configuration")
+    provider = select_provider()
+    model = select_model(provider)
+    api_key = st.text_input(f"{provider} API Key", type="password")
+    use_memory, context_len, decay = memory_config()
+
+    if st.button("\U0001F4BE Save Configuration"):
+        persist_config(
+            {
+                "provider": provider,
+                "model": model,
+                "api_key": api_key,
+                "use_memory": use_memory,
+                "context_length": context_len,
+                "decay": decay,
+            }
+        )
+        st.success("Settings saved.")
+

--- a/mobile_ui/components/diagnostics.py
+++ b/mobile_ui/components/diagnostics.py
@@ -1,0 +1,7 @@
+import streamlit as st
+
+
+def render_diagnostics():
+    st.title("\U0001F9EA Diagnostics")
+    st.write("Coming soon: system metrics, model latency, GPU status, API call logs...")
+

--- a/mobile_ui/components/memory.py
+++ b/mobile_ui/components/memory.py
@@ -1,0 +1,15 @@
+import streamlit as st
+
+
+def memory_config():
+    st.subheader("\U0001F9E0 Memory Configuration")
+    use_memory = st.checkbox("Enable Memory", value=True)
+    context_len = st.slider("Context Length", 50, 2048, 512)
+    decay = st.slider("Memory Decay Rate", 0.0, 1.0, 0.1)
+    return use_memory, context_len, decay
+
+
+def render_memory():
+    st.title("\U0001F4E6 Memory Settings")
+    memory_config()
+

--- a/mobile_ui/components/models.py
+++ b/mobile_ui/components/models.py
@@ -1,0 +1,19 @@
+import streamlit as st
+
+MODEL_OPTIONS = {
+    "Local (Ollama)": ["llama3.2:latest", "mistral", "codellama"],
+    "HuggingFace": ["gpt2", "bloom", "falcon-7b"],
+    "Groq": ["llama3-70b", "mixtral-8x7b"],
+}
+
+
+def select_model(provider: str):
+    st.subheader("\U0001F3AF Select Model")
+    return st.selectbox("Model", MODEL_OPTIONS.get(provider, []))
+
+
+def render_models():
+    st.title("\U0001F9E0 Model Settings")
+    provider = st.selectbox("Choose Provider", list(MODEL_OPTIONS.keys()))
+    select_model(provider)
+

--- a/mobile_ui/components/provider.py
+++ b/mobile_ui/components/provider.py
@@ -1,0 +1,7 @@
+import streamlit as st
+
+
+def select_provider():
+    st.subheader("\U0001F50C LLM Provider")
+    return st.selectbox("Choose a provider", ["Local (Ollama)", "HuggingFace", "Groq"])
+

--- a/mobile_ui/components/sidebar.py
+++ b/mobile_ui/components/sidebar.py
@@ -1,10 +1,6 @@
 import streamlit as st
 
 
-def render_sidebar() -> str:
-    st.sidebar.title("\U0001F464 Kari Mobile")
-    st.sidebar.write("Welcome!")
-    selection = st.sidebar.radio(
-        "Navigation", ["Home", "Settings", "Models", "Memory", "Diagnostics"]
-    )
-    return selection
+def render_sidebar():
+    st.sidebar.title("\U0001F9ED Navigation")
+    return st.sidebar.radio("Go to", ["Home", "Settings", "Models", "Memory", "Diagnostics"])

--- a/mobile_ui/styles/styles.css
+++ b/mobile_ui/styles/styles.css
@@ -1,19 +1,9 @@
-/* styles/styles.css */
 body {
-    background-color: #0f0f0f;
-    color: #f5f5f5;
-    font-family: 'Segoe UI', sans-serif;
+    background-color: #0b0c10;
+    color: #f8f8f2;
+}
+.stButton>button {
+    background-color: #5cdb95;
+    color: black;
 }
 
-.stButton > button {
-    background-color: #0055ff;
-    color: white;
-    border-radius: 0.5rem;
-    padding: 0.5rem 1rem;
-    border: none;
-    font-weight: bold;
-}
-
-.sidebar .sidebar-content {
-    background-color: #1f1f1f;
-}

--- a/mobile_ui/utils/api_client.py
+++ b/mobile_ui/utils/api_client.py
@@ -31,3 +31,22 @@ def get_api_key() -> str | None:
 def get_model() -> str:
     """Return the selected model name from the session state."""
     return st.session_state.get("model", "llama3")
+
+import json
+from pathlib import Path
+
+CONFIG_PATH = Path("config/settings.json")
+
+
+def persist_config(config: dict):
+    CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with open(CONFIG_PATH, "w") as f:
+        json.dump(config, f, indent=2)
+
+
+def load_config() -> dict:
+    if CONFIG_PATH.exists():
+        with open(CONFIG_PATH) as f:
+            return json.load(f)
+    return {}
+


### PR DESCRIPTION
## Summary
- redesign `mobile_ui` to use a modular architecture
- add chat, configuration, diagnostics, memory, model, provider components
- allow saving configuration to `config/settings.json`
- streamline sidebar navigation and styling

## Testing
- `pytest tests/ui/test_chat_hub.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6863a2fbbe908324b06b6c92987a80f3