### PR TITLE
Normalize absolute imports

### DIFF
--- a/capsules/devops/handler.py
+++ b/capsules/devops/handler.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 from typing import Any, Dict
 
-from src.core.plugin_router import PluginRouter
+from ai_karen_engine.core.plugin_router import PluginRouter
 
 router = PluginRouter()
 

--- a/docs/automation_features.md
+++ b/docs/automation_features.md
@@ -7,7 +7,7 @@ Kari ships with a **proprietary automation layer** for chaining tasks and local 
 Our `AutomationManager` orchestrates asynchronous tasks using a custom queue. Plugins can enqueue coroutines that interact with local scripts or trigger n8n workflows.
 
 ```python
-from src.core.automation_manager import AutomationManager
+from ai_karen_engine.core.automation_manager import AutomationManager
 
 auto = AutomationManager()
 auto.add_task(some_async_task())
@@ -19,7 +19,7 @@ results = await auto.run_all()
 The `LocalRPAClient` is Kari's locked‑down wrapper around **PyAutoGUI** for desktop automation. It can click, type, and take screenshots.
 
 ```python
-from src.integrations.local_rpa_client import LocalRPAClient
+from ai_karen_engine.integrations.local_rpa_client import LocalRPAClient
 
 rpa = LocalRPAClient()
 rpa.click(100, 200)
@@ -34,7 +34,7 @@ Use this only on trusted machines because it controls the local keyboard and mou
 The `WorkflowEngineClient` provides a proprietary bridge to n8n. Set `workflow_slug` in a plugin manifest and call `trigger()` with a payload.
 
 ```python
-from src.core.workflow_engine_client import WorkflowEngineClient
+from ai_karen_engine.core.workflow_engine_client import WorkflowEngineClient
 
 wf = WorkflowEngineClient()
 wf.trigger("onboarding", {"user_id": 123})

--- a/docs/event_bus.md
+++ b/docs/event_bus.md
@@ -5,7 +5,7 @@ Kari ships with a simple in-memory EventBus that mirrors Redis Streams. Capsules
 ## API
 
 ```python
-from src.event_bus import EventBus
+from ai_karen_engine.event_bus import EventBus
 
 bus = EventBus()
 msg_id = bus.publish("devops", "deploy", {"status": "ok"}, risk=0.2)

--- a/docs/ice_wrapper.md
+++ b/docs/ice_wrapper.md
@@ -12,7 +12,7 @@ The Integrated Cognitive Engine (ICE) is Kari's lightweight deep reasoning layer
 ## Example
 
 ```python
-from src.core.reasoning.ice_integration import KariICEWrapper
+from ai_karen_engine.core.reasoning.ice_integration import KariICEWrapper
 
 ice = KariICEWrapper()
 result = ice.process("How does Milvus handle vector deletes?")

--- a/docs/n8n_integration.md
+++ b/docs/n8n_integration.md
@@ -15,7 +15,7 @@ Kari includes a proprietary bridge to n8n for orchestrating external workflows. 
 3. In your plugin code, call `WorkflowEngineClient.trigger()` with the desired slug and payload.
 
 ```python
-from src.core.workflow_engine_client import WorkflowEngineClient
+from ai_karen_engine.core.workflow_engine_client import WorkflowEngineClient
 
 wf = WorkflowEngineClient()
 wf.trigger("support_ticket", {"issue": "printer jam"})

--- a/guardrails/__init__.py
+++ b/guardrails/__init__.py
@@ -1,3 +1,3 @@
-from .validator import validate, ValidationError
+from ai_karen_engine.guardrails.validator import validate, ValidationError
 __all__ = ["validate", "ValidationError"]
 

--- a/main.py
+++ b/main.py
@@ -2,9 +2,9 @@ from typing import Any, Dict, List
 from pathlib import Path
 import sys
 import os
-from src.core.cortex.dispatch import CortexDispatcher
-from src.core.embedding_manager import _METRICS as METRICS
-from src.core.soft_reasoning_engine import SoftReasoningEngine
+from ai_karen_engine.core.cortex.dispatch import CortexDispatcher
+from ai_karen_engine.core.embedding_manager import _METRICS as METRICS
+from ai_karen_engine.core.soft_reasoning_engine import SoftReasoningEngine
 
 if (Path(__file__).resolve().parent / "fastapi").is_dir():
     sys.stderr.write(
@@ -17,7 +17,7 @@ try:
     from fastapi.responses import JSONResponse, Response
 except Exception:  # fastapi_stub compatibility
     from fastapi.responses import JSONResponse
-    from src.fastapi_stub import Response
+    from ai_karen_engine.fastapi_stub import Response
 try:
     from prometheus_client import (
         Counter,
@@ -49,12 +49,12 @@ except Exception:  # pragma: no cover - fallback when package is missing
 
     CONTENT_TYPE_LATEST = "text/plain"
     Counter = Histogram = _DummyMetric
-from src.self_refactor import SelfRefactorEngine, SREScheduler
+from ai_karen_engine.self_refactor import SelfRefactorEngine, SREScheduler
 from pydantic import BaseModel
 import asyncio
 import logging
-from src.integrations.llm_registry import registry as llm_registry
-from src.integrations.model_discovery import sync_registry
+from ai_karen_engine.integrations.llm_registry import registry as llm_registry
+from ai_karen_engine.integrations.model_discovery import sync_registry
 
 app = FastAPI()
 
@@ -279,7 +279,7 @@ def select_model(req: ModelSelectRequest) -> ModelListResponse:
 @app.get("/self_refactor/logs")
 def self_refactor_logs(full: bool = False):
     """Return SelfRefactor logs. Sanitized unless ADVANCED_MODE allows full."""
-    from src.self_refactor import log_utils
+    from ai_karen_engine.self_refactor import log_utils
 
     logs = log_utils.load_logs(full=full)
     return {"logs": logs}

--- a/src/ai_karen_engine/__init__.py
+++ b/src/ai_karen_engine/__init__.py
@@ -1,13 +1,35 @@
 """Core runtime components for Kari."""
 
-from .clients.slm_pool import SLMPool
-from .llm_orchestrator import LLMOrchestrator
-from .echocore.fine_tuner import NightlyFineTuner
-from src.core.model_manager import ModelManager
-from src.core.echo_core import EchoCore
-from src.clients.transformers.lnm_client import LNMClient
-from src.clients.nlp.basic_classifier import BasicClassifier
-from src.clients.nlp.spacy_client import SpaCyClient
+from __future__ import annotations
+
+import importlib
+import sys
+
+# expose legacy packages under the ``ai_karen_engine`` namespace
+for _pkg in [
+    "core",
+    "integrations",
+    "plugins",
+    "services",
+    "self_refactor",
+    "event_bus",
+    "ui",
+    "guardrails",
+]:
+    try:
+        target = f"src.{_pkg}" if _pkg != "ui" else _pkg
+        sys.modules[f"ai_karen_engine.{_pkg}"] = importlib.import_module(target)
+    except ModuleNotFoundError:
+        pass
+
+from ai_karen_engine.clients.slm_pool import SLMPool
+from ai_karen_engine.llm_orchestrator import LLMOrchestrator
+from ai_karen_engine.echocore.fine_tuner import NightlyFineTuner
+from ai_karen_engine.core.model_manager import ModelManager
+from ai_karen_engine.core.echo_core import EchoCore
+from ai_karen_engine.clients.transformers.lnm_client import LNMClient
+from ai_karen_engine.clients.nlp.basic_classifier import BasicClassifier
+from ai_karen_engine.clients.nlp.spacy_client import SpaCyClient
 
 __all__ = [
     "SLMPool",

--- a/src/ai_karen_engine/clients/__init__.py
+++ b/src/ai_karen_engine/clients/__init__.py
@@ -1,1 +1,10 @@
+"""Client utilities and adapters."""
 
+import importlib
+import sys
+
+for _sub in ["transformers", "nlp"]:
+    try:
+        sys.modules[f"ai_karen_engine.clients.{_sub}"] = importlib.import_module(f"src.clients.{_sub}")
+    except ModuleNotFoundError:
+        pass

--- a/src/ai_karen_engine/clients/embedding/embedding_client.py
+++ b/src/ai_karen_engine/clients/embedding/embedding_client.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import hashlib
 from typing import List
 
-from src.core.embedding_manager import EmbeddingManager
+from ai_karen_engine.core.embedding_manager import EmbeddingManager
 
 
 def _byte_embedding_model(byte_input: bytes, dim: int = 8) -> List[float]:

--- a/src/ai_karen_engine/clients/slm_pool.py
+++ b/src/ai_karen_engine/clients/slm_pool.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Dict, Iterable, Optional
 
-from src.integrations.llm_utils import LLMUtils
+from ai_karen_engine.integrations.llm_utils import LLMUtils
 
 
 class SLMPool:

--- a/src/ai_karen_engine/llm_orchestrator.py
+++ b/src/ai_karen_engine/llm_orchestrator.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from typing import Optional
 
-from src.integrations.llm_registry import registry
-from .clients.slm_pool import SLMPool
+from ai_karen_engine.integrations.llm_registry import registry
+from ai_karen_engine.clients.slm_pool import SLMPool
 
 
 class LLMOrchestrator:

--- a/src/ai_karen_engine/tauri.py
+++ b/src/ai_karen_engine/tauri.py
@@ -1,0 +1,1 @@
+"""Stub module for Tauri CLI wrappers."""

--- a/src/core/autonomous_agent.py
+++ b/src/core/autonomous_agent.py
@@ -1,10 +1,10 @@
 import time
 import uuid
 
-from src.core.prompt_router import PromptRouter
-from src.core.automation_manager import AutomationManager
-from src.core.workflow_engine_client import WorkflowEngineClient
-from src.integrations.llm_utils import LLMUtils
+from ai_karen_engine.core.prompt_router import PromptRouter
+from ai_karen_engine.core.automation_manager import AutomationManager
+from ai_karen_engine.core.workflow_engine_client import WorkflowEngineClient
+from ai_karen_engine.integrations.llm_utils import LLMUtils
 
 
 class AutonomousAgent:

--- a/src/core/cortex/dispatch.py
+++ b/src/core/cortex/dispatch.py
@@ -8,9 +8,9 @@ from __future__ import annotations
 import asyncio
 from typing import Any, Dict
 
-from ..intent_engine import IntentEngine
-from ..plugin_router import PluginRouter, AccessDenied
-from ..reasoning.ice_integration import KariICEWrapper
+from ai_karen_engine.core.intent_engine import IntentEngine
+from ai_karen_engine.core.plugin_router import PluginRouter, AccessDenied
+from ai_karen_engine.core.reasoning.ice_integration import KariICEWrapper
 
 
 class CortexDispatcher:

--- a/src/core/echo_core.py
+++ b/src/core/echo_core.py
@@ -23,7 +23,7 @@ try:
 except Exception:  # pragma: no cover - optional dep
     AutoTokenizer = AutoModelForSequenceClassification = Trainer = TrainingArguments = None
 
-from .model_manager import ModelManager
+from ai_karen_engine.core.model_manager import ModelManager
 
 
 class EchoCore:

--- a/src/core/milvus_client.py
+++ b/src/core/milvus_client.py
@@ -8,7 +8,7 @@ import time
 from dataclasses import dataclass
 from typing import Any, Dict, Iterable, List, Optional
 
-from .embedding_manager import record_metric
+from ai_karen_engine.core.embedding_manager import record_metric
 
 
 @dataclass

--- a/src/core/orchestration/model_router.py
+++ b/src/core/orchestration/model_router.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from src.integrations.llm_registry import registry
+from ai_karen_engine.integrations.llm_registry import registry
 
 
 def route_input(model: Any, text: str) -> Any:

--- a/src/core/prompt_router.py
+++ b/src/core/prompt_router.py
@@ -1,5 +1,5 @@
 import asyncio
-from src.core.plugin_router import PluginRouter as BaseRouter
+from ai_karen_engine.core.plugin_router import PluginRouter as BaseRouter
 
 
 class PluginWrapper:

--- a/src/core/reasoning/ice_integration.py
+++ b/src/core/reasoning/ice_integration.py
@@ -12,11 +12,11 @@ import asyncio
 from typing import Any, Dict, List
 
  
-from src.integrations.llm_registry import registry as llm_registry
+from ai_karen_engine.integrations.llm_registry import registry as llm_registry
 
-from src.integrations.llm_utils import LLMUtils
+from ai_karen_engine.integrations.llm_utils import LLMUtils
 
-from ..soft_reasoning_engine import SoftReasoningEngine
+from ai_karen_engine.core.soft_reasoning_engine import SoftReasoningEngine
 
 
 class KariICEWrapper:

--- a/src/core/soft_reasoning_engine.py
+++ b/src/core/soft_reasoning_engine.py
@@ -3,8 +3,8 @@ import math
 import time
 from typing import Any, Dict, List, Optional
 
-from .embedding_manager import EmbeddingManager
-from .milvus_client import MilvusClient
+from ai_karen_engine.core.embedding_manager import EmbeddingManager
+from ai_karen_engine.core.milvus_client import MilvusClient
 
 
 class SoftReasoningEngine:

--- a/src/fastapi_stub/testclient.py
+++ b/src/fastapi_stub/testclient.py
@@ -1,5 +1,5 @@
 import asyncio
-from . import Response
+from ai_karen_engine.fastapi_stub import Response
 
 
 class TestClient:

--- a/src/integrations/llm_registry.py
+++ b/src/integrations/llm_registry.py
@@ -7,11 +7,11 @@ from typing import Dict, Iterable, Optional
 logger = logging.getLogger(__name__)
 
     # Relative import for same-package utilities
-from .llm_utils import LLMUtils
+from ai_karen_engine.integrations.llm_utils import LLMUtils
 
 # Absolute imports from services package
-from src.services.ollama_inprocess import generate as local_generate
-from src.services.deepseek_client import DeepSeekClient
+from ai_karen_engine.services.ollama_inprocess import generate as local_generate
+from ai_karen_engine.services.deepseek_client import DeepSeekClient
 
 
 class LlamaCppWrapper:

--- a/src/plugins/desktop_agent/handler.py
+++ b/src/plugins/desktop_agent/handler.py
@@ -1,4 +1,4 @@
-from .agent import DesktopAgent
+from ai_karen_engine.plugins.desktop_agent.agent import DesktopAgent
 
 async def run(params: dict) -> dict:
     """Entry point for the desktop automation plugin."""

--- a/src/plugins/fine_tune_lnm/__init__.py
+++ b/src/plugins/fine_tune_lnm/__init__.py
@@ -1,2 +1,2 @@
-from .handler import run
+from ai_karen_engine.plugins.fine_tune_lnm.handler import run
 __all__ = ["run"]

--- a/src/plugins/fine_tune_lnm/handler.py
+++ b/src/plugins/fine_tune_lnm/handler.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from src.core.echo_core import EchoCore
+from ai_karen_engine.core.echo_core import EchoCore
 
 
 async def run(params: dict) -> str:

--- a/src/plugins/hf_llm/handler.py
+++ b/src/plugins/hf_llm/handler.py
@@ -1,4 +1,4 @@
-from src.integrations.llm_utils import LLMUtils
+from ai_karen_engine.integrations.llm_utils import LLMUtils
 
 llm = LLMUtils()
 

--- a/src/plugins/llm_manager/handler.py
+++ b/src/plugins/llm_manager/handler.py
@@ -1,5 +1,5 @@
-from src.integrations.llm_registry import registry
-from src.integrations import model_discovery
+from ai_karen_engine.integrations.llm_registry import registry
+from ai_karen_engine.integrations import model_discovery
 
 async def run(params: dict) -> dict:
     action = params.get("action", "list")

--- a/src/plugins/tui_fallback/handler.py
+++ b/src/plugins/tui_fallback/handler.py
@@ -1,5 +1,5 @@
 import asyncio
-from . import tui
+from ai_karen_engine.plugins.tui_fallback import tui
 
 async def run(params: dict) -> dict:
     """Launch the interactive TUI with the given state dictionaries."""

--- a/src/self_refactor/__init__.py
+++ b/src/self_refactor/__init__.py
@@ -1,4 +1,4 @@
-from .engine import SelfRefactorEngine, PatchReport
-from .scheduler import SREScheduler
+from ai_karen_engine.self_refactor.engine import SelfRefactorEngine, PatchReport
+from ai_karen_engine.self_refactor.scheduler import SREScheduler
 
 __all__ = ["SelfRefactorEngine", "PatchReport", "SREScheduler"]

--- a/src/self_refactor/engine.py
+++ b/src/self_refactor/engine.py
@@ -12,11 +12,11 @@ import tempfile
 import time
 from typing import Dict, List, Tuple
 
-from src.integrations.nanda_client import NANDAClient
- 
-from src.integrations.llm_registry import registry as llm_registry
+from ai_karen_engine.integrations.nanda_client import NANDAClient
 
-from src.integrations.llm_utils import LLMUtils
+from ai_karen_engine.integrations.llm_registry import registry as llm_registry
+
+from ai_karen_engine.integrations.llm_utils import LLMUtils
 
 
 class PatchReport(dict):
@@ -114,7 +114,7 @@ class SelfRefactorEngine:
                 }
             )
         try:
-            from . import log_utils
+            from ai_karen_engine.self_refactor import log_utils
 
             log_utils.record_report(report)
         except Exception:

--- a/src/self_refactor/log_utils.py
+++ b/src/self_refactor/log_utils.py
@@ -3,7 +3,7 @@ import os
 import pathlib
 from typing import List, Dict, Any
 
-from .engine import PatchReport
+from ai_karen_engine.self_refactor.engine import PatchReport
 
 LOG_PATH = pathlib.Path(os.getenv("SRE_LOG_PATH", "logs/self_refactor.log"))
 

--- a/src/self_refactor/scheduler.py
+++ b/src/self_refactor/scheduler.py
@@ -6,7 +6,7 @@ import os
 import threading
 from typing import Optional
 
-from .engine import SelfRefactorEngine
+from ai_karen_engine.self_refactor.engine import SelfRefactorEngine
 
 
 class SREScheduler:

--- a/src/ui/__init__.py
+++ b/src/ui/__init__.py
@@ -1,5 +1,5 @@
 """UI modules for Kari."""
 
-from .chat_hub import ChatHub, SlashCommand, NeuroVault
+from ai_karen_engine.ui.chat_hub import ChatHub, SlashCommand, NeuroVault
 
 __all__ = ["ChatHub", "SlashCommand", "NeuroVault"]

--- a/src/ui/chat_hub.py
+++ b/src/ui/chat_hub.py
@@ -17,7 +17,7 @@ except Exception:  # pragma: no cover
         def __init__(self, *a, **k): pass
         def observe(self, *a, **k): pass
 
-from src.core.prompt_router import PromptRouter
+from ai_karen_engine.core.prompt_router import PromptRouter
 
 
 @dataclass

--- a/src/ui/widgets/__init__.py
+++ b/src/ui/widgets/__init__.py
@@ -1,7 +1,7 @@
 """Lightweight UI widget stubs."""
 
-from .file_picker import select_file
-from .form_builder import render_form
-from .chart_viewer import show_chart
+from ai_karen_engine.ui.widgets.file_picker import select_file
+from ai_karen_engine.ui.widgets.form_builder import render_form
+from ai_karen_engine.ui.widgets.chart_viewer import show_chart
 
 __all__ = ["select_file", "render_form", "show_chart"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,1 @@
 import os
-import sys
-
-BASE_DIR = os.path.dirname(os.path.dirname(__file__))
-if BASE_DIR not in sys.path:
-    sys.path.insert(0, BASE_DIR)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,7 +1,7 @@
 import sys
 
-import src.fastapi_stub as fastapi_stub
-import src.pydantic_stub as pydantic_stub
+import ai_karen_engine.fastapi_stub as fastapi_stub
+import ai_karen_engine.pydantic_stub as pydantic_stub
 
 sys.modules["fastapi"] = fastapi_stub
 sys.modules["pydantic"] = pydantic_stub

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -1,5 +1,5 @@
 import asyncio
-from src.core.cortex.dispatch import CortexDispatcher
+from ai_karen_engine.core.cortex.dispatch import CortexDispatcher
 
 
 def test_dispatch_greet():

--- a/tests/test_embedding.py
+++ b/tests/test_embedding.py
@@ -1,4 +1,4 @@
-from src.core.embedding_manager import EmbeddingManager, _METRICS
+from ai_karen_engine.core.embedding_manager import EmbeddingManager, _METRICS
 
 
 def test_embed_shape():

--- a/tests/test_embedding_client.py
+++ b/tests/test_embedding_client.py
@@ -1,4 +1,4 @@
-from src.ai_karen_engine.clients.embedding.embedding_client import get_embedding
+from ai_karen_engine.clients.embedding.embedding_client import get_embedding
 
 
 def test_get_embedding_byte_and_default():

--- a/tests/test_gpu_training.py
+++ b/tests/test_gpu_training.py
@@ -1,7 +1,7 @@
 import pytest
 import importlib
 
-import src.core.gpu_training as gpu_training
+import ai_karen_engine.core.gpu_training as gpu_training
 
 
 def test_gpu_training_requires_torch():

--- a/tests/test_ice_integration.py
+++ b/tests/test_ice_integration.py
@@ -1,6 +1,6 @@
 import asyncio
 
-from src.core.reasoning.ice_integration import KariICEWrapper
+from ai_karen_engine.core.reasoning.ice_integration import KariICEWrapper
 
 
 def test_process_returns_keys():

--- a/tests/test_intent_engine.py
+++ b/tests/test_intent_engine.py
@@ -1,4 +1,4 @@
-from src.core.intent_engine import IntentEngine
+from ai_karen_engine.core.intent_engine import IntentEngine
 
 
 def test_detect_intent():

--- a/tests/test_llm_manager.py
+++ b/tests/test_llm_manager.py
@@ -1,8 +1,8 @@
 import asyncio
 
-from src.plugins.llm_manager.handler import run
-from src.integrations.llm_registry import registry
-from src.integrations import model_discovery
+from ai_karen_engine.plugins.llm_manager.handler import run
+from ai_karen_engine.integrations.llm_registry import registry
+from ai_karen_engine.integrations import model_discovery
 
 
 def test_refresh_models(tmp_path, monkeypatch):

--- a/tests/test_llm_orchestrator.py
+++ b/tests/test_llm_orchestrator.py
@@ -1,5 +1,5 @@
-from src.ai_karen_engine import SLMPool, LLMOrchestrator
-from src.integrations.llm_utils import LLMUtils
+from ai_karen_engine import SLMPool, LLMOrchestrator
+from ai_karen_engine.integrations.llm_utils import LLMUtils
 
 
 def test_orchestrator_uses_skill_model():

--- a/tests/test_llm_utils.py
+++ b/tests/test_llm_utils.py
@@ -1,4 +1,4 @@
-from src.integrations.llm_utils import LLMUtils
+from ai_karen_engine.integrations.llm_utils import LLMUtils
 
 
 def test_llm_utils_fallback():

--- a/tests/test_log_utils.py
+++ b/tests/test_log_utils.py
@@ -1,5 +1,5 @@
-from src.self_refactor.log_utils import record_report, load_logs, LOG_PATH
-from src.self_refactor.engine import PatchReport
+from ai_karen_engine.self_refactor.log_utils import record_report, load_logs, LOG_PATH
+from ai_karen_engine.self_refactor.engine import PatchReport
 import os
 import json
 

--- a/tests/test_mesh_planner.py
+++ b/tests/test_mesh_planner.py
@@ -1,5 +1,5 @@
 import asyncio
-from src.core.mesh_planner import MeshPlanner
+from ai_karen_engine.core.mesh_planner import MeshPlanner
 
 
 def test_load_and_route(tmp_path, monkeypatch):

--- a/tests/test_milvus_client.py
+++ b/tests/test_milvus_client.py
@@ -1,7 +1,7 @@
 import time
 import pytest
 
-from src.core.milvus_client import MilvusClient
+from ai_karen_engine.core.milvus_client import MilvusClient
 
 
 def test_upsert_and_search():

--- a/tests/test_nanda_client.py
+++ b/tests/test_nanda_client.py
@@ -1,4 +1,4 @@
-from src.integrations.nanda_client import NANDAClient
+from ai_karen_engine.integrations.nanda_client import NANDAClient
 
 
 

--- a/tests/test_plugin_router.py
+++ b/tests/test_plugin_router.py
@@ -1,10 +1,9 @@
 import asyncio
 import json
-import sys
 from types import ModuleType
 import pytest
 
-from src.core.plugin_router import AccessDenied, PluginRouter
+from ai_karen_engine.core.plugin_router import AccessDenied, PluginRouter
 
 
 def ensure_optional_dependency(name: str):
@@ -26,7 +25,7 @@ def test_invalid_manifest(monkeypatch, tmp_path):
     bad = tmp_path / "bad_plugin"
     bad.mkdir()
     (bad / "plugin_manifest.json").write_text("{ invalid json }")
-    monkeypatch.setattr("src.core.plugin_router.PLUGIN_DIR", str(tmp_path))
+    monkeypatch.setattr("ai_karen_engine.core.plugin_router.PLUGIN_DIR", str(tmp_path))
     for dep in ["pyautogui", "urwid"]:
         ensure_optional_dependency(dep)
     router = PluginRouter()
@@ -78,8 +77,7 @@ def test_plugin_ui_gating(tmp_path, monkeypatch):
     )
     (plugin / "handler.py").write_text("async def run(params):\n    return 'ok'\n")
     (plugin / "ui.py").write_text("def render():\n    return '<div>UI</div>'\n")
-    monkeypatch.setattr("src.core.plugin_router.PLUGIN_DIR", str(tmp_path))
-    sys.path.insert(0, str(tmp_path))
+    monkeypatch.setattr("ai_karen_engine.core.plugin_router.PLUGIN_DIR", str(tmp_path))
     router = PluginRouter(plugin_dir=str(tmp_path))
     record = router.get_plugin("ui_intent")
     assert record is not None

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -8,9 +8,6 @@ from types import ModuleType
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 PLUGIN_DIR = os.path.join(BASE_DIR, 'src', 'plugins')
 
-if BASE_DIR not in sys.path:
-    sys.path.insert(0, BASE_DIR)
-
 
 def ensure_optional_dependency(name: str):
     """Create a dummy module if the real one is missing."""
@@ -39,6 +36,6 @@ def test_manifest_and_handler():
         # provide dummy optional deps such as pyautogui and urwid
         for dep in ['pyautogui', 'urwid']:
             ensure_optional_dependency(dep)
-        handler_module = importlib.import_module(f'src.plugins.{plugin}.handler')
+        handler_module = importlib.import_module(f'ai_karen_engine.plugins.{plugin}.handler')
         assert hasattr(handler_module, 'run')
         assert inspect.iscoroutinefunction(handler_module.run)

--- a/tests/test_self_refactor.py
+++ b/tests/test_self_refactor.py
@@ -1,5 +1,5 @@
 import pathlib
-from src.self_refactor import SelfRefactorEngine
+from ai_karen_engine.self_refactor import SelfRefactorEngine
 
 
 class DummyLLM:

--- a/tests/test_self_refactor_loop.py
+++ b/tests/test_self_refactor_loop.py
@@ -1,4 +1,4 @@
-from src.self_refactor import SelfRefactorEngine
+from ai_karen_engine.self_refactor import SelfRefactorEngine
 
 
 class DummyLLM:

--- a/tests/test_slm_pool.py
+++ b/tests/test_slm_pool.py
@@ -1,5 +1,5 @@
-from src.ai_karen_engine.clients.slm_pool import SLMPool
-from src.integrations.llm_utils import LLMUtils
+from ai_karen_engine.clients.slm_pool import SLMPool
+from ai_karen_engine.integrations.llm_utils import LLMUtils
 
 
 def test_slm_pool_register_and_get():

--- a/tests/test_soft_reasoning.py
+++ b/tests/test_soft_reasoning.py
@@ -7,7 +7,7 @@ import asyncio
 
  
  
-from src.core.soft_reasoning_engine import SoftReasoningEngine
+from ai_karen_engine.core.soft_reasoning_engine import SoftReasoningEngine
 
 
 def test_ingest_and_query():

--- a/tests/test_sre_scheduler.py
+++ b/tests/test_sre_scheduler.py
@@ -1,6 +1,6 @@
 import os
 
-from src.self_refactor import SREScheduler, SelfRefactorEngine
+from ai_karen_engine.self_refactor import SREScheduler, SelfRefactorEngine
 
 
 class DummyEngine(SelfRefactorEngine):

--- a/tests/test_tokenizer_manager.py
+++ b/tests/test_tokenizer_manager.py
@@ -1,4 +1,4 @@
-from src.ai_karen_engine.core.tokenizer_manager import TokenizerManager
+from ai_karen_engine.core.tokenizer_manager import TokenizerManager
 
 
 def test_byte_encoding():

--- a/tests/ui/test_chat_hub.py
+++ b/tests/ui/test_chat_hub.py
@@ -1,6 +1,6 @@
 import asyncio
 
-from src.ui.chat_hub import ChatHub, SlashCommand, NeuroVault
+from ai_karen_engine.ui.chat_hub import ChatHub, SlashCommand, NeuroVault
 
 
 class DummyRouter:

--- a/ui/admin_ui/pages/mesh_panel.py
+++ b/ui/admin_ui/pages/mesh_panel.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from .. import tauri
+from ai_karen_engine import tauri
 
 
 def render(events: list[dict]) -> str:

--- a/ui/mobile_ui/config/config_manager.py
+++ b/ui/mobile_ui/config/config_manager.py
@@ -1,7 +1,7 @@
 # ui/mobile_ui/config/config_manager.py
 import os
 import json
-from .config_ui import ConfigUI
+from ai_karen_engine.ui.mobile_ui.config.config_ui import ConfigUI
 
 config = ConfigUI.load_from_env()
 class ConfigManager:

--- a/ui/mobile_ui/mobile_components/__init__.py
+++ b/ui/mobile_ui/mobile_components/__init__.py
@@ -1,10 +1,18 @@
-from .sidebar import render_sidebar
-from .chat import render_chat
-from .settings import render_settings
-from .memory import render_memory, memory_config
-from .models import render_models, select_model
-from .provider_selector import select_provider
-from .diagnostics import Diagnostics
+from ai_karen_engine.ui.mobile_ui.mobile_components.sidebar import render_sidebar
+from ai_karen_engine.ui.mobile_ui.mobile_components.chat import render_chat
+from ai_karen_engine.ui.mobile_ui.mobile_components.settings import render_settings
+from ai_karen_engine.ui.mobile_ui.mobile_components.memory import (
+    render_memory,
+    memory_config,
+)
+from ai_karen_engine.ui.mobile_ui.mobile_components.models import (
+    render_models,
+    select_model,
+)
+from ai_karen_engine.ui.mobile_ui.mobile_components.provider_selector import (
+    select_provider,
+)
+from ai_karen_engine.ui.mobile_ui.mobile_components.diagnostics import Diagnostics
 
 __all__ = [
     "render_sidebar",

--- a/ui/mobile_ui/mobile_components/configuration.py
+++ b/ui/mobile_ui/mobile_components/configuration.py
@@ -1,7 +1,9 @@
 import streamlit as st
-from .provider_selector import select_provider
-from .models import select_model
-from .memory import memory_config
+from ai_karen_engine.ui.mobile_ui.mobile_components.provider_selector import (
+    select_provider,
+)
+from ai_karen_engine.ui.mobile_ui.mobile_components.models import select_model
+from ai_karen_engine.ui.mobile_ui.mobile_components.memory import memory_config
 from utils.api_client import persist_config
 
 

--- a/ui/mobile_ui/mobile_components/provider.py
+++ b/ui/mobile_ui/mobile_components/provider.py
@@ -32,7 +32,7 @@ class ProviderManager:
         """Fetch providers with caching and error handling"""
         try:
             time.sleep(0.2)
-            from src.integrations.llm_registry import registry as llm_registry
+            from ai_karen_engine.integrations.llm_registry import registry as llm_registry
             providers = list(llm_registry.list_models())
             if not providers:
                 raise ValueError("No providers available in registry")

--- a/ui/mobile_ui/mobile_components/provider_selector.py
+++ b/ui/mobile_ui/mobile_components/provider_selector.py
@@ -1,7 +1,7 @@
 import streamlit as st
 import logging
 
-from src.integrations.llm_registry import registry as llm_registry  # This import will now work
+from ai_karen_engine.integrations.llm_registry import registry as llm_registry  # This import will now work
 
 def _providers() -> list[str]:
     return list(llm_registry.list_models())

--- a/ui/mobile_ui/services/config_manager.py
+++ b/ui/mobile_ui/services/config_manager.py
@@ -2,7 +2,7 @@ import json
 from pathlib import Path
 import duckdb
 
-from .vault import store_secret, load_secret
+from ai_karen_engine.ui.mobile_ui.services.vault import store_secret, load_secret
 
 BASE_DIR = Path(__file__).resolve().parent.parent
 DB_PATH = BASE_DIR / "data" / "config.duckdb"

--- a/ui/mobile_ui/services/health_checker.py
+++ b/ui/mobile_ui/services/health_checker.py
@@ -7,9 +7,9 @@ import logging
 import os
 from pathlib import Path
 
-from src.integrations.llm_registry import registry as llm_registry
-from .memory_controller import MEM_DB
-from .vault import VAULT_DB
+from ai_karen_engine.integrations.llm_registry import registry as llm_registry
+from ai_karen_engine.ui.mobile_ui.services.memory_controller import MEM_DB
+from ai_karen_engine.ui.mobile_ui.services.vault import VAULT_DB
 
 logger = logging.getLogger(__name__)
 

--- a/ui/mobile_ui/services/runtime_dispatcher.py
+++ b/ui/mobile_ui/services/runtime_dispatcher.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 
-import os, sys
+import os
 from pathlib import Path
 from typing import Callable, Dict, Any
 
 import requests
 from prometheus_client import Histogram
-sys.path.append(str(Path(__file__).resolve().parent.parent))
-from src.services.ollama_inprocess import generate as local_generate
+from ai_karen_engine.services.ollama_inprocess import generate as local_generate
 
 try:  # pragma: no cover - optional dep
     import onnxruntime as ort  # type: ignore
@@ -26,7 +25,7 @@ def run_llama_model(meta: dict, prompt: str) -> str:
 
 def run_hf_model(meta: dict, prompt: str) -> str:
     """Use HuggingFace transformers with automatic download."""
-    from src.integrations.llm_utils import LLMUtils
+    from ai_karen_engine.integrations.llm_utils import LLMUtils
 
     model_name = meta.get("model_name", "distilbert-base-uncased")
     llm = LLMUtils(model_name)


### PR DESCRIPTION
## Summary
- route imports through the `ai_karen_engine` namespace
- alias legacy packages in `ai_karen_engine.__init__`
- update UI and plugin modules to use absolute imports
- fix tests to avoid modifying `sys.path`

## Testing
- `PYTHONPATH=src pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6866c301d09483248bcd6ad8e1e96b19