### PR TITLE
Add Tauri launcher skeleton with plugin manager page

### DIFF
--- a/src/ui_logic/config/pages_manifest.py
+++ b/src/ui_logic/config/pages_manifest.py
@@ -5,5 +5,6 @@ PAGES = [
     {"key": "autonomous", "label": "Autonomous Ops", "roles": ["admin", "devops"], "flag": "premium"},
     {"key": "automation", "label": "Automation", "roles": ["user", "admin"], "flag": "premium"},
     {"key": "presence", "label": "Live Sessions", "roles": ["admin"], "flag": "premium"},
+    {"key": "plugin_manager", "label": "Plugin Manager", "roles": ["admin", "developer"], "flag": "enable_plugins"},
     # ...
 ]

--- a/src/ui_logic/pages/plugin_manager.py
+++ b/src/ui_logic/pages/plugin_manager.py
@@ -1,0 +1,31 @@
+"""
+Kari Tauri Plugin Manager Page
+- Role: manage plugins through Tauri UI
+- RBAC: admin or developer only
+- Feature Flag: enable_plugins
+"""
+
+from typing import Dict, Any
+import logging
+
+from src.ui_logic.config.feature_flags import get_flag
+from src.ui_logic.hooks.rbac import check_rbac
+
+
+def plugin_manager_page(user_ctx: Dict[str, Any], **_: Any) -> Dict[str, Any]:
+    """Handle Plugin Manager business logic for Tauri UI."""
+    if not get_flag("enable_plugins"):
+        raise PermissionError("Plugin management is disabled.")
+    if not check_rbac(user_ctx, ["admin", "developer"]):
+        raise PermissionError("Insufficient privileges for Plugin Manager.")
+    logging.info("Plugin Manager accessed by %s", user_ctx.get("user_id"))
+    raise NotImplementedError("Plugin Manager page is coming soon!")
+
+
+if __name__ == "__main__":
+    # Basic smoke test
+    demo_ctx = {"user_id": "zeus", "roles": ["admin", "developer"]}
+    try:
+        plugin_manager_page(demo_ctx)
+    except NotImplementedError:
+        print("Plugin Manager stub loaded correctly")

--- a/src/ui_logic/ui_core.py
+++ b/src/ui_logic/ui_core.py
@@ -1,0 +1,57 @@
+"""
+Kari UI Core Logic
+- Builds page manifests and dispatches page handlers
+- RBAC and feature flag guarded
+"""
+
+from typing import Any, Dict, Callable, List
+import logging
+
+from src.ui_logic.config.pages_manifest import PAGES
+from src.ui_logic.config.feature_flags import get_flag
+from src.ui_logic.hooks.rbac import check_rbac
+
+# --- Page Handler Registry ---
+from src.ui_logic.pages import plugin_manager as plugin_manager_page
+
+PAGE_HANDLERS: Dict[str, Callable[[Dict[str, Any]], Any]] = {
+    "plugin_manager": plugin_manager_page.plugin_manager_page,
+}
+
+
+def get_page_manifest(user_ctx: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Return manifest of pages accessible to the current user."""
+    manifest: List[Dict[str, Any]] = []
+    for entry in PAGES:
+        flag = entry.get("flag")
+        if flag and not get_flag(flag):
+            continue
+        if not check_rbac(user_ctx, entry.get("roles", [])):
+            continue
+        manifest.append(entry)
+    return manifest
+
+
+def dispatch_page(page_key: str, user_ctx: Dict[str, Any], **kwargs: Any) -> Any:
+    """Dispatch to the registered page handler after RBAC/flag checks."""
+    entry = next((p for p in PAGES if p["key"] == page_key), None)
+    if not entry:
+        raise KeyError(f"Page {page_key} not registered")
+    if entry.get("flag") and not get_flag(entry["flag"]):
+        raise PermissionError("Feature flag disabled for page")
+    if not check_rbac(user_ctx, entry.get("roles", [])):
+        raise PermissionError("Access denied for page")
+    handler = PAGE_HANDLERS.get(page_key)
+    if not handler:
+        raise NotImplementedError(f"Handler for {page_key} not implemented")
+    logging.info("Dispatching page %s for user %s", page_key, user_ctx.get("user_id"))
+    return handler(user_ctx=user_ctx, **kwargs)
+
+
+if __name__ == "__main__":
+    demo_ctx = {"user_id": "zeus", "roles": ["admin", "developer"]}
+    print(get_page_manifest(demo_ctx))
+    try:
+        dispatch_page("plugin_manager", demo_ctx)
+    except NotImplementedError:
+        print("Dispatch works: plugin manager not yet implemented")

--- a/ui_launchers/tauri_launcher/__init__.py
+++ b/ui_launchers/tauri_launcher/__init__.py
@@ -1,0 +1,1 @@
+"""Tauri launcher package."""

--- a/ui_launchers/tauri_launcher/app.py
+++ b/ui_launchers/tauri_launcher/app.py
@@ -1,0 +1,37 @@
+"""
+Kari Tauri Launcher Skeleton
+- Loads page manifest and dispatches pages using ui_core
+- Actual Tauri window spawning is delegated to the Rust project
+"""
+import logging
+import subprocess
+from pathlib import Path
+
+from src.ui_logic import ui_core
+from ui_launchers.tauri_launcher.helpers.session import get_user_context
+
+
+def main() -> None:
+    """Entry point for the Tauri desktop launcher."""
+    logging.basicConfig(level=logging.INFO)
+    user_ctx = get_user_context()
+    manifest = ui_core.get_page_manifest(user_ctx)
+    logging.info("Available pages: %s", [p["label"] for p in manifest])
+    if manifest:
+        try:
+            ui_core.dispatch_page(manifest[0]["key"], user_ctx)
+        except NotImplementedError:
+            logging.info("Page stub executed")
+    else:
+        logging.warning("No accessible pages for current user")
+
+    tauri_dir = Path(__file__).parent
+    if (tauri_dir / "src-tauri").exists():
+        try:
+            subprocess.run(["tauri", "dev"], cwd=tauri_dir, check=False)
+        except Exception as exc:
+            logging.error("Failed to start Tauri: %s", exc)
+
+
+if __name__ == "__main__":
+    main()

--- a/ui_launchers/tauri_launcher/helpers/__init__.py
+++ b/ui_launchers/tauri_launcher/helpers/__init__.py
@@ -1,0 +1,1 @@
+"""Tauri launcher helpers."""

--- a/ui_launchers/tauri_launcher/helpers/session.py
+++ b/ui_launchers/tauri_launcher/helpers/session.py
@@ -1,0 +1,13 @@
+"""User context provider for the Tauri launcher (demo)."""
+from typing import Dict, Any
+
+def get_user_context() -> Dict[str, Any]:
+    """Return demo user context. Replace with real auth integration."""
+    return {
+        "user_id": "zeus",
+        "name": "God Zeus",
+        "roles": ["admin", "developer", "user"],
+        "session_token": "dev-token",
+    }
+
+__all__ = ["get_user_context"]

--- a/ui_launchers/tauri_launcher/pages/__init__.py
+++ b/ui_launchers/tauri_launcher/pages/__init__.py
@@ -1,0 +1,1 @@
+"""Tauri launcher pages."""

--- a/ui_launchers/tauri_launcher/pages/plugin_manager.py
+++ b/ui_launchers/tauri_launcher/pages/plugin_manager.py
@@ -1,0 +1,5 @@
+from src.ui_logic.pages.plugin_manager import plugin_manager_page as _page
+
+
+def plugin_manager_page(user_ctx=None):
+    _page(user_ctx=user_ctx)


### PR DESCRIPTION
## Summary
- add a plugin manager page in `src/ui_logic` guarded by RBAC and feature flag
- update `pages_manifest` with `plugin_manager`
- implement minimal `ui_core` registry/dispatcher
- create `ui_launchers/tauri_launcher` skeleton with session helper and app stub

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jinja2')*

------
https://chatgpt.com/codex/tasks/task_e_6868039cb1c48324b55787c7b97708f9