### PR TITLE
Fix LLMUtils import path and clarify model loader

### DIFF
--- a/src/integrations/llm_registry.py
+++ b/src/integrations/llm_registry.py
@@ -9,7 +9,8 @@ import logging
 logger = logging.getLogger(__name__)
 
 try:
-    from integrations.llm_utils import LLMUtils
+    # Use the shared LLM helper from the src.integrations package
+    from src.integrations.llm_utils import LLMUtils
     from services.ollama_inprocess import generate as local_generate
     from services.deepseek_client import DeepSeekClient
 except ImportError as e:

--- a/ui/mobile_ui/utils/model_loader.py
+++ b/ui/mobile_ui/utils/model_loader.py
@@ -1,3 +1,10 @@
+"""Utility helpers used by the mobile UI to ensure optional ML libraries.
+
+This module is unrelated to ``LLMUtils``; it simply verifies that small
+dependencies like spaCy models or scikit-learn are installed so the
+Streamlit interface works out of the box.
+"""
+
 import importlib.util
 import subprocess
 


### PR DESCRIPTION
## Summary
- use `src.integrations.llm_utils` in `LLMRegistry`
- clarify mobile UI model loader purpose

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865d93fbc688324bda87f0804defd27