### PR TITLE
Add workflow and RPA integration modules

### DIFF
--- a/ai_karen_engine/__init__.py
+++ b/ai_karen_engine/__init__.py
@@ -1,0 +1,14 @@
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+import sys
+
+src_path = Path(__file__).resolve().parent.parent / 'src' / 'ai_karen_engine'
+if src_path.exists():
+    spec = spec_from_file_location('src.ai_karen_engine', src_path / '__init__.py')
+    module = module_from_spec(spec)
+    sys.modules['src.ai_karen_engine'] = module
+    spec.loader.exec_module(module)
+    globals().update(module.__dict__)
+    __path__ = [str(src_path)]
+
+

--- a/docs/automation_features.md
+++ b/docs/automation_features.md
@@ -7,7 +7,7 @@ Kari ships with a **proprietary automation layer** for chaining tasks and local 
 Our `AutomationManager` orchestrates asynchronous tasks using a custom queue. Plugins can enqueue coroutines that interact with local scripts or trigger n8n workflows.
 
 ```python
-from src.core.automation_manager import AutomationManager
+from ai_karen_engine.integrations.automation_manager import AutomationManager
 
 auto = AutomationManager()
 auto.add_task(some_async_task())
@@ -19,7 +19,7 @@ results = await auto.run_all()
 The `LocalRPAClient` is Kari's locked‑down wrapper around **PyAutoGUI** for desktop automation. It can click, type, and take screenshots.
 
 ```python
-from src.integrations.local_rpa_client import LocalRPAClient
+from ai_karen_engine.integrations.local_rpa_client import LocalRPAClient
 
 rpa = LocalRPAClient()
 rpa.click(100, 200)
@@ -34,7 +34,7 @@ Use this only on trusted machines because it controls the local keyboard and mou
 The `WorkflowEngineClient` provides a proprietary bridge to n8n. Set `workflow_slug` in a plugin manifest and call `trigger()` with a payload.
 
 ```python
-from src.core.workflow_engine_client import WorkflowEngineClient
+from ai_karen_engine.core.workflow_engine_client import WorkflowEngineClient
 
 wf = WorkflowEngineClient()
 wf.trigger("onboarding", {"user_id": 123})

--- a/docs/n8n_integration.md
+++ b/docs/n8n_integration.md
@@ -15,7 +15,7 @@ Kari includes a proprietary bridge to n8n for orchestrating external workflows. 
 3. In your plugin code, call `WorkflowEngineClient.trigger()` with the desired slug and payload.
 
 ```python
-from src.core.workflow_engine_client import WorkflowEngineClient
+from ai_karen_engine.core.workflow_engine_client import WorkflowEngineClient
 
 wf = WorkflowEngineClient()
 wf.trigger("support_ticket", {"issue": "printer jam"})

--- a/src/ai_karen_engine/core/__init__.py
+++ b/src/ai_karen_engine/core/__init__.py
@@ -1,1 +1,5 @@
 """Core utilities for AI Karen engine."""
+
+from .workflow_engine_client import WorkflowEngineClient
+
+__all__ = ["WorkflowEngineClient"]

--- a/src/ai_karen_engine/core/workflow_engine_client.py
+++ b/src/ai_karen_engine/core/workflow_engine_client.py
@@ -1,0 +1,7 @@
+class WorkflowEngineClient:
+    """Simple stub for triggering n8n workflows."""
+
+    def trigger(self, workflow_slug: str, payload: dict) -> None:
+        """Trigger the workflow identified by ``workflow_slug`` with ``payload``."""
+        print(f"[WorkflowEngine] Triggered {workflow_slug} with {payload}")
+

--- a/src/ai_karen_engine/integrations/__init__.py
+++ b/src/ai_karen_engine/integrations/__init__.py
@@ -1,1 +1,6 @@
 """Integration helpers for Kari AI (compatibility wrappers)."""
+
+from .automation_manager import AutomationManager
+from .local_rpa_client import LocalRPAClient
+
+__all__ = ["AutomationManager", "LocalRPAClient"]

--- a/src/ai_karen_engine/integrations/automation_manager.py
+++ b/src/ai_karen_engine/integrations/automation_manager.py
@@ -1,0 +1,21 @@
+from typing import Awaitable, List
+
+
+class AutomationManager:
+    """Simple scheduler for asynchronous automation tasks."""
+
+    def __init__(self) -> None:
+        self.queue: List[Awaitable] = []
+
+    def add_task(self, coro: Awaitable) -> None:
+        """Add a coroutine to the queue."""
+        self.queue.append(coro)
+
+    async def run_all(self) -> list:
+        """Run all queued tasks sequentially and return their results."""
+        results = []
+        for task in self.queue:
+            results.append(await task)
+        self.queue.clear()
+        return results
+

--- a/src/ai_karen_engine/integrations/local_rpa_client.py
+++ b/src/ai_karen_engine/integrations/local_rpa_client.py
@@ -1,0 +1,16 @@
+import pyautogui
+
+
+class LocalRPAClient:
+    """Thin wrapper around PyAutoGUI for local RPA tasks."""
+
+    def click(self, x: int, y: int) -> None:
+        pyautogui.click(x, y)
+
+    def type_text(self, text: str) -> None:
+        pyautogui.typewrite(text)
+
+    def screenshot(self, path: str = "screenshot.png") -> str:
+        pyautogui.screenshot(path)
+        return path
+

--- a/tests/test_workflow_rpa.py
+++ b/tests/test_workflow_rpa.py
@@ -1,0 +1,52 @@
+import sys
+from pathlib import Path
+from types import ModuleType
+import asyncio
+
+dummy = ModuleType("pyautogui")
+dummy.click = lambda *args, **kwargs: None
+dummy.typewrite = lambda *args, **kwargs: None
+dummy.screenshot = lambda path="screenshot.png": path
+sys.modules.setdefault("pyautogui", dummy)
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from ai_karen_engine.core.workflow_engine_client import WorkflowEngineClient
+from ai_karen_engine.integrations.automation_manager import AutomationManager
+from ai_karen_engine.integrations.local_rpa_client import LocalRPAClient
+from src.core.plugin_router import PluginRouter
+
+
+def test_workflow_engine_trigger(capfd):
+    wf = WorkflowEngineClient()
+    wf.trigger("test_flow", {"ok": True})
+    captured = capfd.readouterr()
+    assert "test_flow" in captured.out
+
+
+def test_automation_manager_run_all():
+    mgr = AutomationManager()
+
+    async def sample():
+        return "done"
+
+    mgr.add_task(sample())
+    results = asyncio.run(mgr.run_all())
+    assert results == ["done"]
+
+
+def test_local_rpa_client():
+    rpa = LocalRPAClient()
+    assert rpa.click(1, 2) is None
+    assert rpa.type_text("hi") is None
+    assert rpa.screenshot("foo.png") == "foo.png"
+
+
+def test_manifest_workflow_slug():
+    router = PluginRouter()
+    plugin = router.get_plugin("autonomous_task_handler")
+    assert plugin.manifest.get("workflow_slug") == "autonomous_task_followup"
+
+


### PR DESCRIPTION
## Summary
- add workflow engine client to `ai_karen_engine.core`
- add automation manager and local RPA client integrations
- document new paths in workflow and automation docs
- add compatibility package so `ai_karen_engine` imports work
- test workflow/RPA functionality

## Testing
- `pre-commit` *(fails: command not found)*
- `pytest -q tests/test_workflow_rpa.py`

------
https://chatgpt.com/codex/tasks/task_e_6866d46826488324b81050096892637f