### PR TITLE
Fix admin mesh panel import

### DIFF
--- a/ui/admin_ui/pages/mesh_panel.py
+++ b/ui/admin_ui/pages/mesh_panel.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-from .. import tauri
 
 
 def render(events: list[dict]) -> str:


### PR DESCRIPTION
## Summary
- remove stray tauri import from admin UI mesh panel

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6866c50f98d88324bc17c3092f5c9a9c