### PR TITLE
Fix LLM registry imports

### DIFF
--- a/src/integrations/llm_registry.py
+++ b/src/integrations/llm_registry.py
@@ -5,9 +5,9 @@ from typing import Dict, Iterable
 from pathlib import Path
 
 import os
-from .integrations.llm_utils import LLMUtils
-from .services.ollama_inprocess import generate as local_generate
-from .services.deepseek_client import DeepSeekClient
+from src.integrations.llm_utils import LLMUtils
+from services.ollama_inprocess import generate as local_generate
+from services.deepseek_client import DeepSeekClient
 
 
 class LlamaCppWrapper:

--- a/ui/mobile_ui/__init__.py
+++ b/ui/mobile_ui/__init__.py
@@ -4,5 +4,11 @@ import pathlib
 PROJECT_ROOT = pathlib.Path(__file__).resolve().parents[2]  # AI-Karen root
 SRC_PATH = PROJECT_ROOT / "src"
 
+# Ensure both the project root and ``src`` directory are importable before any
+# submodules within ``ui.mobile_ui`` are loaded. Streamlit eagerly imports
+# components, so ``sys.path`` must be patched at package import time.
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
 if str(SRC_PATH) not in sys.path:
     sys.path.insert(0, str(SRC_PATH))

--- a/ui/mobile_ui/app.py
+++ b/ui/mobile_ui/app.py
@@ -5,7 +5,12 @@ import pathlib
 PROJECT_ROOT = pathlib.Path(__file__).resolve().parents[2]  # AI-Karen root
 SRC_PATH = PROJECT_ROOT / "src"
 
-# Add src/ to sys.path to allow absolute imports like "from src.integrations..."
+# Make project modules importable before anything else is loaded. This mirrors
+# the logic in ``ui.mobile_ui.__init__`` but is repeated here for direct script
+# execution.
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
 if str(SRC_PATH) not in sys.path:
     sys.path.insert(0, str(SRC_PATH))
 
@@ -14,7 +19,7 @@ import streamlit as st
 from components.sidebar import render_sidebar
 from components.provider_selector import select_provider
 from config.config_manager import ConfigManager
-from services.model_loader import ensure_spacy_models, ensure_sklearn_installed
+from utils.model_loader import ensure_spacy_models, ensure_sklearn_installed
 
 def load_styles():
     try:


### PR DESCRIPTION
## Summary
- ensure project root is on `sys.path` before components are imported
- correct imports in `llm_registry`
- fix `model_loader` import path in mobile UI app

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68654f15dfac8324b8358301f35c190c