### PR TITLE
Add persona controls and UI blueprint

### DIFF
--- a/docs/ui_blueprint.md
+++ b/docs/ui_blueprint.md
@@ -1,0 +1,36 @@
+# Kari UI/UX Blueprint
+
+This document outlines the high level design goals for the Kari user interface. It is intended as a living reference for future development.
+
+## Conversational Intelligence
+- Persistent multi-turn chat with markdown rendering and file previews.
+- Context panel showing what Kari remembers in the current session.
+- Controls to change persona, tone, language and emotional style on the fly.
+- Guardrails and transparency indicators.
+
+## Multi-Modal Interactions
+- Voice input and TTS output using local providers when available.
+- Drag and drop file uploads with OCR and table parsing.
+- Quick summaries and task extraction from documents.
+
+## Plugin and Automation Ecosystem
+- Plugin store UI for browsing and managing extensions.
+- Workflow builder with drag and drop triggers and actions.
+- Visualisation of running tasks and agent chat.
+
+## Memory and Knowledge Graph
+- Session memory explorer with timeline view.
+- Editable profile panel for strengths and interests.
+- Graph view showing relations between entities.
+
+## Model and Provider Management
+- Switch between LLM backends with usage stats and benchmarking.
+- Credential vault with secure storage and rotation UI.
+- Fallback analytics showing token usage and cost.
+
+## Privacy and Security
+- All on-device data stores encrypted by default.
+- Transparency log of what Kari has stored with delete/export options.
+- Consent flows for personal profiling and EchoCore learning.
+
+This blueprint acts as a guideline for building a modular, user focused interface. Features should remain configurable through feature flags and developed as independent components under the `ui/` directory.

--- a/ui/mobile_ui/mobile_components/persona_controls.py
+++ b/ui/mobile_ui/mobile_components/persona_controls.py
@@ -1,0 +1,52 @@
+import streamlit as st
+
+DEFAULT_PERSONA = "default"
+DEFAULT_TONE = "neutral"
+DEFAULT_LANGUAGE = "en"
+DEFAULT_EMOTION = "neutral"
+
+PERSONA_OPTIONS = ["default", "coach", "developer", "friend", "admin"]
+TONE_OPTIONS = ["neutral", "friendly", "professional", "playful"]
+LANG_OPTIONS = ["en", "es", "fr", "de"]
+EMOTION_OPTIONS = ["neutral", "happy", "sad", "angry"]
+
+
+def render_persona_controls() -> None:
+    """Render dynamic persona and tone controls."""
+    st.sidebar.subheader("\U0001F464 Persona")
+    persona = st.sidebar.selectbox(
+        "Persona",
+        PERSONA_OPTIONS,
+        index=PERSONA_OPTIONS.index(st.session_state.get("persona", DEFAULT_PERSONA)),
+        key="persona_select",
+    )
+    tone = st.sidebar.selectbox(
+        "Tone",
+        TONE_OPTIONS,
+        index=TONE_OPTIONS.index(st.session_state.get("tone", DEFAULT_TONE)),
+        key="tone_select",
+    )
+    language = st.sidebar.selectbox(
+        "Language",
+        LANG_OPTIONS,
+        index=LANG_OPTIONS.index(st.session_state.get("language", DEFAULT_LANGUAGE)),
+        key="lang_select",
+    )
+    emotion = st.sidebar.selectbox(
+        "Emotion",
+        EMOTION_OPTIONS,
+        index=EMOTION_OPTIONS.index(st.session_state.get("emotion", DEFAULT_EMOTION)),
+        key="emotion_select",
+    )
+    if st.sidebar.button("Apply Style", key="apply_style"):
+        st.session_state.update(
+            persona=persona, tone=tone, language=language, emotion=emotion
+        )
+        try:
+            from ui.mobile_ui.services.config_manager import update_config
+            update_config(
+                persona=persona, tone=tone, language=language, emotion=emotion
+            )
+            st.sidebar.success("Style updated")
+        except Exception:
+            st.sidebar.warning("Could not persist style settings")

--- a/ui/mobile_ui/mobile_components/provider.py
+++ b/ui/mobile_ui/mobile_components/provider.py
@@ -32,7 +32,7 @@ class ProviderManager:
         """Fetch providers with caching and error handling"""
         try:
             time.sleep(0.2)
-            from src.integrations.llm_registry import registry as llm_registry
+            from ai_karen_engine.integrations.llm_registry import registry as llm_registry
             providers = list(llm_registry.list_models())
             if not providers:
                 raise ValueError("No providers available in registry")

--- a/ui/mobile_ui/mobile_components/provider_selector.py
+++ b/ui/mobile_ui/mobile_components/provider_selector.py
@@ -1,7 +1,7 @@
 import streamlit as st
 import logging
 
-from src.integrations.llm_registry import registry as llm_registry  # This import will now work
+from ai_karen_engine.integrations.llm_registry import registry as llm_registry
 
 def _providers() -> list[str]:
     return list(llm_registry.list_models())

--- a/ui/mobile_ui/mobile_components/settings.py
+++ b/ui/mobile_ui/mobile_components/settings.py
@@ -74,6 +74,23 @@ def render_settings():
     decay = st.slider("Memory Decay", 0.0, 1.0, value=config.get("decay", 0.1))
 
     persona = st.text_input("Persona", value=config.get("persona", "default"))
+    tone = st.selectbox(
+        "Tone",
+        ["neutral", "friendly", "professional", "playful"],
+        index=["neutral", "friendly", "professional", "playful"].index(
+            config.get("tone", "neutral")
+        ),
+    )
+    language = st.selectbox(
+        "Language",
+        ["en", "es", "fr", "de"],
+        index=["en", "es", "fr", "de"].index(config.get("language", "en")),
+    )
+    emotion = st.selectbox(
+        "Emotion",
+        ["neutral", "happy", "sad", "angry"],
+        index=["neutral", "happy", "sad", "angry"].index(config.get("emotion", "neutral")),
+    )
 
     prov_conf = get_provider_config(provider)
     if st.button("\U0001F4BE Save Configuration"):
@@ -85,5 +102,8 @@ def render_settings():
             "context_length": context_len,
             "decay": decay,
             "persona": persona,
+            "tone": tone,
+            "language": language,
+            "emotion": emotion,
         })
         st.success("Settings saved.")

--- a/ui/mobile_ui/pages/chat.py
+++ b/ui/mobile_ui/pages/chat.py
@@ -20,6 +20,9 @@ import streamlit as st
 from concurrent.futures import ThreadPoolExecutor
 import traceback
 
+from ui.mobile_ui.mobile_components.persona_controls import render_persona_controls
+from ui.mobile_ui.services.config_manager import load_config
+
 logging.basicConfig(
     level=logging.INFO,
     format='%(asctime)s [%(levelname)s] %(message)s',
@@ -79,6 +82,18 @@ class ChatUI:
             st.session_state.chat_history = []
         if "model_info" not in st.session_state:
             st.session_state.model_info = {}
+        defaults = {
+            "persona": "default",
+            "tone": "neutral",
+            "language": "en",
+            "emotion": "neutral",
+        }
+        try:
+            cfg = load_config()
+        except Exception:
+            cfg = {}
+        for k, v in defaults.items():
+            st.session_state.setdefault(k, cfg.get(k, v))
 
     @staticmethod
     def render_model_selector(models: List[str], current_model: str) -> Optional[str]:
@@ -181,6 +196,7 @@ async def render_chat_page() -> None:
 
         ui.render_chat_history()
         ui.render_memory_controls()
+        render_persona_controls()
 
         prompt = st.chat_input("Message AI...")
         if prompt and chat_mgr._validate_input(prompt):

--- a/ui/mobile_ui/services/config_manager.py
+++ b/ui/mobile_ui/services/config_manager.py
@@ -31,7 +31,13 @@ def _init_db(con: duckdb.DuckDBPyConnection) -> None:
 def load_config() -> dict:
     """Return saved configuration with DeepSeek defaults."""
     if not DB_PATH.exists():
-        return {"provider": "deepseek"}
+        return {
+            "provider": "deepseek",
+            "persona": "default",
+            "tone": "neutral",
+            "language": "en",
+            "emotion": "neutral",
+        }
     con = _connect()
     _init_db(con)
     row = con.execute("SELECT data FROM settings WHERE id=1").fetchone()
@@ -39,10 +45,20 @@ def load_config() -> dict:
     if row:
         data = json.loads(row[0])
         data.setdefault("provider", "deepseek")
+        data.setdefault("persona", "default")
+        data.setdefault("tone", "neutral")
+        data.setdefault("language", "en")
+        data.setdefault("emotion", "neutral")
         if "api_key_ref" in data:
             data["api_key"] = load_secret(data["api_key_ref"]) or ""
         return data
-    return {"provider": "deepseek"}
+    return {
+        "provider": "deepseek",
+        "persona": "default",
+        "tone": "neutral",
+        "language": "en",
+        "emotion": "neutral",
+    }
 
 
 def save_config(config: dict) -> None:

--- a/ui/mobile_ui/services/health_checker.py
+++ b/ui/mobile_ui/services/health_checker.py
@@ -7,7 +7,7 @@ import logging
 import os
 from pathlib import Path
 
-from src.integrations.llm_registry import registry as llm_registry
+from ai_karen_engine.integrations.llm_registry import registry as llm_registry
 from ui.mobile_ui.services.memory_controller import MEM_DB
 from ui.mobile_ui.services.vault import VAULT_DB
 


### PR DESCRIPTION
## Summary
- document high-level UI goals
- default persona and tone settings in config manager
- expose persona, tone, language and emotion controls in settings
- add dynamic persona controls in chat interface
- fix legacy imports for llm registry

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866fe48f6b08324a9799b87159e7c87