### PR TITLE
Fix KariICEWrapper llm default

### DIFF
--- a/src/core/reasoning/ice_integration.py
+++ b/src/core/reasoning/ice_integration.py
@@ -26,9 +26,7 @@ class KariICEWrapper:
         self.engine = SoftReasoningEngine()
         self.threshold = threshold
  
-        self.llm = llm or llm_registry.get_active()
-
-        self.llm = llm or LLMUtils()
+        self.llm = llm or llm_registry.get_active() or LLMUtils()
  
 
     def process(self, text: str) -> Dict[str, Any]:


### PR DESCRIPTION
## Summary
- reduce redundant `KariICEWrapper` initialization

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866c5031b7c8324aec09d807af84e99