### PR TITLE
Enhance mobile UI with model metadata and chat page

### DIFF
--- a/mobile_ui/logic/model_registry.py
+++ b/mobile_ui/logic/model_registry.py
@@ -113,6 +113,17 @@ def get_models() -> List[dict]:
     return entries
 
 
+def get_model_meta(name: str) -> Optional[dict]:
+    """Return a single model metadata block by name or alias."""
+    registry = load_registry()
+    if name in registry:
+        return registry[name]
+    for meta in registry.values():
+        if meta.get("alias") == name or meta.get("model_name") == name:
+            return meta
+    return None
+
+
 # ---------------------------------------------------------------------------
 # Registry helpers
 # ---------------------------------------------------------------------------

--- a/mobile_ui/pages/chat.py
+++ b/mobile_ui/pages/chat.py
@@ -1,0 +1,53 @@
+import time
+import streamlit as st
+
+from logic.config_manager import load_config, update_config
+from logic.model_registry import get_models, get_model_meta
+from logic.runtime_dispatcher import dispatch_runtime
+
+
+def render_chat_page() -> None:
+    st.markdown("## :speech_balloon: Chat")
+
+    models = [m.get("model_name") for m in get_models()]
+    if not models:
+        st.warning("No models available")
+        return
+
+    config = load_config()
+    active_name = config.get("model", models[0])
+
+    selected = st.selectbox(
+        "Active Model",
+        models,
+        index=models.index(active_name) if active_name in models else 0,
+    )
+    if selected != active_name:
+        update_config(model=selected)
+        active_name = selected
+
+    meta = get_model_meta(active_name)
+    if not meta:
+        st.error("Model metadata not found")
+        return
+
+    st.markdown(f"### \U0001f4ac Chat with `{meta.get('model_name', active_name)}`")
+
+    user_input = st.chat_input("Type your message here...")
+    if user_input:
+        st.chat_message("user").write(user_input)
+        start = time.perf_counter()
+        with st.spinner("Thinking..."):
+            response = dispatch_runtime(meta, user_input)
+        duration = time.perf_counter() - start
+        st.chat_message("ai").write(response)
+        token_count = len(response.split())
+        st.markdown("---")
+        st.caption(
+            f"Provider: {meta.get('provider')} | Runtime: {meta.get('runtime')} | "
+            f"Tokens: {token_count} | Time: {duration:.2f}s"
+        )
+
+
+if __name__ == "__main__":
+    render_chat_page()

--- a/mobile_ui/pages/settings.py
+++ b/mobile_ui/pages/settings.py
@@ -1,0 +1,52 @@
+import streamlit as st
+
+from logic.model_registry import get_models
+from logic.runtime_dispatcher import dispatch_runtime
+
+
+def render_model_catalog() -> None:
+    st.markdown("## :brain: Model Catalog")
+    models = get_models()
+    if not models:
+        st.info("No models found in registry")
+        return
+
+    for meta in models:
+        name = meta.get("model_name", "unknown")
+        with st.expander(name):
+            st.markdown(
+                f"**Runtime:** {meta.get('runtime', 'n/a')} | "
+                f"**Provider:** {meta.get('provider', 'n/a')}"
+            )
+            st.markdown(f"**Path:** {meta.get('path', '-')}")
+            st.markdown(
+                f"Tokenizer: {meta.get('tokenizer_type', '-')}",
+            )
+            limit = meta.get("prompt_limit_bytes")
+            if limit:
+                st.markdown(f"Prompt Limit: {limit}")
+            feats = [
+                f"Streaming {'✅' if meta.get('streaming') else '❌'}",
+                f"Quantized {'✅' if meta.get('quantized') else '❌'}",
+                f"LoRA {'✅' if meta.get('lora_support') else '❌'}",
+            ]
+            st.markdown(" | ".join(feats))
+
+            prompt_key = f"prompt_{name}"
+            prompt = st.text_input("Quick Prompt", key=prompt_key)
+            if st.button("Run Quick Prompt", key=f"run_{name}") and prompt:
+                with st.spinner("Running..."):
+                    response = dispatch_runtime(meta, prompt)
+                st.write(response)
+
+            loaded = st.session_state.get(f"loaded_{name}", False)
+            if st.button("Unload" if loaded else "Load", key=f"load_{name}"):
+                st.session_state[f"loaded_{name}"] = not loaded
+            st.caption(
+                "Loaded" if st.session_state.get(f"loaded_{name}", False) else "Unloaded"
+            )
+            st.markdown("---")
+
+
+if __name__ == "__main__":
+    render_model_catalog()


### PR DESCRIPTION
## Summary
- implement model metadata lookup via `get_model_meta`
- update runtime dispatcher to return inference text
- add `pages/settings.py` to display rich model catalog with quick prompts
- add `pages/chat.py` with selectable model chat interface

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68648422a7d883249314b8d5ffbe447a