### PR TITLE
Improve provider list from registry

### DIFF
--- a/mobile_ui/logic/model_registry.py
+++ b/mobile_ui/logic/model_registry.py
@@ -92,8 +92,13 @@ def canonical_provider(name: str) -> str:
 
 
 def get_providers() -> List[str]:
-    """Return list of all known provider keys."""
-    return list(MODEL_PROVIDERS.keys())
+    """Return list of all known provider keys including registry entries."""
+    providers = set(MODEL_PROVIDERS.keys())
+    for meta in _load_registry_entries():
+        p = canonical_provider(str(meta.get("provider", "")))
+        if p:
+            providers.add(p)
+    return sorted(providers)
 
 
 def _discover_provider_models() -> List[dict]:

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -44,3 +44,16 @@ def test_ready_models_default(tmp_path, monkeypatch):
     monkeypatch.setattr(mr, "REGISTRY_PATH", path)
     ready = mr.get_ready_models()
     assert any(m["model_name"] == "distilbert-base-uncased" for m in ready)
+
+
+def test_get_providers_includes_registry_providers(tmp_path, monkeypatch):
+    data = {
+        "foo": {"model_name": "foo", "provider": "llama-cpp"},
+        "bar": {"model_name": "bar", "provider": "custom_provider"},
+    }
+    path = tmp_path / "reg.json"
+    path.write_text(json.dumps(data))
+    monkeypatch.setattr(mr, "REGISTRY_PATH", path)
+    providers = mr.get_providers()
+    assert "llama-cpp" in providers
+    assert "custom_provider" in providers


### PR DESCRIPTION
## Summary
- extend provider listing to include registry entries
- test provider list for custom providers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68649a5c2b6c83249578aff5e3fb45e7