### PR TITLE
Add get_model_meta helper

### DIFF
--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -57,3 +57,13 @@ def test_get_providers_includes_registry_providers(tmp_path, monkeypatch):
     providers = mr.get_providers()
     assert "llama-cpp" in providers
     assert "custom_provider" in providers
+
+
+def test_get_model_meta(monkeypatch):
+    models = [
+        {"model_name": "foo", "provider": "llama-cpp"},
+        {"model_name": "bar", "provider": "anthropic"},
+    ]
+    monkeypatch.setattr(mr, "get_ready_models", lambda: models)
+    assert mr.get_model_meta("foo") == models[0]
+    assert mr.get_model_meta("missing") is None

--- a/ui/mobile_ui/services/model_registry.py
+++ b/ui/mobile_ui/services/model_registry.py
@@ -213,6 +213,14 @@ def get_providers() -> List[str]:
     return sorted(p for p in providers if p)
 
 
+def get_model_meta(model_name: str) -> Optional[Dict[str, Any]]:
+    """Return the metadata dict for ``model_name`` if available."""
+    for model in get_ready_models():
+        if model.get("model_name") == model_name:
+            return model
+    return None
+
+
 def ensure_model_downloaded(model: Dict[str, Any]) -> str:
     """
     Ensure the given model entry is available locally.


### PR DESCRIPTION
## Summary
- add `get_model_meta` in `model_registry`
- test metadata retrieval

## Testing
- `pytest -q tests/test_model_registry.py`
- `pytest -q` *(fails: NameError: LLMUtils not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6865d9333f908324a9e4133cd0732caa