### PR TITLE
Fix LLM selection in ICE wrapper

### DIFF
--- a/src/core/reasoning/ice_integration.py
+++ b/src/core/reasoning/ice_integration.py
@@ -26,7 +26,10 @@ class KariICEWrapper:
         self.engine = SoftReasoningEngine()
         self.threshold = threshold
  
-        self.llm = llm or llm_registry.get_active() or LLMUtils()
+        if llm is not None:
+            self.llm = llm
+        else:
+            self.llm = llm_registry.get_active() or LLMUtils()
  
 
     def process(self, text: str) -> Dict[str, Any]:


### PR DESCRIPTION
## Summary
- ensure `KariICEWrapper` chooses one LLM source
- pick the provided argument if given; otherwise fall back to the registry or new instance

## Testing
- `pytest tests/test_ice_integration.py::test_process_returns_keys -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866c8d5538483249d744609a497ca64