### PR TITLE
Add UI blueprint link

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,8 @@ Updates are typically released once a month. See `ui/desktop_ui/README.md` for t
 
 Runs as a native Tauri app; all traffic stays on `localhost`.
 
+For a high-level overview of the planned user interface, see the [UI Blueprint](docs/ui_blueprint.md) which outlines conversational features, plugin management screens and memory visualization tools.
+
  
 Run the API with `uvicorn main:app` and start the Tauri Control Room for a
 full-featured desktop experience.


### PR DESCRIPTION
## Summary
- add link to UI Blueprint in Control Room docs section

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686702b94f8c832482bb1804c09c7e4d