### PR TITLE
Remove sys.path hacks in mobile UI

### DIFF
--- a/src/ai_karen_engine/integrations/__init__.py
+++ b/src/ai_karen_engine/integrations/__init__.py
@@ -1,0 +1,1 @@
+"""Integration helpers for Kari AI (compatibility wrappers)."""

--- a/src/ai_karen_engine/integrations/llm_utils.py
+++ b/src/ai_karen_engine/integrations/llm_utils.py
@@ -1,0 +1,1 @@
+from src.integrations.llm_utils import *  # re-export

--- a/src/ai_karen_engine/services/__init__.py
+++ b/src/ai_karen_engine/services/__init__.py
@@ -1,0 +1,8 @@
+"""Service utilities for Kari AI (compatibility wrappers)."""
+
+from . import ollama_inprocess, deepseek_client
+
+__all__ = [
+    "ollama_inprocess",
+    "deepseek_client",
+]

--- a/src/ai_karen_engine/services/deepseek_client.py
+++ b/src/ai_karen_engine/services/deepseek_client.py
@@ -1,0 +1,1 @@
+from src.services.deepseek_client import *  # re-export

--- a/src/ai_karen_engine/services/ollama_inprocess.py
+++ b/src/ai_karen_engine/services/ollama_inprocess.py
@@ -1,0 +1,1 @@
+from src.services.ollama_inprocess import *  # re-export

--- a/ui/mobile_ui/app.py
+++ b/ui/mobile_ui/app.py
@@ -1,25 +1,12 @@
 #!/usr/bin/env python3
-import sys
 import pathlib
-
-# ==== PATH PATCHING FOR IMPORTS ====
-CURRENT_FILE = pathlib.Path(__file__).resolve()
-PROJECT_ROOT = CURRENT_FILE.parents[2]  # AI-Karen root
-SRC_PATH = PROJECT_ROOT / "src"
-MOBILE_UI_PATH = PROJECT_ROOT / "ui" / "mobile_ui"
-
-if str(SRC_PATH) not in sys.path:
-    sys.path.insert(0, str(SRC_PATH))
-
-if str(MOBILE_UI_PATH) not in sys.path:
-    sys.path.insert(0, str(MOBILE_UI_PATH))
 
 # ========== STANDARD IMPORTS ==========
 import streamlit as st
-from mobile_components.sidebar import render_sidebar
-from mobile_components.provider_selector import select_provider
-from config.config_manager import ConfigManager
-from utils.model_loader import ensure_spacy_models, ensure_sklearn_installed
+from .mobile_components.sidebar import render_sidebar
+from .mobile_components.provider_selector import select_provider
+from .config.config_manager import ConfigManager
+from .utils.model_loader import ensure_spacy_models, ensure_sklearn_installed
 
 # ========== STYLING ==========
 def load_styles():
@@ -46,10 +33,10 @@ def main():
 
     selection = render_sidebar()
     if selection == "Chat":
-        import pages.chat as chat_page
+        from .pages import chat as chat_page
         chat_page.render_chat()
     elif selection == "Settings":
-        import pages.settings as settings_page
+        from .pages import settings as settings_page
         settings_page.render_settings()
     else:
         st.error(f"Unknown page: {selection}")

--- a/ui/mobile_ui/services/runtime_dispatcher.py
+++ b/ui/mobile_ui/services/runtime_dispatcher.py
@@ -1,13 +1,11 @@
 from __future__ import annotations
 
-import os, sys
-from pathlib import Path
+import os
 from typing import Callable, Dict, Any
 
 import requests
 from prometheus_client import Histogram
-sys.path.append(str(Path(__file__).resolve().parent.parent))
-from src.services.ollama_inprocess import generate as local_generate
+from ai_karen_engine.services.ollama_inprocess import generate as local_generate
 
 try:  # pragma: no cover - optional dep
     import onnxruntime as ort  # type: ignore
@@ -26,7 +24,7 @@ def run_llama_model(meta: dict, prompt: str) -> str:
 
 def run_hf_model(meta: dict, prompt: str) -> str:
     """Use HuggingFace transformers with automatic download."""
-    from src.integrations.llm_utils import LLMUtils
+    from ai_karen_engine.integrations.llm_utils import LLMUtils
 
     model_name = meta.get("model_name", "distilbert-base-uncased")
     llm = LLMUtils(model_name)


### PR DESCRIPTION
## Summary
- drop `sys.path` patching in mobile_ui app and runtime dispatcher
- import mobile UI components using package-relative paths
- expose services and integrations under `ai_karen_engine` for clean imports

## Testing
- `pytest -q`
- `python -m ui.mobile_ui.app --help` *(fails: No module named 'streamlit')*

------
https://chatgpt.com/codex/tasks/task_e_6866c86e01008324a9fafeb98fe44872