### PR TITLE
Document ConfigUI location

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ capsules/      # domain-specific agents (DevOps, Finance, …)
 integrations/  # NANDA client, RPA helpers, external bridges
 plugins/       # drop-in plugins (manifest + handler + ui)
 ui/desktop_ui/ # Tauri Control Room (Rust + React)
+ui/mobile_ui/config/config_ui.py # Streamlit UI settings (ConfigUI class)
 fastapi_stub/  # API entrypoints, chat & metrics
 pydantic_stub/ # DTOs & schemas
 tests/         # pytest suite

--- a/docs/development_guide.md
+++ b/docs/development_guide.md
@@ -16,6 +16,9 @@ xdg-open http://localhost:8000/docs
 # run the Streamlit UI
 streamlit run ui/mobile_ui/app.py
 ```
+The Streamlit UI reads environment variables via
+`ui/mobile_ui/config/config_ui.py`.
+If you previously imported `config/config_ui.py`, switch to this new path.
 
 ## Build Mode (Tauri App)
 


### PR DESCRIPTION
## Summary
- document the location of ConfigUI
- mention new path in the development guide

## Testing
- `pytest -q` *(fails: NameError: name 'LLMUtils' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6865d935ea28832496c783bd9a6162e5