### PR TITLE
Fix LlamaCpp wrapper registration

### DIFF
--- a/src/integrations/llm_registry.py
+++ b/src/integrations/llm_registry.py
@@ -34,11 +34,11 @@ class LLMRegistry:
 
         # optional llama.cpp / ollama wrapper
         try:
-            LlamaCppWrapper()
+            wrapper = LlamaCppWrapper()
         except Exception:
             pass
         else:
-            self.backends["ollama_cpp"] = LlamaCppWrapper()
+            self.backends["ollama_cpp"] = wrapper
 
         # optional OpenAI backend
         try:  # pragma: no cover - optional dep


### PR DESCRIPTION
## Summary
- update LLMRegistry to only instantiate LlamaCppWrapper once

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'transformers')*

------
https://chatgpt.com/codex/tasks/task_e_6863fa7d05488324a623c85c68b2a602