### PR TITLE
Fix provider selection crash and add model utilities

### DIFF
--- a/core/kari_runner.py
+++ b/core/kari_runner.py
@@ -1,0 +1,13 @@
+def run_kari_core(prompt: str, provider: str, model: str) -> str:
+    """Generate text using a transformers pipeline, safely handling args."""
+    from transformers import pipeline
+
+    pipe = pipeline("text-generation", model=model, device=0)
+
+    valid_args = set(pipe.model.generation_config.to_diff_dict().keys())
+    gen_args = {"max_new_tokens": 250}
+    if "temperature" in valid_args:
+        gen_args["temperature"] = 0.7
+
+    result = pipe(prompt, **gen_args)
+    return result[0]["generated_text"]

--- a/mobile_ui/app.py
+++ b/mobile_ui/app.py
@@ -16,6 +16,7 @@ from components.settings import render_settings
 from components.memory import render_memory
 from components.models import render_models
 from components.diagnostics import render_diagnostics
+from utils.model_loader import ensure_spacy_models, ensure_sklearn_installed
 
 
 def load_styles() -> None:
@@ -55,6 +56,10 @@ def main() -> None:
         page_icon="🤖",
         initial_sidebar_state="expanded",
     )
+
+    # Ensure base NLP dependencies are available
+    ensure_spacy_models()
+    ensure_sklearn_installed()
 
     load_styles()
     selection = render_sidebar()

--- a/mobile_ui/components/sidebar.py
+++ b/mobile_ui/components/sidebar.py
@@ -7,16 +7,24 @@ def render_sidebar():
     config = load_config()
 
     providers = list_providers()
+    default_provider = config.get("provider")
+    if default_provider not in providers and providers:
+        default_provider = providers[0]
+
     provider = st.sidebar.selectbox(
         "LLM Provider",
         providers,
-        index=providers.index(config.get("provider", providers[0])) if providers else 0,
+        index=providers.index(default_provider) if providers else 0,
     )
+
     if provider != config.get("provider"):
         update_config(provider=provider)
 
     models = [m["name"] for m in get_models(provider)]
-    model_default = config.get("model") if config.get("model") in models else models[0]
+    model_default = config.get("model")
+    if model_default not in models and models:
+        model_default = models[0]
+
     model = st.sidebar.selectbox("Model", models, index=models.index(model_default))
     if model != config.get("model"):
         update_config(model=model)

--- a/mobile_ui/utils/model_loader.py
+++ b/mobile_ui/utils/model_loader.py
@@ -1,0 +1,17 @@
+import importlib.util
+import subprocess
+
+
+def ensure_spacy_models() -> None:
+    """Ensure the small English spaCy model is installed."""
+    try:
+        import spacy
+        spacy.load("en_core_web_sm")
+    except (OSError, ImportError):
+        subprocess.run(["python", "-m", "spacy", "download", "en_core_web_sm"], check=True)
+
+
+def ensure_sklearn_installed() -> None:
+    """Ensure scikit-learn is available."""
+    if importlib.util.find_spec("sklearn") is None:
+        subprocess.run(["pip", "install", "scikit-learn"], check=True)


### PR DESCRIPTION
## Summary
- avoid crash when stored provider name is missing
- add utility helpers to ensure spaCy model and scikit-learn are available
- call dependency helpers in Streamlit boot
- expose a simple text generation runner using transformers

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'transformers')*

------
https://chatgpt.com/codex/tasks/task_e_686414a20fcc83249bd096ec014d8253