### PR TITLE
Fix MilvusClient delete behavior and tests

### DIFF
--- a/src/core/milvus_client.py
+++ b/src/core/milvus_client.py
@@ -54,19 +54,11 @@ class MilvusClient:
 
 
     def delete(self, ids: Iterable[int]) -> None:
+        """Delete records by ID."""
         start = time.time()
         with self._lock:
             for rid in list(ids):
                 self._data.pop(rid, None)
- 
-
-
-    def delete(self, ids: List[int]) -> None:
-        """Delete records by ID."""
-        start = time.time()
-        self._data = [r for r in self._data if r["id"] not in ids]
- 
- 
         record_metric("vector_delete_seconds", time.time() - start)
 
     @staticmethod

--- a/tests/test_milvus_client.py
+++ b/tests/test_milvus_client.py
@@ -34,3 +34,22 @@ def test_ttl_pruning():
     texts = [r["payload"]["text"] for r in results]
     assert "new" in texts
     assert "old" not in texts
+
+
+def test_delete_removes_ids_and_preserves_dict():
+    client = MilvusClient()
+    id1 = client.upsert([0.1, 0.2], {"text": "a"})
+    id2 = client.upsert([0.2, 0.1], {"text": "b"})
+    id3 = client.upsert([0.3, 0.3], {"text": "c"})
+    client.delete([id1, id3])
+    assert isinstance(client._data, dict)
+    assert id1 not in client._data
+    assert id3 not in client._data
+    assert id2 in client._data
+
+
+def test_delete_nonexistent_id_no_error():
+    client = MilvusClient()
+    kept = client.upsert([1.0, 0.0], {"text": "keep"})
+    client.delete([9999])
+    assert kept in client._data


### PR DESCRIPTION
## Summary
- remove incorrect list-based delete implementation
- ensure delete keeps the dict and records metrics
- add unit tests to cover deletion behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866bc7ec534832486b6fcbf079baa94