### PR TITLE
Fix relative imports for llm_registry

### DIFF
--- a/src/integrations/llm_registry.py
+++ b/src/integrations/llm_registry.py
@@ -9,10 +9,10 @@ import logging
 logger = logging.getLogger(__name__)
 
 try:
-    # Use the shared LLM helper from the src.integrations package
-    from src.integrations.llm_utils import LLMUtils
-    from services.ollama_inprocess import generate as local_generate
-    from services.deepseek_client import DeepSeekClient
+    # Use the shared LLM helper from the same package
+    from .llm_utils import LLMUtils
+    from ..services.ollama_inprocess import generate as local_generate
+    from ..services.deepseek_client import DeepSeekClient
 except ImportError as e:
     logger.warning(f"Import error: {e}")
     


### PR DESCRIPTION
## Summary
- update `llm_registry` imports to use relative paths

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865eb25708483248e86a38e2f8bdbad