### PR TITLE
Integrate personalized NLP modules

### DIFF
--- a/clients/nlp/basic_classifier.py
+++ b/clients/nlp/basic_classifier.py
@@ -1,0 +1,49 @@
+"""scikit-learn intent classifier."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List, Tuple
+
+try:
+    import joblib
+    import numpy as np
+    from sklearn.feature_extraction.text import TfidfVectorizer
+    from sklearn.linear_model import LogisticRegression
+except Exception:  # pragma: no cover - optional dep
+    joblib = np = TfidfVectorizer = LogisticRegression = None
+
+MODEL_FILE = "classifier.joblib"
+VECT_FILE = "vectorizer.joblib"
+
+
+class BasicClassifier:
+    """Tiny TF-IDF + LogisticRegression model."""
+
+    def __init__(self, model_dir: Path) -> None:
+        if any(dep is None for dep in (joblib, np, TfidfVectorizer, LogisticRegression)):
+            raise RuntimeError("scikit-learn is required for BasicClassifier")
+        self.model_path = model_dir / MODEL_FILE
+        self.vector_path = model_dir / VECT_FILE
+        if self.model_path.exists():
+            self.clf = joblib.load(self.model_path)
+            self.vectorizer = joblib.load(self.vector_path)
+        else:
+            self.clf = None
+            self.vectorizer = None
+
+    def fit(self, texts: List[str], labels: List[str]) -> None:
+        self.vectorizer = TfidfVectorizer(max_features=25_000, ngram_range=(1, 2))
+        X = self.vectorizer.fit_transform(texts)
+        self.clf = LogisticRegression(max_iter=1_000).fit(X, labels)
+        self._save()
+
+    def predict(self, text: str) -> Tuple[str, float]:
+        X = self.vectorizer.transform([text])
+        proba = self.clf.predict_proba(X)[0]
+        idx = int(np.argmax(proba))
+        return self.clf.classes_[idx], float(proba[idx])
+
+    def _save(self) -> None:
+        self.model_path.parent.mkdir(parents=True, exist_ok=True)
+        joblib.dump(self.clf, self.model_path)
+        joblib.dump(self.vectorizer, self.vector_path)

--- a/clients/nlp/spacy_client.py
+++ b/clients/nlp/spacy_client.py
@@ -1,0 +1,32 @@
+"""spaCy wrapper for deeper NLP analysis."""
+from __future__ import annotations
+
+from typing import Dict, List
+
+try:
+    import spacy
+except Exception:  # pragma: no cover - optional dep
+    spacy = None
+
+DEFAULT_MODEL = "en_core_web_trf"
+
+
+class SpaCyClient:
+    """Expose common spaCy pipeline hooks."""
+
+    def __init__(self, model_name: str = DEFAULT_MODEL) -> None:
+        if spacy is None:
+            raise RuntimeError("spaCy is required for SpaCyClient")
+        self.nlp = spacy.load(model_name)
+
+    def extract_entities(self, text: str) -> List[Dict[str, str]]:
+        doc = self.nlp(text)
+        return [{"text": ent.text, "label": ent.label_} for ent in doc.ents]
+
+    def pos_tags(self, text: str) -> List[Dict[str, str]]:
+        doc = self.nlp(text)
+        return [{"text": tok.text, "pos": tok.pos_} for tok in doc]
+
+    def dependency_tree(self, text: str) -> List[Dict[str, str]]:
+        doc = self.nlp(text)
+        return [{"text": tok.text, "dep": tok.dep_, "head": tok.head.text} for tok in doc]

--- a/clients/transformers/lnm_client.py
+++ b/clients/transformers/lnm_client.py
@@ -1,0 +1,47 @@
+"""Inference helper for personalised DistilBERT models."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List
+
+try:
+    import torch
+except Exception:  # pragma: no cover - optional dep
+    torch = None
+try:
+    from transformers import AutoTokenizer, AutoModelForSequenceClassification, pipeline
+except Exception:  # pragma: no cover - optional dep
+    AutoTokenizer = AutoModelForSequenceClassification = pipeline = None
+
+
+class LNMClient:
+    """Thin wrapper around transformers pipelines."""
+
+    def __init__(self, model_dir: Path) -> None:
+        if AutoTokenizer is None or AutoModelForSequenceClassification is None or pipeline is None:
+            raise RuntimeError("transformers library is required for LNMClient")
+        self.tokenizer = AutoTokenizer.from_pretrained(model_dir)
+        self.model = AutoModelForSequenceClassification.from_pretrained(model_dir)
+        device = 0 if (torch and torch.cuda.is_available()) else -1
+        self.cls_pipe = pipeline(
+            "text-classification", model=self.model, tokenizer=self.tokenizer, device=device
+        )
+        self.feat_pipe = pipeline(
+            "feature-extraction", model=self.model, tokenizer=self.tokenizer, device=device
+        )
+
+    def classify(self, text: str) -> str:
+        """Return the predicted label."""
+        return max(self.cls_pipe(text), key=lambda x: x["score"])["label"]
+
+    def embed(self, text: str) -> List[float]:
+        """Return mean-pooled embedding."""
+        emb = self.feat_pipe(text, truncation=True, padding=True, return_tensors="pt")[0]
+        return emb.mean(dim=0).tolist()
+
+    def generate(self, text: str, context: str | None = None) -> str:
+        """Simplistic echo generation with intent filter."""
+        label = self.classify(text)
+        if label == "chit_chat" and context:
+            return f"{context} … {text}"
+        return f"Intent '{label}' acknowledged."

--- a/core/echo_core.py
+++ b/core/echo_core.py
@@ -1,0 +1,97 @@
+"""Fine-tune DistilBERT models on interaction logs."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, List
+
+try:
+    import torch
+except Exception:  # pragma: no cover - optional dep
+    torch = None
+try:
+    from datasets import Dataset
+except Exception:  # pragma: no cover - optional dep
+    Dataset = None
+try:
+    from transformers import (
+        AutoTokenizer,
+        AutoModelForSequenceClassification,
+        Trainer,
+        TrainingArguments,
+    )
+except Exception:  # pragma: no cover - optional dep
+    AutoTokenizer = AutoModelForSequenceClassification = Trainer = TrainingArguments = None
+
+from .model_manager import ModelManager
+
+
+class EchoCore:
+    """Personalized fine-tuning engine."""
+
+    def __init__(self, user_id: str, model_name: str = "distilbert-base-uncased") -> None:
+        self.user_id = user_id
+        self.model_name = model_name
+        self.mm = ModelManager()
+        if AutoTokenizer is None:
+            raise RuntimeError("transformers is required for EchoCore")
+        self.model_path = self.mm.download_model(model_name, user_id)
+        self.tokenizer = AutoTokenizer.from_pretrained(self.model_path)
+        if torch:
+            self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        else:
+            self.device = "cpu"
+
+    # Fine-tuning --------------------------------------------------------
+    def fine_tune(self, interactions_path: Path, epochs: int = 3) -> None:
+        """Fine-tune on a JSON list of {text, intent}."""
+        if torch is None:
+            raise RuntimeError("PyTorch is required for fine-tuning")
+        data = self._load_interactions(interactions_path)
+        dataset = self._build_dataset(data)
+        num_labels = len(dataset.features["label"].names)
+        if AutoModelForSequenceClassification is None:
+            raise RuntimeError("transformers is required for fine-tuning")
+        model = AutoModelForSequenceClassification.from_pretrained(
+            self.model_path, num_labels=num_labels
+        )
+        if torch:
+            model = model.to(self.device)
+
+        if TrainingArguments is None or Trainer is None:
+            raise RuntimeError("transformers training utilities are required")
+        args = TrainingArguments(
+            output_dir=str(self.model_path / "checkpoints"),
+            per_device_train_batch_size=16,
+            num_train_epochs=epochs,
+            learning_rate=5e-5,
+            save_total_limit=2,
+            logging_steps=50,
+            report_to="none",
+            remove_unused_columns=True,
+        )
+        trainer = Trainer(model=model, args=args, train_dataset=dataset)
+        trainer.train()
+
+        model.save_pretrained(self.model_path)
+        self.tokenizer.save_pretrained(self.model_path)
+
+    # Helpers ------------------------------------------------------------
+    def _load_interactions(self, path: Path) -> List[Dict[str, str]]:
+        with open(path, "r", encoding="utf-8") as f:
+            return json.load(f)
+
+    def _build_dataset(self, data: List[Dict[str, str]]) -> Dataset:
+        if Dataset is None:
+            raise RuntimeError("datasets library is required for fine-tuning")
+        texts, labels = [], []
+        label_set = sorted({item["intent"] for item in data})
+        label_map = {lbl: idx for idx, lbl in enumerate(label_set)}
+
+        for item in data:
+            texts.append(item["text"])
+            labels.append(label_map[item["intent"]])
+
+        enc = self.tokenizer(texts, truncation=True, padding=True)
+        enc["label"] = labels
+        return Dataset.from_dict(enc).cast_column("label", "int64")

--- a/core/model_manager.py
+++ b/core/model_manager.py
@@ -1,0 +1,50 @@
+"""Download and manage per-user models via HuggingFace."""
+from __future__ import annotations
+
+import os
+import shutil
+from pathlib import Path
+from typing import List
+
+try:
+    from huggingface_hub import snapshot_download
+except Exception:  # pragma: no cover - optional dep
+    snapshot_download = None
+
+DEFAULT_CACHE = Path(os.getenv("KARI_MODEL_CACHE", "data/users"))
+
+
+class ModelManager:
+    """Simple registry for user-scoped models."""
+
+    def __init__(self, base_dir: Path = DEFAULT_CACHE) -> None:
+        self.base_dir = Path(base_dir)
+        self.base_dir.mkdir(parents=True, exist_ok=True)
+
+    # Public API ---------------------------------------------------------
+    def download_model(self, model_name: str, user_id: str, revision: str = "main") -> Path:
+        """Download a model from HuggingFace or return cached path."""
+        dest = self._user_model_dir(user_id, model_name)
+        if dest.exists():
+            return dest
+        if snapshot_download is None:
+            raise RuntimeError("huggingface_hub is required for model download")
+        snapshot_download(repo_id=model_name, revision=revision, local_dir=dest, local_dir_use_symlinks=False)
+        return dest
+
+    def list_models(self, user_id: str) -> List[str]:
+        """List cached models for ``user_id``."""
+        user_root = self.base_dir / user_id / "model"
+        if not user_root.exists():
+            return []
+        return [p.name for p in user_root.iterdir() if p.is_dir()]
+
+    def delete_model(self, user_id: str, model_name: str) -> None:
+        """Remove a cached model."""
+        target = self._user_model_dir(user_id, model_name)
+        if target.exists():
+            shutil.rmtree(target, ignore_errors=True)
+
+    # Helpers ------------------------------------------------------------
+    def _user_model_dir(self, user_id: str, model_name: str) -> Path:
+        return self.base_dir / user_id / "model" / model_name

--- a/plugins/fine_tune_lnm/__init__.py
+++ b/plugins/fine_tune_lnm/__init__.py
@@ -1,0 +1,2 @@
+from .handler import run
+__all__ = ["run"]

--- a/plugins/fine_tune_lnm/handler.py
+++ b/plugins/fine_tune_lnm/handler.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from core.echo_core import EchoCore
+
+
+async def run(params: dict) -> str:
+    """Fine-tune the user's LNM on recorded interactions."""
+    user_id = params.get("user_id", "default")
+    logs = Path(params.get("log_path", f"data/users/{user_id}/interactions.json"))
+    epochs = int(params.get("epochs", 3))
+
+    core = EchoCore(user_id)
+    core.fine_tune(logs, epochs=epochs)
+    return "fine_tune_complete"

--- a/plugins/fine_tune_lnm/plugin_manifest.json
+++ b/plugins/fine_tune_lnm/plugin_manifest.json
@@ -1,0 +1,7 @@
+{
+  "plugin_api_version": "1.0",
+  "enable_external_workflow": false,
+  "required_roles": ["admin", "dev"],
+  "intent": "fine_tune_lnm",
+  "trusted_ui": false
+}

--- a/plugins/fine_tune_lnm/prompt.txt
+++ b/plugins/fine_tune_lnm/prompt.txt
@@ -1,0 +1,2 @@
+Train a personalised DistilBERT on recent interactions.
+Inputs: {{ text }}, {{ intent }}, {{ category }}.

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,9 @@ openai
 requests
 streamlit
 llama-cpp-python
+scikit-learn==1.5.*
+spacy==3.7.*
+datasets
 
  
 huggingface_hub

--- a/src/ai_karen_engine/__init__.py
+++ b/src/ai_karen_engine/__init__.py
@@ -3,5 +3,19 @@
 from .clients.slm_pool import SLMPool
 from .llm_orchestrator import LLMOrchestrator
 from .echocore.fine_tuner import NightlyFineTuner
+from core.model_manager import ModelManager
+from core.echo_core import EchoCore
+from clients.transformers.lnm_client import LNMClient
+from clients.nlp.basic_classifier import BasicClassifier
+from clients.nlp.spacy_client import SpaCyClient
 
-__all__ = ["SLMPool", "LLMOrchestrator", "NightlyFineTuner"]
+__all__ = [
+    "SLMPool",
+    "LLMOrchestrator",
+    "NightlyFineTuner",
+    "ModelManager",
+    "EchoCore",
+    "LNMClient",
+    "BasicClassifier",
+    "SpaCyClient",
+]


### PR DESCRIPTION
## Summary
- add new `ModelManager` for managing cached HF models
- implement `EchoCore` DistilBERT fine‑tuning engine
- provide `LNMClient` inference wrapper
- include basic scikit‑learn and spaCy NLP helpers
- scaffold `fine_tune_lnm` plugin
- export new utilities via package init
- update requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863c7c2b5848324b2ee1afee1193356