### PR TITLE
Improve health checks in mobile ui

### DIFF
--- a/mobile_ui/components/diagnostics.py
+++ b/mobile_ui/components/diagnostics.py
@@ -1,7 +1,24 @@
 import streamlit as st
 from logic.health_checker import get_system_health
 
-def render_diagnostics():
+
+def render_diagnostics() -> None:
+    """Display runtime diagnostics in the UI."""
     st.title("\U0001F9EA Diagnostics")
     health = get_system_health()
-    st.write(health)
+
+    st.subheader("Runtime")
+    st.json(health.get("runtime"))
+
+    st.subheader("Memory")
+    st.json(health.get("memory"))
+
+    st.subheader("LLM Backends")
+    st.json(health.get("llm_backends"))
+
+    st.subheader("Packages")
+    st.json(health.get("packages"))
+
+    st.subheader("spaCy Models")
+    st.write(", ".join(health.get("spacy_models", [])))
+


### PR DESCRIPTION
## Summary
- add milvus and DuckDB connection tests
- surface registered LLM backends
- expand diagnostics page

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'transformers')*

------
https://chatgpt.com/codex/tasks/task_e_6863fa7d80488324917c591d0a7689f0