### PR TITLE
Fix style path for mobile UI

### DIFF
--- a/ui/mobile_ui/app.py
+++ b/ui/mobile_ui/app.py
@@ -23,12 +23,16 @@ from utils.model_loader import ensure_spacy_models, ensure_sklearn_installed
 
 # ========== STYLING ==========
 def load_styles():
+    css_path = pathlib.Path(__file__).parent / "styles" / "styles.css"
     try:
-        with open("styles/styles.css", "r") as f:
+        with open(css_path, "r") as f:
             st.markdown(f"<style>{f.read()}</style>", unsafe_allow_html=True)
+            return
     except Exception:
-        fallback_css = ".stButton>button { border-radius: 8px; border: 1px solid #4CAF50; }"
-        st.markdown(f"<style>{fallback_css}</style>", unsafe_allow_html=True)
+        pass
+
+    fallback_css = ".stButton>button { border-radius: 8px; border: 1px solid #4CAF50; }"
+    st.markdown(f"<style>{fallback_css}</style>", unsafe_allow_html=True)
 
 # ========== MAIN ==========
 def main():


### PR DESCRIPTION
## Summary
- load CSS from `styles/styles.css` using a path relative to `app.py`
- display fallback styles if the file fails to load

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6865eb215d308324b5942736c1113ae2