### PR TITLE
Implement presence page with RBAC utilities

### DIFF
--- a/src/ui_logic/components/presence/__init__.py
+++ b/src/ui_logic/components/presence/__init__.py
@@ -1,0 +1,11 @@
+"""Presence components module."""
+
+from .session_table import get_active_sessions
+from .device_sync import sync_user_devices
+from .status_monitor import get_system_status
+
+__all__ = [
+    "get_active_sessions",
+    "sync_user_devices",
+    "get_system_status",
+]

--- a/src/ui_logic/components/presence/device_sync.py
+++ b/src/ui_logic/components/presence/device_sync.py
@@ -1,0 +1,9 @@
+"""Device synchronization utilities."""
+
+from typing import Dict
+
+
+def sync_user_devices(user_id: str) -> Dict[str, str]:
+    """Placeholder device sync for ``user_id``."""
+    # Normally interacts with device registry/service
+    return {"user": user_id, "synced": "ok"}

--- a/src/ui_logic/components/presence/session_table.py
+++ b/src/ui_logic/components/presence/session_table.py
@@ -1,0 +1,11 @@
+"""Logic for listing active user sessions."""
+
+from typing import List, Dict
+
+
+def get_active_sessions() -> List[Dict[str, str]]:
+    """Return a placeholder list of active sessions."""
+    # This would query the session store/service in a real system
+    return [
+        {"user": "demo", "status": "active"},
+    ]

--- a/src/ui_logic/components/presence/status_monitor.py
+++ b/src/ui_logic/components/presence/status_monitor.py
@@ -1,0 +1,9 @@
+"""System status monitor for presence tracking."""
+
+from typing import Dict
+
+
+def get_system_status() -> Dict[str, str]:
+    """Return a mock system status report."""
+    # This would aggregate health metrics in production
+    return {"status": "nominal"}

--- a/src/ui_logic/config/pages_manifest.py
+++ b/src/ui_logic/config/pages_manifest.py
@@ -4,5 +4,6 @@ PAGES = [
     {"key": "personas", "label": "Personas", "roles": ["user", "admin"], "flag": "core"},
     {"key": "autonomous", "label": "Autonomous Ops", "roles": ["admin", "devops"], "flag": "premium"},
     {"key": "automation", "label": "Automation", "roles": ["user", "admin"], "flag": "premium"},
+    {"key": "presence", "label": "Live Sessions", "roles": ["admin"], "flag": "premium"},
     # ...
 ]

--- a/src/ui_logic/pages/__init__.py
+++ b/src/ui_logic/pages/__init__.py
@@ -11,6 +11,7 @@ from .home import *
 from .iot import *
 from .memory import *
 from .plugins import *
+from .presence import *
 from .settings import *
 
 # Registry for dynamic UI routers
@@ -21,6 +22,7 @@ PAGES = {
     "home": "Home",
     "iot": "IoT & Devices",
     "memory": "Memory & Knowledge",
+    "presence": "Live Sessions",
     "plugins": "Plugins & Workflows",
     "settings": "Settings & Privacy",
 }

--- a/src/ui_logic/pages/presence.py
+++ b/src/ui_logic/pages/presence.py
@@ -1,0 +1,15 @@
+"""Presence page logic."""
+
+from typing import Dict
+
+from ui_logic.components.presence import get_active_sessions, get_system_status
+
+
+def get_live_sessions(user_ctx: Dict) -> Dict[str, list]:
+    """Return live session data if user has appropriate role."""
+    if "admin" not in user_ctx.get("roles", []):
+        raise PermissionError("Unauthorized.")
+    return {
+        "sessions": get_active_sessions(),
+        "status": get_system_status(),
+    }

--- a/ui/common/__init__.py
+++ b/ui/common/__init__.py
@@ -1,0 +1,1 @@
+"""Common UI utilities."""

--- a/ui/common/components/__init__.py
+++ b/ui/common/components/__init__.py
@@ -1,0 +1,3 @@
+from .rbac import has_role, require_role
+
+__all__ = ["has_role", "require_role"]

--- a/ui/common/components/rbac.py
+++ b/ui/common/components/rbac.py
@@ -1,0 +1,38 @@
+"""Simple RBAC utilities shared across UI layers."""
+
+try:
+    import streamlit as st
+except ModuleNotFoundError:  # pragma: no cover - fallback for non-UI environments
+    class _DummyStreamlit:
+        """Minimal stub for Streamlit when unavailable."""
+
+        def __init__(self) -> None:
+            self.session_state = {}
+
+        def error(self, *args, **kwargs) -> None:
+            """Placeholder for ``st.error`` used in tests."""
+            pass
+
+    st = _DummyStreamlit()
+
+from typing import Callable, Any
+
+
+def has_role(role: str) -> bool:
+    """Return ``True`` if current user has ``role``."""
+    return role in st.session_state.get("roles", [])
+
+
+def require_role(role: str) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """Decorator to gate page rendering by role."""
+
+    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            if not has_role(role):
+                st.error("Access denied")
+                return None
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator

--- a/ui_launchers/streamlit_ui/config/routing.py
+++ b/ui_launchers/streamlit_ui/config/routing.py
@@ -10,6 +10,7 @@ from ui_launchers.streamlit_ui.pages.iot import iot_page
 from ui_launchers.streamlit_ui.pages.memory import memory_page
 from ui_launchers.streamlit_ui.pages.admin import admin_page
 from ui_launchers.streamlit_ui.pages.settings import settings_page
+from ui_launchers.streamlit_ui.pages.presence import presence_page
 
 PAGE_MAP = {
     "Home": home_page,
@@ -18,6 +19,7 @@ PAGE_MAP = {
     "Plugins": plugins_page,
     "IoT": iot_page,
     "Memory": memory_page,
+    "Presence": presence_page,
     "Admin": admin_page,
     "Settings": settings_page,
 }

--- a/ui_launchers/streamlit_ui/pages/presence.py
+++ b/ui_launchers/streamlit_ui/pages/presence.py
@@ -1,0 +1,12 @@
+"""Streamlit wrapper for the presence page."""
+
+from ui_logic.pages.presence import get_live_sessions
+
+
+def presence_page(user_ctx=None):
+    data = get_live_sessions(user_ctx or {})
+    # In a real UI we would build tables/graphs here
+    import streamlit as st
+
+    st.header("Live Sessions")
+    st.write(data)


### PR DESCRIPTION
## Summary
- add presence components for session tracking
- integrate presence page and update page registry
- expose new presence route in Streamlit launcher
- provide shared RBAC utilities for UI code

## Testing
- `pytest -q` *(fails: KARI_MODEL_SIGNING_KEY must be set)*

------
https://chatgpt.com/codex/tasks/task_e_6867fec7f0f08324945c835b2dd0b485