### PR TITLE
Update main imports and add ai_karen_engine wrappers

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,10 +2,9 @@ from typing import Any, Dict, List
 from pathlib import Path
 import sys
 import os
-from src.core.cortex.dispatch import CortexDispatcher
-from src.core.embedding_manager import _METRICS as METRICS
-from src.core.soft_reasoning_engine import SoftReasoningEngine
-
+from ai_karen_engine.core.cortex.dispatch import CortexDispatcher
+from ai_karen_engine.core.embedding_manager import _METRICS as METRICS
+from ai_karen_engine.core.soft_reasoning_engine import SoftReasoningEngine
 if (Path(__file__).resolve().parent / "fastapi").is_dir():
     sys.stderr.write(
         "Error: A local 'fastapi' directory exists. It shadows the installed FastAPI package.\n"
@@ -17,7 +16,7 @@ try:
     from fastapi.responses import JSONResponse, Response
 except Exception:  # fastapi_stub compatibility
     from fastapi.responses import JSONResponse
-    from src.fastapi_stub import Response
+    from ai_karen_engine.fastapi_stub import Response
 try:
     from prometheus_client import (
         Counter,
@@ -49,12 +48,12 @@ except Exception:  # pragma: no cover - fallback when package is missing
 
     CONTENT_TYPE_LATEST = "text/plain"
     Counter = Histogram = _DummyMetric
-from src.self_refactor import SelfRefactorEngine, SREScheduler
+from ai_karen_engine.self_refactor import SelfRefactorEngine, SREScheduler
 from pydantic import BaseModel
 import asyncio
 import logging
-from src.integrations.llm_registry import registry as llm_registry
-from src.integrations.model_discovery import sync_registry
+from ai_karen_engine.integrations.llm_registry import registry as llm_registry
+from ai_karen_engine.integrations.model_discovery import sync_registry
 
 app = FastAPI()
 
@@ -279,7 +278,7 @@ def select_model(req: ModelSelectRequest) -> ModelListResponse:
 @app.get("/self_refactor/logs")
 def self_refactor_logs(full: bool = False):
     """Return SelfRefactor logs. Sanitized unless ADVANCED_MODE allows full."""
-    from src.self_refactor import log_utils
+    from ai_karen_engine.self_refactor import log_utils
 
     logs = log_utils.load_logs(full=full)
     return {"logs": logs}

--- a/src/ai_karen_engine/core/cortex/__init__.py
+++ b/src/ai_karen_engine/core/cortex/__init__.py
@@ -1,0 +1,3 @@
+from src.core.cortex.dispatch import CortexDispatcher
+
+__all__ = ["CortexDispatcher"]

--- a/src/ai_karen_engine/core/cortex/dispatch.py
+++ b/src/ai_karen_engine/core/cortex/dispatch.py
@@ -1,0 +1,1 @@
+from src.core.cortex.dispatch import *  # noqa: F401,F403

--- a/src/ai_karen_engine/core/embedding_manager.py
+++ b/src/ai_karen_engine/core/embedding_manager.py
@@ -1,0 +1,3 @@
+from src.core.embedding_manager import EmbeddingManager, record_metric, _METRICS
+
+__all__ = ["EmbeddingManager", "record_metric", "_METRICS"]

--- a/src/ai_karen_engine/core/soft_reasoning_engine.py
+++ b/src/ai_karen_engine/core/soft_reasoning_engine.py
@@ -1,0 +1,1 @@
+from src.core.soft_reasoning_engine import *  # noqa: F401,F403

--- a/src/ai_karen_engine/fastapi_stub/__init__.py
+++ b/src/ai_karen_engine/fastapi_stub/__init__.py
@@ -1,0 +1,3 @@
+from src.fastapi_stub import Response
+
+__all__ = ["Response"]

--- a/src/ai_karen_engine/integrations/__init__.py
+++ b/src/ai_karen_engine/integrations/__init__.py
@@ -1,0 +1,1 @@
+"""Integration adapters for AI Karen."""

--- a/src/ai_karen_engine/integrations/llm_registry.py
+++ b/src/ai_karen_engine/integrations/llm_registry.py
@@ -1,0 +1,1 @@
+from src.integrations.llm_registry import *  # noqa: F401,F403

--- a/src/ai_karen_engine/integrations/model_discovery.py
+++ b/src/ai_karen_engine/integrations/model_discovery.py
@@ -1,0 +1,1 @@
+from src.integrations.model_discovery import *  # noqa: F401,F403

--- a/src/ai_karen_engine/self_refactor/__init__.py
+++ b/src/ai_karen_engine/self_refactor/__init__.py
@@ -1,0 +1,3 @@
+from src.self_refactor import SelfRefactorEngine, PatchReport, SREScheduler
+
+__all__ = ["SelfRefactorEngine", "PatchReport", "SREScheduler"]

--- a/src/ai_karen_engine/self_refactor/log_utils.py
+++ b/src/ai_karen_engine/self_refactor/log_utils.py
@@ -1,0 +1,1 @@
+from src.self_refactor.log_utils import *  # noqa: F401,F403


### PR DESCRIPTION
## Summary
- remove obsolete imports from `main.py`
- use `ai_karen_engine.<module>` paths in `main.py`
- provide wrapper modules under `src/ai_karen_engine/` so imports resolve

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866c84893388324b0fc0ae1e0817c8a