### PR TITLE
Dynamic provider list from llm_registry

### DIFF
--- a/config/settings.json
+++ b/config/settings.json
@@ -1,5 +1,5 @@
 {
-  "provider": "Local (Ollama)",
+  "provider": "local",
   "model": "llama3.2:latest",
   "api_key": "",
   "use_memory": true,

--- a/mobile_ui/components/key_manager.py
+++ b/mobile_ui/components/key_manager.py
@@ -1,8 +1,10 @@
 import streamlit as st
 
+LOCAL_PROVIDERS = {"local", "ollama_cpp"}
+
 
 def key_input(provider: str):
-    if provider == "Local (Ollama)":
+    if provider in LOCAL_PROVIDERS:
         return None
     return st.text_input(
         f"Enter your API key for {provider}", type="password", key=f"{provider}_key"

--- a/mobile_ui/components/model_selector.py
+++ b/mobile_ui/components/model_selector.py
@@ -1,21 +1,10 @@
 import streamlit as st
 import logging
 
-MODELS = {
-    "Local (Ollama)": ["llama3.2:latest", "mistral", "gemma"],
-    "OpenAI": ["gpt-4o", "gpt-3.5-turbo"],
-    "Anthropic": ["claude-3-opus", "claude-3-haiku"],
-    "Gemini": ["gemini-pro", "gemini-pro-vision"],
-    "Groq": ["llama3-8b-8192", "mixtral-8x7b"],
-    "HuggingFace": ["gpt2", "bloom"],
-    "Cohere": ["command-r", "command-r-plus"],
-    "OpenRouter": ["openrouter/gpt-4", "openrouter/mistral-7b"],
-    "Together": ["together/llama3", "together/mixtral"],
-    "Custom": ["<Manual Entry>"],
-}
+from logic.model_registry import get_models
 
 def select_model(provider: str):
-    options = MODELS.get(provider, [])
+    options = [m["name"] for m in get_models(provider)]
     model = st.selectbox("Select Model", options)
     logging.info("[ui_config] Model chosen: %s", model)
     return model

--- a/mobile_ui/components/models.py
+++ b/mobile_ui/components/models.py
@@ -1,6 +1,6 @@
 import streamlit as st
 import pandas as pd
-from logic.model_registry import MODEL_REGISTRY, get_models
+from logic.model_registry import get_models, list_providers
 
 
 def select_model(provider: str):
@@ -11,7 +11,7 @@ def select_model(provider: str):
 
 def render_models():
     st.title("\U0001F9E0 Model Catalog")
-    provider = st.selectbox("Choose Provider", list(MODEL_REGISTRY.keys()))
+    provider = st.selectbox("Choose Provider", list_providers())
     data = get_models(provider)
     if data:
         st.table(pd.DataFrame(data))

--- a/mobile_ui/components/provider.py
+++ b/mobile_ui/components/provider.py
@@ -1,24 +1,19 @@
 import streamlit as st
 import logging
 
-PROVIDERS = [
-    "Local (Ollama)",
-    "OpenAI",
-    "Anthropic",
-    "Gemini",
-    "Groq",
-    "HuggingFace",
-    "Cohere",
-    "OpenRouter",
-    "Together",
-    "Custom",
-]
+from src.integrations.llm_registry import registry as llm_registry
+
+
+def _available_providers() -> list[str]:
+    """Return provider names from the LLM registry."""
+    return list(llm_registry.list_models())
 
 
 def select_provider() -> str:
     """Return the chosen LLM provider from the sidebar."""
     st.subheader("\U0001F50C LLM Provider")
-    provider = st.selectbox("Choose a provider", PROVIDERS)
+    providers = _available_providers()
+    provider = st.selectbox("Choose a provider", providers)
     logging.info("[ui_config] Provider selected: %s", provider)
     return provider
 

--- a/mobile_ui/components/provider_selector.py
+++ b/mobile_ui/components/provider_selector.py
@@ -1,22 +1,15 @@
 import streamlit as st
 import logging
 
+from src.integrations.llm_registry import registry as llm_registry
+
+
+def _providers() -> list[str]:
+    """Return available provider names."""
+    return list(llm_registry.list_models())
+
 def select_provider():
     st.subheader("\U0001F9E0 LLM Provider")
-    provider = st.selectbox(
-        "Choose a provider",
-        [
-            "Local (Ollama)",
-            "OpenAI",
-            "Anthropic",
-            "Gemini",
-            "Groq",
-            "HuggingFace",
-            "Cohere",
-            "OpenRouter",
-            "Together",
-            "Custom",
-        ],
-    )
+    provider = st.selectbox("Choose a provider", _providers())
     logging.info("[ui_config] User selected provider: %s", provider)
     return provider

--- a/mobile_ui/components/settings.py
+++ b/mobile_ui/components/settings.py
@@ -1,34 +1,31 @@
 import streamlit as st
 from logic.config_manager import load_config, save_config
-from logic.model_registry import get_models
+from logic.model_registry import get_models, list_providers
 
-
-PROVIDERS = [
-    "Local (Ollama)",
-    "OpenAI",
-    "Anthropic",
-    "Gemini",
-    "Groq",
-    "HuggingFace",
-    "Cohere",
-    "OpenRouter",
-    "Together",
-    "Custom",
-]
+LOCAL_PROVIDERS = {"local", "ollama_cpp"}
 
 
 def render_settings():
     st.title("\u2699\ufe0f Kari Configuration")
     config = load_config()
 
-    provider = st.selectbox("LLM Provider", PROVIDERS, index=PROVIDERS.index(config.get("provider", PROVIDERS[0])))
+    providers = list_providers()
+    provider = st.selectbox(
+        "LLM Provider",
+        providers,
+        index=providers.index(config.get("provider", providers[0])) if providers else 0,
+    )
     models = [m["name"] for m in get_models(provider)]
     model_default = config.get("model") if config.get("model") in models else models[0]
     model = st.selectbox("Model", models, index=models.index(model_default))
 
     api_key = ""
-    if provider != "Local (Ollama)":
-        api_key = st.text_input(f"{provider} API Key", type="password", value=config.get("api_key", ""))
+    if provider not in LOCAL_PROVIDERS:
+        api_key = st.text_input(
+            f"{provider} API Key",
+            type="password",
+            value=config.get("api_key", ""),
+        )
 
     st.subheader("Memory Settings")
     use_memory = st.checkbox("Enable Memory", value=config.get("use_memory", True))

--- a/mobile_ui/components/sidebar.py
+++ b/mobile_ui/components/sidebar.py
@@ -1,28 +1,16 @@
 import streamlit as st
-from logic.model_registry import get_models
+from logic.model_registry import get_models, list_providers
 from logic.config_manager import update_config, load_config, get_status
-
-PROVIDERS = [
-    "Local (Ollama)",
-    "OpenAI",
-    "Anthropic",
-    "Gemini",
-    "Groq",
-    "HuggingFace",
-    "Cohere",
-    "OpenRouter",
-    "Together",
-    "Custom",
-]
 
 def render_sidebar():
     st.sidebar.title("\U0001F9ED Navigation")
     config = load_config()
 
+    providers = list_providers()
     provider = st.sidebar.selectbox(
         "LLM Provider",
-        PROVIDERS,
-        index=PROVIDERS.index(config.get("provider", PROVIDERS[0])),
+        providers,
+        index=providers.index(config.get("provider", providers[0])) if providers else 0,
     )
     if provider != config.get("provider"):
         update_config(provider=provider)

--- a/mobile_ui/logic/config_manager.py
+++ b/mobile_ui/logic/config_manager.py
@@ -54,7 +54,8 @@ def get_status() -> str:
     model = config.get("model")
     if not provider or not model:
         return "Pending Config"
-    if provider != "Local (Ollama)":
+    local_providers = {"local", "ollama_cpp"}
+    if provider not in local_providers:
         key = config.get("api_key") or load_secret(config.get("api_key_ref", "llm_api_key"))
         if not key:
             return "Invalid"

--- a/mobile_ui/logic/model_registry.py
+++ b/mobile_ui/logic/model_registry.py
@@ -1,36 +1,22 @@
-MODEL_REGISTRY = {
-    "Local (Ollama)": [
-        {"name": "llama3.2:latest", "size": "7B", "speed": "fast", "type": "chat"},
-        {"name": "mistral", "size": "7B", "speed": "fast", "type": "chat"},
-        {"name": "codellama", "size": "7B", "speed": "fast", "type": "code"},
-    ],
-    "OpenAI": [
-        {"name": "gpt-4o", "size": "n/a", "speed": "fast", "type": "chat"},
-        {"name": "gpt-3.5-turbo", "size": "n/a", "speed": "fast", "type": "chat"},
-    ],
-    "Anthropic": [
-        {"name": "claude-3-opus", "size": "n/a", "speed": "fast", "type": "chat"},
-        {"name": "claude-3-haiku", "size": "n/a", "speed": "fast", "type": "chat"},
-    ],
-    "Gemini": [
-        {"name": "gemini-pro", "size": "n/a", "speed": "fast", "type": "chat"},
-        {"name": "gemini-pro-vision", "size": "n/a", "speed": "fast", "type": "chat"},
-    ],
-    "Groq": [
-        {"name": "llama3-70b", "size": "70B", "speed": "fast", "type": "chat"},
-        {"name": "mixtral-8x7b", "size": "56B", "speed": "fast", "type": "chat"},
-    ],
-    "HuggingFace": [
-        {"name": "gpt2", "size": "small", "speed": "fast", "type": "chat"},
-        {"name": "bloom", "size": "176B", "speed": "slow", "type": "chat"},
-        {"name": "falcon-7b", "size": "7B", "speed": "medium", "type": "chat"},
-    ],
-    "Cohere": [
-        {"name": "command-r", "size": "n/a", "speed": "fast", "type": "chat"},
-        {"name": "command-r-plus", "size": "n/a", "speed": "fast", "type": "chat"},
-    ],
-}
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List, Dict
+
+from src.integrations.llm_registry import registry as llm_registry
 
 
-def get_models(provider: str):
-    return MODEL_REGISTRY.get(provider, [])
+def list_providers() -> List[str]:
+    """Return available provider names."""
+    return list(llm_registry.list_models())
+
+
+def get_models(provider: str) -> List[Dict[str, str]]:
+    """Return model details for ``provider`` from the active registry."""
+    llm = llm_registry.backends.get(provider)
+    if not llm:
+        return []
+    name = getattr(llm, "model_name", None) or getattr(llm, "model", None)
+    if not name and hasattr(llm, "model_path"):
+        name = Path(getattr(llm, "model_path")).stem
+    return [{"name": name or provider}]


### PR DESCRIPTION
## Summary
- use llm_registry to populate provider select boxes
- dynamically derive provider model names
- update UI pieces to handle local provider names
- adjust config to treat `local`/`ollama_cpp` as offline

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'transformers')*

------
https://chatgpt.com/codex/tasks/task_e_6863fa6f5b1883249d68adc540e48d58