### PR TITLE
Refactor tests to use package imports

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,2 @@
-import os
-import sys
+"""Shared pytest configuration (currently empty)."""
 
-BASE_DIR = os.path.dirname(os.path.dirname(__file__))
-if BASE_DIR not in sys.path:
-    sys.path.insert(0, BASE_DIR)
-
-SRC_DIR = os.path.join(BASE_DIR, "src")
-if SRC_DIR not in sys.path:
-    sys.path.insert(0, SRC_DIR)

--- a/tests/test_embedding_client.py
+++ b/tests/test_embedding_client.py
@@ -1,4 +1,4 @@
-from src.ai_karen_engine.clients.embedding.embedding_client import get_embedding
+from ai_karen_engine.clients.embedding.embedding_client import get_embedding
 
 
 def test_get_embedding_byte_and_default():

--- a/tests/test_llm_orchestrator.py
+++ b/tests/test_llm_orchestrator.py
@@ -1,4 +1,4 @@
-from src.ai_karen_engine import SLMPool, LLMOrchestrator
+from ai_karen_engine import SLMPool, LLMOrchestrator
 from src.integrations.llm_utils import LLMUtils
 
 

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,15 +1,12 @@
 import importlib
 import json
 import os
-import sys
 import inspect
+from pathlib import Path
 from types import ModuleType
+import sys
 
-BASE_DIR = os.path.dirname(os.path.dirname(__file__))
-PLUGIN_DIR = os.path.join(BASE_DIR, 'src', 'plugins')
-
-if BASE_DIR not in sys.path:
-    sys.path.insert(0, BASE_DIR)
+PLUGIN_DIR = Path(__file__).resolve().parents[1] / "src" / "plugins"
 
 
 def ensure_optional_dependency(name: str):

--- a/tests/test_slm_pool.py
+++ b/tests/test_slm_pool.py
@@ -1,4 +1,4 @@
-from src.ai_karen_engine.clients.slm_pool import SLMPool
+from ai_karen_engine.clients.slm_pool import SLMPool
 from src.integrations.llm_utils import LLMUtils
 
 

--- a/tests/test_tokenizer_manager.py
+++ b/tests/test_tokenizer_manager.py
@@ -1,4 +1,4 @@
-from src.ai_karen_engine.core.tokenizer_manager import TokenizerManager
+from ai_karen_engine.core.tokenizer_manager import TokenizerManager
 
 
 def test_byte_encoding():


### PR DESCRIPTION
## Summary
- drop path manipulation from `tests/conftest.py` and `tests/test_plugins.py`
- import modules using the `ai_karen_engine` package namespace
- update plugin test to resolve plugin directory via `Path`

## Testing
- `env PYTHONPATH=src python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866c880d24c83248d1a7e3ac2ffd038