### PR TITLE
Improve mobile UI modules

### DIFF
--- a/mobile_ui/app.py
+++ b/mobile_ui/app.py
@@ -12,6 +12,7 @@ Core application entry point with enhanced:
 import sys
 import logging
 from pathlib import Path
+from datetime import datetime
 from typing import Optional
 
 # 🚀 Initialization before imports to ensure path correctness

--- a/mobile_ui/components/models.py
+++ b/mobile_ui/components/models.py
@@ -19,3 +19,6 @@ def render_models():
     data = [m for m in get_models() if m.get("provider") == provider]
     if data:
         st.table(pd.DataFrame(data))
+    else:
+        st.info("No models to display for this provider.")
+

--- a/mobile_ui/pages/chat.py
+++ b/mobile_ui/pages/chat.py
@@ -1,57 +1,14 @@
-import time
 import streamlit as st
 
-from logic.config_manager import load_config, update_config
-from logic.model_registry import get_ready_models, get_model_meta
-from logic.runtime_dispatcher import dispatch_runtime
+from components.chat import render_chat
 
 
 def render_chat_page() -> None:
+    """High-level chat page using reusable chat component."""
     st.markdown("## :speech_balloon: Chat")
-    
-    models = [m.get("model_name") for m in get_ready_models()]
-    if not models:
-        st.warning("No models available")
-        return
-
-    config = load_config()
-    active_name = config.get("model", models[0])
-
-    selected = st.selectbox(
-        "Active Model",
-        models,
-        index=models.index(active_name) if active_name in models else 0,
-    )
-    if selected != active_name:
-        update_config(model=selected)
-        active_name = selected
-
-    meta = get_model_meta(active_name)
-    if not meta:
-        st.error("Model metadata not found")
-        return
-
-    st.markdown(f"### \U0001f4ac Chat with `{meta.get('model_name', active_name)}`")
-
-    user_input = st.chat_input("Type your message here...")
-    if user_input:
-        st.chat_message("user").write(user_input)
-        start = time.perf_counter()
-        try:
-            with st.spinner("Thinking..."):
-                response = dispatch_runtime(meta, user_input)
-        except Exception as exc:
-            st.chat_message("ai").error(f"Runtime error: {exc}")
-            return
-        duration = time.perf_counter() - start
-        st.chat_message("ai").write(response)
-        token_count = len(response.split())
-        st.markdown("---")
-        st.caption(
-            f"Provider: {meta.get('provider')} | Runtime: {meta.get('runtime')} | "
-            f"Tokens: {token_count} | Time: {duration:.2f}s"
-        )
+    render_chat()
 
 
 if __name__ == "__main__":
     render_chat_page()
+

--- a/mobile_ui/pages/settings.py
+++ b/mobile_ui/pages/settings.py
@@ -1,6 +1,7 @@
 import streamlit as st
 
 from logic.model_registry import get_models
+from logic.runtime_dispatcher import dispatch_runtime
 
 
 def render_model_catalog() -> None:
@@ -49,3 +50,4 @@ def render_model_catalog() -> None:
 
 if __name__ == "__main__":
     render_model_catalog()
+


### PR DESCRIPTION
## Summary
- fix missing datetime import in main app
- show message when no provider models
- simplify chat page to use component
- fix settings page import and EOL issues

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'huggingface_hub')*

------
https://chatgpt.com/codex/tasks/task_e_6864c7f1a3788324ba11d354b6aa01b8