### PR TITLE
Add custom runtime registry and dispatcher

### DIFF
--- a/mobile_ui/components/model_selector.py
+++ b/mobile_ui/components/model_selector.py
@@ -4,7 +4,11 @@ import logging
 from logic.model_registry import get_models
 
 def select_model(provider: str):
-    options = [m["name"] for m in get_models(provider)]
+    options = [
+        m.get("alias", m.get("model_name"))
+        for m in get_models()
+        if m.get("provider") == provider
+    ]
     model = st.selectbox("Select Model", options)
     logging.info("[ui_config] Model chosen: %s", model)
     return model

--- a/mobile_ui/components/models.py
+++ b/mobile_ui/components/models.py
@@ -5,13 +5,17 @@ from logic.model_registry import get_models, list_providers
 
 def select_model(provider: str):
     st.subheader("\U0001F3AF Select Model")
-    models = [m["name"] for m in get_models(provider)]
+    models = [
+        m.get("alias", m.get("model_name"))
+        for m in get_models()
+        if m.get("provider") == provider
+    ]
     return st.selectbox("Model", models)
 
 
 def render_models():
     st.title("\U0001F9E0 Model Catalog")
     provider = st.selectbox("Choose Provider", list_providers())
-    data = get_models(provider)
+    data = [m for m in get_models() if m.get("provider") == provider]
     if data:
         st.table(pd.DataFrame(data))

--- a/mobile_ui/components/settings.py
+++ b/mobile_ui/components/settings.py
@@ -10,12 +10,18 @@ def render_settings():
     config = load_config()
 
     providers = list_providers()
+    if any(m.get("provider") == "custom_provider" for m in get_models()):
+        providers.append("custom_provider")
     provider = st.selectbox(
         "LLM Provider",
         providers,
         index=providers.index(config.get("provider", providers[0])) if providers else 0,
     )
-    models = [m["name"] for m in get_models(provider)]
+    models = [
+        m.get("alias", m.get("model_name"))
+        for m in get_models()
+        if m.get("provider") == provider
+    ]
     model_default = config.get("model") if config.get("model") in models else models[0]
     model = st.selectbox("Model", models, index=models.index(model_default))
 

--- a/mobile_ui/logic/runtime_dispatcher.py
+++ b/mobile_ui/logic/runtime_dispatcher.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import os
+from typing import Callable, Dict, Any
+
+import requests
+from prometheus_client import Histogram
+
+# Placeholder runtime loaders -------------------------------------------------
+
+def load_llama_model(meta: dict) -> Any:
+    path = os.path.join(meta.get("path", ""), meta.get("model_name", ""))
+    return {"runtime": "llama_cpp", "path": path}
+
+
+def load_hf_model(meta: dict) -> Any:
+    from src.integrations.llm_utils import LLMUtils
+    return LLMUtils(meta.get("model_name", "distilgpt2"))
+
+
+def load_onnx_model(meta: dict) -> Any:
+    return {"runtime": "onnx", "path": meta.get("path")}
+
+
+def query_rest_endpoint(meta: dict, prompt: str) -> Any:
+    headers = meta.get("headers", {}).copy()
+    if meta.get("auth"):
+        headers["Authorization"] = meta["auth"]
+    payload = {"prompt": prompt}
+    resp = requests.post(meta["endpoint"], json=payload, headers=headers, timeout=30)
+    resp.raise_for_status()
+    data = resp.json()
+    return data.get("response", data)
+
+
+RUNTIME_EXECUTORS: Dict[str, Callable[..., Any]] = {
+    "llama_cpp": load_llama_model,
+    "huggingface": load_hf_model,
+    "onnx": load_onnx_model,
+    "remote_rest": query_rest_endpoint,
+}
+
+RUNTIME_LATENCY = Histogram(
+    "runtime_latency_seconds", "LLM Runtime Latency", ["runtime"]
+)
+
+
+def dispatch_runtime(model_meta: dict, *args, **kwargs) -> Any:
+    runtime = model_meta.get("runtime")
+    if not runtime:
+        raise ValueError(
+            f"[custom_provider] Missing 'runtime' in metadata block: {model_meta}"
+        )
+    executor = RUNTIME_EXECUTORS.get(runtime)
+    if not executor:
+        raise ValueError(f"[custom_provider] Unknown runtime: {runtime}")
+
+    with RUNTIME_LATENCY.labels(runtime).time():
+        return executor(model_meta, *args, **kwargs)

--- a/models/llm_registry.json
+++ b/models/llm_registry.json
@@ -10,5 +10,24 @@
     "provider": "llama-cpp",
     "tokenizer_type": "byte",
     "prompt_limit_bytes": 65536
+  },
+  "custom_gpt4all": {
+    "provider": "custom_provider",
+    "runtime": "llama_cpp",
+    "model_name": "ggml-gpt4all-j-v1.3-groovy.bin",
+    "path": "/models/custom/gpt4all/",
+    "tokenizer_type": "byte",
+    "prompt_limit_bytes": 32768
+  },
+  "custom_rest_llm": {
+    "provider": "custom_provider",
+    "runtime": "remote_rest",
+    "endpoint": "http://localhost:5005/infer",
+    "auth": "Bearer xyz123",
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "tokenizer_type": "json",
+    "prompt_limit_bytes": 65536
   }
 }

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -25,6 +25,14 @@ def test_get_registry_models_filter(tmp_path, monkeypatch):
     assert llama_only[0]["model_name"] == "foo"
 
 
-def test_get_models_alias(monkeypatch):
-    monkeypatch.setitem(mr.MODEL_PROVIDERS, "llama-cpp", lambda: ["m1"])
-    assert mr.get_models("ollama") == ["m1"]
+def test_get_models_reads_registry(tmp_path, monkeypatch):
+    data = {
+        "foo": {"model_name": "foo", "provider": "llama-cpp"},
+        "bar": {"model_name": "bar", "provider": "custom_provider"},
+    }
+    path = tmp_path / "reg.json"
+    path.write_text(json.dumps(data))
+    monkeypatch.setattr(mr, "REGISTRY_PATH", path)
+    models = mr.get_models()
+    assert any(m["model_name"] == "foo" for m in models)
+    assert any(m["provider"] == "custom_provider" for m in models)


### PR DESCRIPTION
## Summary
- register custom GPT4All and REST models
- support `huggingface` provider name
- expose runtime dispatcher with Prometheus metrics
- adjust model selectors and settings to load from registry
- update tests for new registry loader

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68647bd0de308324a0ef1d3d291156a6