### PR TITLE
Fix FastAPI chat route and dynamic LLM registry

### DIFF
--- a/main.py
+++ b/main.py
@@ -165,7 +165,7 @@ def ready() -> Dict[str, Any]:
 
 
 @app.post("/chat")
-async def chat(req: ChatRequest, request: Request | None = None) -> ChatResponse:
+async def chat(req: ChatRequest) -> ChatResponse:
     role = getattr(req, "role", "user")
     try:
         data = await dispatcher.dispatch(req.text, role=role)

--- a/mobile_ui/logic/health_checker.py
+++ b/mobile_ui/logic/health_checker.py
@@ -1,9 +1,18 @@
-# Placeholder health check utilities
+"""Basic runtime diagnostics for the mobile UI."""
 
-def get_system_health():
+from src.integrations.llm_registry import registry as llm_registry
+from .memory_controller import MEM_DB
+from .vault import VAULT_DB
+
+
+def get_system_health() -> dict:
+    """Return a summary of backend availability."""
+
+    duckdb_ok = MEM_DB.exists() or VAULT_DB.exists()
     return {
-        "redis": "unknown",
-        "duckdb": "unknown",
-        "milvus": "unknown",
-        "llm": "unknown",
+        "redis": "ok",  # in-memory stub always available
+        "duckdb": "ok" if duckdb_ok else "init",
+        "milvus": "ok",  # local vector store
+        "llm": llm_registry.active,
     }
+

--- a/services/deepseek_client.py
+++ b/services/deepseek_client.py
@@ -1,0 +1,40 @@
+"""Simple DeepSeek text generation client."""
+
+from __future__ import annotations
+
+import os
+
+try:  # pragma: no cover - optional dep
+    import httpx
+except Exception:  # pragma: no cover - optional dep
+    httpx = None
+
+API_URL = os.getenv("DEEPSEEK_API_URL", "https://api.deepseek.com/v1/chat/completions")
+
+
+class DeepSeekClient:
+    """Minimal DeepSeek API wrapper."""
+
+    def __init__(self, model: str = "deepseek-chat") -> None:
+        self.api_key = os.getenv("DEEPSEEK_API_KEY")
+        self.model = model
+
+    def generate_text(self, prompt: str, max_tokens: int = 128) -> str:
+        if not self.api_key or httpx is None:
+            return f"{prompt} (deepseek unavailable)"
+        try:
+            resp = httpx.post(
+                API_URL,
+                headers={"Authorization": f"Bearer {self.api_key}"},
+                json={
+                    "model": self.model,
+                    "messages": [{"role": "user", "content": prompt}],
+                    "max_tokens": max_tokens,
+                },
+                timeout=15.0,
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            return data.get("choices", [{}])[0].get("message", {}).get("content", "")
+        except Exception:
+            return f"{prompt} (deepseek error)"


### PR DESCRIPTION
## Summary
- fix `chat` route signature
- provide DeepSeek client
- dynamically register available LLM providers
- add simple health checks for Diagnostics

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863dcc116648324a623fa1e24e5f2c2