### PR TITLE
Enforce UI import rules via Ruff

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,12 @@ Pre-commit hooks run these checks automatically. After cloning run:
 ```bash
 pre-commit install
 ```
+Ruff also enforces the UI boundaries described in `AGENTS.md`:
+
+* relative imports are forbidden inside `ui/`
+* modules under `src/ui/` may not import from the top-level `ui` package
+
+See `pyproject.toml` for the full configuration.
 ### Advanced / Unrestricted Mode
 
 Set `ADVANCED_MODE=true` to enable full SelfRefactor logs and allow plugin UIs marked as untrusted. Use with caution.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,16 @@
+[tool.ruff]
+line-length = 100
+
+[tool.ruff.lint]
+extend-select = ["TID252", "TID251"]
+
+[tool.ruff.lint.per-file-ignores]
+"src/**/*.py" = ["TID252"]
+"ui/**/*.py" = ["TID251"]
+"tests/**/*.py" = ["TID251"]
+
+[tool.ruff.lint.flake8-tidy-imports]
+ban-relative-imports = "all"
+
+[tool.ruff.lint.flake8-tidy-imports.banned-api]
+"ui" = { msg = "src/ui must not import from the /ui package" }


### PR DESCRIPTION
## Summary
- add a `pyproject.toml` with Ruff settings
- document UI lint rules in the README

## Testing
- `ruff check ui/mobile_ui/config/config_manager.py --config=pyproject.toml | head -n 20`
- `ruff check src/ui/test_import.py --config=pyproject.toml` *(after creating a temporary file)*

------
https://chatgpt.com/codex/tasks/task_e_6866ea07c6608324b7c3dcc267d7ac0d