### PR TITLE
Enhance provider configuration

### DIFF
--- a/mobile_ui/components/settings.py
+++ b/mobile_ui/components/settings.py
@@ -1,5 +1,10 @@
 import streamlit as st
-from logic.config_manager import load_config, save_config
+from logic.config_manager import (
+    load_config,
+    save_config,
+    save_provider_config,
+    get_provider_config,
+)
 from logic.model_registry import get_models, list_providers
 
 LOCAL_PROVIDERS = {"local", "ollama_cpp"}
@@ -13,35 +18,53 @@ def render_settings():
     if any(m.get("provider") == "custom_provider" for m in get_models()):
         if "custom_provider" not in providers:
             providers.append("custom_provider")
-    default_provider = config.get("provider")
-    if default_provider not in providers and providers:
-        default_provider = providers[0]
+
+    default_provider = config.get("provider", providers[0] if providers else "")
     provider = st.selectbox(
-        "LLM Provider",
+        "Default Provider",
         providers,
-        index=providers.index(default_provider) if providers else 0,
+        index=providers.index(default_provider) if default_provider in providers else 0,
     )
+    prov_conf = get_provider_config(provider)
     models = [
         m.get("alias", m.get("model_name"))
         for m in get_models()
         if m.get("provider") == provider
     ]
-    if models:
-        model_default = (
-            config.get("model") if config.get("model") in models else models[0]
-        )
-        model = st.selectbox("Model", models, index=models.index(model_default))
-    else:
-        st.warning("No models available for selected provider")
-        model = ""
+    default_model = st.selectbox(
+        "Default Model",
+        models,
+        index=models.index(prov_conf.get("model", models[0])) if models else 0,
+    ) if models else ""
 
-    api_key = ""
-    if provider not in LOCAL_PROVIDERS:
-        api_key = st.text_input(
-            f"{provider} API Key",
-            type="password",
-            value=config.get("api_key", ""),
-        )
+    st.markdown("### Provider Configuration")
+    for prov in providers:
+        with st.expander(prov, expanded=False):
+            prov_conf = get_provider_config(prov)
+            models = [
+                m.get("alias", m.get("model_name"))
+                for m in get_models()
+                if m.get("provider") == prov
+            ]
+            model = st.selectbox(
+                "Model",
+                models,
+                index=models.index(prov_conf.get("model", models[0])) if models else 0,
+                key=f"model_{prov}",
+            ) if models else ""
+
+            api_key = ""
+            if prov not in LOCAL_PROVIDERS:
+                api_key = st.text_input(
+                    f"{prov} API Key",
+                    type="password",
+                    value=prov_conf.get("api_key", ""),
+                    key=f"key_{prov}",
+                )
+
+            if st.button("Save", key=f"save_{prov}"):
+                save_provider_config(prov, {"model": model, "api_key": api_key})
+                st.success(f"Saved {prov}")
 
     st.subheader("Memory Settings")
     use_memory = st.checkbox("Enable Memory", value=config.get("use_memory", True))
@@ -50,11 +73,12 @@ def render_settings():
 
     persona = st.text_input("Persona", value=config.get("persona", "default"))
 
+    prov_conf = get_provider_config(provider)
     if st.button("\U0001F4BE Save Configuration"):
         save_config({
             "provider": provider,
-            "model": model,
-            "api_key": api_key,
+            "model": default_model,
+            "api_key": prov_conf.get("api_key", ""),
             "use_memory": use_memory,
             "context_length": context_len,
             "decay": decay,

--- a/mobile_ui/components/sidebar.py
+++ b/mobile_ui/components/sidebar.py
@@ -4,7 +4,13 @@ from logic.model_registry import (
     list_providers,
     ensure_model_downloaded,
 )
-from logic.config_manager import update_config, load_config, get_status
+from logic.config_manager import (
+    update_config,
+    load_config,
+    get_status,
+    list_configured_providers,
+    get_provider_config,
+)
 import streamlit as st
 import pandas as pd
 
@@ -83,6 +89,15 @@ def render_sidebar():
     status = get_status()
     emoji = {"Ready": "🟢", "Pending Config": "🟡", "Invalid": "🔴"}.get(status, "❔")
     st.sidebar.markdown(f"**Status:** {emoji} {status}")
+
+    # Configured providers summary
+    configured = list_configured_providers()
+    if configured:
+        st.sidebar.subheader("Configured Providers")
+        for prov in configured:
+            meta = get_provider_config(prov)
+            model = meta.get("model", "-")
+            st.sidebar.write(f"- {prov}: {model}")
 
     # Navigation
     return st.sidebar.radio("🧭 Navigate", ["Chat", "Settings", "Models", "Memory", "Diagnostics"])

--- a/mobile_ui/logic/config_manager.py
+++ b/mobile_ui/logic/config_manager.py
@@ -12,11 +12,21 @@ def _connect():
     return duckdb.connect(str(DB_PATH))
 
 
+def _init_db(con: duckdb.DuckDBPyConnection) -> None:
+    """Ensure required tables exist."""
+    con.execute(
+        "CREATE TABLE IF NOT EXISTS settings (id INTEGER PRIMARY KEY, data TEXT)"
+    )
+    con.execute(
+        "CREATE TABLE IF NOT EXISTS providers (name TEXT PRIMARY KEY, data TEXT)"
+    )
+
+
 def load_config() -> dict:
     if not DB_PATH.exists():
         return {}
     con = _connect()
-    con.execute("CREATE TABLE IF NOT EXISTS settings (id INTEGER PRIMARY KEY, data TEXT)")
+    _init_db(con)
     row = con.execute("SELECT data FROM settings WHERE id=1").fetchone()
     con.close()
     if row:
@@ -34,9 +44,7 @@ def save_config(config: dict) -> None:
         store_secret(ref, api_key)
         config["api_key_ref"] = ref
     con = _connect()
-    con.execute(
-        "CREATE TABLE IF NOT EXISTS settings (id INTEGER PRIMARY KEY, data TEXT)"
-    )
+    _init_db(con)
     con.execute("DELETE FROM settings WHERE id=1")
     con.execute("INSERT INTO settings VALUES (1, ?)", (json.dumps(config),))
     con.close()
@@ -46,6 +54,42 @@ def update_config(**kwargs) -> None:
     config = load_config()
     config.update(kwargs)
     save_config(config)
+
+
+def save_provider_config(provider: str, config: dict) -> None:
+    """Store provider-specific configuration and credentials."""
+    api_key = config.pop("api_key", "")
+    if api_key:
+        ref = config.get("api_key_ref", f"{provider}_api_key")
+        store_secret(ref, api_key)
+        config["api_key_ref"] = ref
+    con = _connect()
+    _init_db(con)
+    con.execute(
+        "INSERT OR REPLACE INTO providers VALUES (?, ?)",
+        (provider, json.dumps(config)),
+    )
+    con.close()
+
+
+def load_provider_configs() -> dict:
+    """Return mapping of provider name to saved config."""
+    if not DB_PATH.exists():
+        return {}
+    con = _connect()
+    _init_db(con)
+    rows = con.execute("SELECT name, data FROM providers").fetchall()
+    con.close()
+    result = {}
+    for name, data in rows:
+        try:
+            meta = json.loads(data)
+        except Exception:
+            meta = {}
+        if "api_key_ref" in meta:
+            meta["api_key"] = load_secret(meta["api_key_ref"]) or ""
+        result[name] = meta
+    return result
 
 
 def get_status() -> str:
@@ -60,3 +104,13 @@ def get_status() -> str:
         if not key:
             return "Invalid"
     return "Ready"
+
+
+def list_configured_providers() -> list[str]:
+    """Return provider names that have saved configuration."""
+    return sorted(load_provider_configs().keys())
+
+
+def get_provider_config(provider: str) -> dict:
+    """Return saved config for a single provider."""
+    return load_provider_configs().get(provider, {})


### PR DESCRIPTION
## Summary
- allow saving credentials for each provider
- add a duckdb table storing provider configs
- list configured providers in the sidebar
- update configuration page to handle all providers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68649f940f0c83248df28a855bcf4caf