### PR TITLE
Phase 1.2 Autonomous agent wrappers

### DIFF
--- a/capsules/devops/handler.py
+++ b/capsules/devops/handler.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 from typing import Any, Dict
 
-from src.core.plugin_router import PluginRouter
+from ai_karen_engine.plugin_router import PluginRouter
 
 router = PluginRouter()
 

--- a/cli.py
+++ b/cli.py
@@ -4,7 +4,7 @@ import sys
 from pathlib import Path
 
 from src.ai_karen_engine import LLMOrchestrator
-from src.core.plugin_router import PluginRouter
+from ai_karen_engine.plugin_router import PluginRouter
 
 
 CONFIG_PATH = Path("config") / "settings.json"

--- a/docs/automation_features.md
+++ b/docs/automation_features.md
@@ -47,3 +47,10 @@ Our production build uses a custom HTTP client to contact your n8n instance. The
 - **Basic usage** uses only the local AutomationManager and RPA client.
 - **Advanced usage** combines RPA tasks with external workflow triggers via n8n when enabled by the plugin manifest.
 
+## 4. Autonomous Agents
+
+The `autonomous_task_handler` plugin showcases a simple autonomous loop. The
+agent breaks a goal into steps with the local LLM, executes each subtask, and
+queues follow-up tasks through the Automation Manager. When a workflow slug is
+configured, results can be sent to n8n for additional processing.
+

--- a/docs/features_usage.md
+++ b/docs/features_usage.md
@@ -160,6 +160,12 @@ Setting `ADVANCED_MODE=true` unlocks unrestricted behavior:
 
 > 🔒 Use only in dev environments or trusted operator sessions.
 
+## 🦾 11. Autonomous Agents
+
+Kari includes a lightweight autonomous agent that decomposes a goal into
+subtasks and executes them via the `autonomous_task_handler` plugin. Results may
+trigger external workflows when permitted by the plugin manifest.
+
 ---
 
 ## 📚 Additional Docs

--- a/src/ai_karen_engine/core/autonomous_agent.py
+++ b/src/ai_karen_engine/core/autonomous_agent.py
@@ -1,0 +1,5 @@
+"""Autonomous agent loop wrapper."""
+
+from src.core.autonomous_agent import AutonomousAgent
+
+__all__ = ["AutonomousAgent"]

--- a/src/ai_karen_engine/core/intent_engine.py
+++ b/src/ai_karen_engine/core/intent_engine.py
@@ -1,0 +1,5 @@
+"""Intent detection wrapper for Kari."""
+
+from src.core.intent_engine import IntentEngine
+
+__all__ = ["IntentEngine"]

--- a/src/ai_karen_engine/plugin_router.py
+++ b/src/ai_karen_engine/plugin_router.py
@@ -1,0 +1,5 @@
+"""Plugin router wrapper for Kari."""
+
+from src.core.plugin_router import AccessDenied, PluginRouter, PLUGIN_DIR
+
+__all__ = ["AccessDenied", "PluginRouter", "PLUGIN_DIR"]

--- a/src/core/prompt_router.py
+++ b/src/core/prompt_router.py
@@ -1,5 +1,5 @@
 import asyncio
-from src.core.plugin_router import PluginRouter as BaseRouter
+from ai_karen_engine.plugin_router import PluginRouter as BaseRouter
 
 
 class PluginWrapper:

--- a/tests/test_autonomous_agent.py
+++ b/tests/test_autonomous_agent.py
@@ -1,0 +1,30 @@
+from ai_karen_engine.core.autonomous_agent import AutonomousAgent
+
+
+def test_autonomous_agent(monkeypatch):
+    agent = AutonomousAgent("u1")
+
+    responses = iter(["steps", "subtask"])
+    monkeypatch.setattr(agent.llm, "generate_text", lambda *_: next(responses))
+
+    class DummyPlugin:
+        manifest = {"enable_external_workflow": True, "workflow_slug": "slug"}
+
+        def run(self, _):
+            return {"message": "continue"}
+
+    monkeypatch.setattr(agent.prompt_router, "route", lambda _: DummyPlugin())
+
+    triggered = []
+    monkeypatch.setattr(agent.workflow_engine, "trigger", lambda slug, payload: triggered.append(slug))
+
+    tasks = []
+    monkeypatch.setattr(agent.automation_manager, "create_task", lambda **kw: tasks.append(kw))
+
+    monkeypatch.setattr("time.sleep", lambda *_: None)
+
+    agent.think_and_act("goal", max_iterations=1)
+
+    assert triggered == ["slug"]
+    assert tasks and tasks[0]["user_id"] == "u1"
+

--- a/tests/test_intent_engine.py
+++ b/tests/test_intent_engine.py
@@ -1,4 +1,4 @@
-from src.core.intent_engine import IntentEngine
+from ai_karen_engine.core.intent_engine import IntentEngine
 
 
 def test_detect_intent():

--- a/tests/test_plugin_router.py
+++ b/tests/test_plugin_router.py
@@ -4,7 +4,7 @@ import sys
 from types import ModuleType
 import pytest
 
-from src.core.plugin_router import AccessDenied, PluginRouter
+from ai_karen_engine.plugin_router import AccessDenied, PluginRouter
 
 
 def ensure_optional_dependency(name: str):


### PR DESCRIPTION
## Summary
- expose intent engine, plugin router and autonomous agent under `ai_karen_engine`
- update CLI and devops capsule imports
- document autonomous agent usage
- add unit test for AutonomousAgent

## Testing
- `PYTHONPATH=.:src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866d39d7e648324927ed6f0e271d742