### PR TITLE
Fix SelfRefactorEngine default LLM

### DIFF
--- a/src/self_refactor/engine.py
+++ b/src/self_refactor/engine.py
@@ -46,9 +46,6 @@ class SelfRefactorEngine:
  
         self.llm = llm or llm_registry.get_active()
         self.deepseek = deepseek or llm_registry.get_active()
-
-        self.llm = llm or LLMUtils()
-        self.deepseek = deepseek or LLMUtils()
  
         self.nanda = nanda or NANDAClient(agent_name="SelfRefactor")
         self.test_cmd = test_cmd or ["pytest", "-q"]


### PR DESCRIPTION
## Summary
- simplify LLM handling in `SelfRefactorEngine`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'transformers')*

------
https://chatgpt.com/codex/tasks/task_e_6863fa7bd6608324aa2038ac5ae15b98