### PR TITLE
Add model-agnostic config panel

### DIFF
--- a/config/config_ui.py
+++ b/config/config_ui.py
@@ -1,0 +1,44 @@
+import streamlit as st
+from mobile_ui.logic.model_registry import MODEL_PROVIDERS, get_models
+
+
+def render_model_config():
+    st.subheader("🧠 Model Configuration")
+
+    # 1. Provider Selection
+    provider_keys = list(MODEL_PROVIDERS.keys())
+    selected_provider = st.selectbox("Select Model Provider", provider_keys)
+
+    # 2. Load Available Models for Provider
+    try:
+        models = get_models(selected_provider)
+    except Exception as e:
+        st.error(f"🚨 Error loading models for provider '{selected_provider}': {str(e)}")
+        models = []
+
+    # 3. Handle string-based static model lists
+    model_options = []
+    if models and isinstance(models[0], str):
+        model_options = models
+        model_meta_list = [{"name": name} for name in models]
+    elif models and isinstance(models[0], dict):
+        model_options = [m["name"] for m in models]
+        model_meta_list = models
+    else:
+        model_options = []
+        model_meta_list = []
+
+    # 4. Model Selection Dropdown
+    selected_model = st.selectbox("Select Model", model_options)
+
+    # 5. Retrieve Metadata for selected model (if any)
+    model_metadata = next((m for m in model_meta_list if m.get("name") == selected_model), {})
+
+    # 6. Save to Session State
+    st.session_state["model_provider"] = selected_provider
+    st.session_state["model_name"] = selected_model
+    st.session_state["model_metadata"] = model_metadata
+
+    # 7. Optional Debug View
+    with st.expander("🔍 Model Metadata"):
+        st.json(model_metadata)

--- a/mobile_ui/logic/model_registry.py
+++ b/mobile_ui/logic/model_registry.py
@@ -92,8 +92,13 @@ def canonical_provider(name: str) -> str:
 
 
 def get_providers() -> List[str]:
-    """Return list of all known provider keys."""
-    return list(MODEL_PROVIDERS.keys())
+    """Return list of all known provider keys including registry entries."""
+    providers = set(MODEL_PROVIDERS.keys())
+    for meta in _load_registry_entries():
+        p = canonical_provider(str(meta.get("provider", "")))
+        if p:
+            providers.add(p)
+    return sorted(providers)
 
 
 def _discover_provider_models() -> List[dict]:

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -44,3 +44,16 @@ def test_ready_models_default(tmp_path, monkeypatch):
     monkeypatch.setattr(mr, "REGISTRY_PATH", path)
     ready = mr.get_ready_models()
     assert any(m["model_name"] == "distilbert-base-uncased" for m in ready)
+
+
+def test_get_providers_includes_registry_providers(tmp_path, monkeypatch):
+    data = {
+        "foo": {"model_name": "foo", "provider": "llama-cpp"},
+        "bar": {"model_name": "bar", "provider": "custom_provider"},
+    }
+    path = tmp_path / "reg.json"
+    path.write_text(json.dumps(data))
+    monkeypatch.setattr(mr, "REGISTRY_PATH", path)
+    providers = mr.get_providers()
+    assert "llama-cpp" in providers
+    assert "custom_provider" in providers


### PR DESCRIPTION
## Summary
- add new `config/config_ui.py` implementing provider + model selector
- include empty `config/__init__.py`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68649a5c2b6c83249578aff5e3fb45e7