### PR TITLE
Add pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,25 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 23.9.1
+    hooks:
+      - id: black
+  - repo: https://github.com/pycqa/isort
+    rev: 5.12.0
+    hooks:
+      - id: isort
+        args: ["--profile=black"]
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.1.5
+    hooks:
+      - id: ruff
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.7.0
+    hooks:
+      - id: mypy
+        args: ["--strict", "--install-types", "--non-interactive"]
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: check-yaml

--- a/README.md
+++ b/README.md
@@ -227,6 +227,12 @@ cd ui/desktop_ui && tauri dev  # hot reloads the desktop shell using src-tauri/t
 | Lint               | `ruff .`                               |
 | Tests              | `pytest`                               |
 | Hot-reload plugins | just save the folder—Kari auto-detects |
+
+Pre-commit hooks run these checks automatically. After cloning run:
+
+```bash
+pre-commit install
+```
 ### Advanced / Unrestricted Mode
 
 Set `ADVANCED_MODE=true` to enable full SelfRefactor logs and allow plugin UIs marked as untrusted. Use with caution.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -6,7 +6,7 @@ We welcome community plugins and bug fixes. Please follow the checklist below wh
 
 ```bash
 pip install -r requirements.txt
-pre-commit install
+pre-commit install  # sets up git hooks from .pre-commit-config.yaml
 ```
 
 ## Coding Standards


### PR DESCRIPTION
## Summary
- add `.pre-commit-config.yaml` with Black, isort, ruff and mypy
- document installing pre-commit hooks
- mention pre-commit usage in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866bd1e169c8324a64838ab74c2fe37