### PR TITLE
Add RBAC page stubs

### DIFF
--- a/src/ui_logic/pages/automation.py
+++ b/src/ui_logic/pages/automation.py
@@ -1,0 +1,29 @@
+"""Automation dashboard stub with role and feature gating."""
+
+from ui.config.feature_flags import get_flag
+from ui.hooks.auth import get_current_user
+from ui.hooks.rbac import check_rbac
+
+REQUIRED_ROLES = ["user", "admin"]
+FEATURE_FLAG = "enable_workflows"
+
+
+def render_page(user_ctx: dict | None = None) -> None:
+    """Render the automation page.
+
+    Args:
+        user_ctx: Optional user context dictionary.
+
+    Raises:
+        PermissionError: If RBAC checks fail.
+        RuntimeError: If the feature is disabled.
+        NotImplementedError: Always, placeholder stub.
+    """
+
+    user = user_ctx or get_current_user()
+    if not check_rbac(user, REQUIRED_ROLES):
+        raise PermissionError("Access denied for Automation page")
+    if not get_flag(FEATURE_FLAG):
+        raise RuntimeError("Automation feature disabled")
+    raise NotImplementedError("Automation page not implemented")
+

--- a/src/ui_logic/pages/code_lab.py
+++ b/src/ui_logic/pages/code_lab.py
@@ -1,0 +1,29 @@
+"""In-browser code lab page stub for experimentation."""
+
+from ui.config.feature_flags import get_flag
+from ui.hooks.auth import get_current_user
+from ui.hooks.rbac import check_rbac
+
+REQUIRED_ROLES = ["dev", "admin"]
+FEATURE_FLAG = "show_experimental"
+
+
+def render_page(user_ctx: dict | None = None) -> None:
+    """Render the Code Lab page when experimental mode is enabled.
+
+    Args:
+        user_ctx: Optional user context dictionary.
+
+    Raises:
+        PermissionError: If RBAC checks fail.
+        RuntimeError: If experimental features are disabled.
+        NotImplementedError: Always raised as this page is a stub.
+    """
+
+    user = user_ctx or get_current_user()
+    if not check_rbac(user, REQUIRED_ROLES):
+        raise PermissionError("Code Lab access denied")
+    if not get_flag(FEATURE_FLAG):
+        raise RuntimeError("Code Lab feature disabled")
+    raise NotImplementedError("Code Lab page not implemented")
+

--- a/src/ui_logic/pages/context.py
+++ b/src/ui_logic/pages/context.py
@@ -1,0 +1,29 @@
+"""Session context explorer page stub."""
+
+from ui.config.feature_flags import get_flag
+from ui.hooks.auth import get_current_user
+from ui.hooks.rbac import check_rbac
+
+REQUIRED_ROLES = ["user", "admin"]
+FEATURE_FLAG = "enable_memory_graph"
+
+
+def render_page(user_ctx: dict | None = None) -> None:
+    """Render the Context page if memory graph is enabled.
+
+    Args:
+        user_ctx: Optional user context.
+
+    Raises:
+        PermissionError: If roles are insufficient.
+        RuntimeError: If the memory graph feature is disabled.
+        NotImplementedError: Always raised as this is a placeholder.
+    """
+
+    user = user_ctx or get_current_user()
+    if not check_rbac(user, REQUIRED_ROLES):
+        raise PermissionError("Context page access denied")
+    if not get_flag(FEATURE_FLAG):
+        raise RuntimeError("Memory graph disabled")
+    raise NotImplementedError("Context page not implemented")
+

--- a/src/ui_logic/pages/diagnostics.py
+++ b/src/ui_logic/pages/diagnostics.py
@@ -1,0 +1,29 @@
+"""System diagnostics and metrics page stub."""
+
+from ui.config.feature_flags import get_flag
+from ui.hooks.auth import get_current_user
+from ui.hooks.rbac import check_rbac
+
+REQUIRED_ROLES = ["admin"]
+FEATURE_FLAG = "enable_admin_panel"
+
+
+def render_page(user_ctx: dict | None = None) -> None:
+    """Render the Diagnostics page if admin panel is enabled.
+
+    Args:
+        user_ctx: Optional user context dictionary.
+
+    Raises:
+        PermissionError: If RBAC fails.
+        RuntimeError: If admin panel is disabled.
+        NotImplementedError: Always raised since this is a placeholder.
+    """
+
+    user = user_ctx or get_current_user()
+    if not check_rbac(user, REQUIRED_ROLES):
+        raise PermissionError("Diagnostics page requires admin role")
+    if not get_flag(FEATURE_FLAG):
+        raise RuntimeError("Admin panel disabled")
+    raise NotImplementedError("Diagnostics page not implemented")
+

--- a/src/ui_logic/pages/echo_core.py
+++ b/src/ui_logic/pages/echo_core.py
@@ -1,0 +1,29 @@
+"""EchoCore profile and tuning page stub."""
+
+from ui.config.feature_flags import get_flag
+from ui.hooks.auth import get_current_user
+from ui.hooks.rbac import check_rbac
+
+REQUIRED_ROLES = ["admin"]
+FEATURE_FLAG = "enable_premium"
+
+
+def render_page(user_ctx: dict | None = None) -> None:
+    """Render the EchoCore page for persona tuning.
+
+    Args:
+        user_ctx: Optional user context.
+
+    Raises:
+        PermissionError: If RBAC enforcement fails.
+        RuntimeError: If premium mode is not enabled.
+        NotImplementedError: Always raised as this is a placeholder.
+    """
+
+    user = user_ctx or get_current_user()
+    if not check_rbac(user, REQUIRED_ROLES):
+        raise PermissionError("EchoCore admin access required")
+    if not get_flag(FEATURE_FLAG):
+        raise RuntimeError("Premium features disabled")
+    raise NotImplementedError("EchoCore page not implemented")
+

--- a/src/ui_logic/pages/files.py
+++ b/src/ui_logic/pages/files.py
@@ -1,0 +1,29 @@
+"""File management and upload page stub."""
+
+from ui.config.feature_flags import get_flag
+from ui.hooks.auth import get_current_user
+from ui.hooks.rbac import check_rbac
+
+REQUIRED_ROLES = ["user", "admin"]
+FEATURE_FLAG = "enable_multimodal"
+
+
+def render_page(user_ctx: dict | None = None) -> None:
+    """Render the Files page for multimodal uploads.
+
+    Args:
+        user_ctx: Optional user context dictionary.
+
+    Raises:
+        PermissionError: If the user lacks permissions.
+        RuntimeError: If file uploads are disabled.
+        NotImplementedError: Always raised because logic is not yet implemented.
+    """
+
+    user = user_ctx or get_current_user()
+    if not check_rbac(user, REQUIRED_ROLES):
+        raise PermissionError("File manager access denied")
+    if not get_flag(FEATURE_FLAG):
+        raise RuntimeError("Multimodal uploads disabled")
+    raise NotImplementedError("Files page not implemented")
+

--- a/src/ui_logic/pages/integrations.py
+++ b/src/ui_logic/pages/integrations.py
@@ -1,0 +1,29 @@
+"""Third‑party integrations management stub."""
+
+from ui.config.feature_flags import get_flag
+from ui.hooks.auth import get_current_user
+from ui.hooks.rbac import check_rbac
+
+REQUIRED_ROLES = ["admin", "dev"]
+FEATURE_FLAG = "enable_plugins"
+
+
+def render_page(user_ctx: dict | None = None) -> None:
+    """Render the integrations page for plugin/LLM setup.
+
+    Args:
+        user_ctx: Optional user context dictionary.
+
+    Raises:
+        PermissionError: If RBAC enforcement fails.
+        RuntimeError: If integrations are disabled.
+        NotImplementedError: Always raised as this is a stub.
+    """
+
+    user = user_ctx or get_current_user()
+    if not check_rbac(user, REQUIRED_ROLES):
+        raise PermissionError("Insufficient privileges for integrations page")
+    if not get_flag(FEATURE_FLAG):
+        raise RuntimeError("Integrations feature disabled")
+    raise NotImplementedError("Integrations page not implemented")
+

--- a/src/ui_logic/pages/labs.py
+++ b/src/ui_logic/pages/labs.py
@@ -1,0 +1,29 @@
+"""Experimental labs UI stub gated by feature flags."""
+
+from ui.config.feature_flags import get_flag
+from ui.hooks.auth import get_current_user
+from ui.hooks.rbac import check_rbac
+
+REQUIRED_ROLES = ["dev", "admin"]
+FEATURE_FLAG = "show_experimental"
+
+
+def render_page(user_ctx: dict | None = None) -> None:
+    """Render the Labs page when experimental mode is enabled.
+
+    Args:
+        user_ctx: Optional user context.
+
+    Raises:
+        PermissionError: If RBAC check fails.
+        RuntimeError: If the experimental flag is not enabled.
+        NotImplementedError: Always raised as this is a placeholder.
+    """
+
+    user = user_ctx or get_current_user()
+    if not check_rbac(user, REQUIRED_ROLES):
+        raise PermissionError("Labs access denied")
+    if not get_flag(FEATURE_FLAG):
+        raise RuntimeError("Labs feature is disabled")
+    raise NotImplementedError("Labs page not implemented")
+

--- a/src/ui_logic/pages/personas.py
+++ b/src/ui_logic/pages/personas.py
@@ -1,0 +1,29 @@
+"""Persona library and editor stub."""
+
+from ui.config.feature_flags import get_flag
+from ui.hooks.auth import get_current_user
+from ui.hooks.rbac import check_rbac
+
+REQUIRED_ROLES = ["user", "admin"]
+FEATURE_FLAG = "enable_premium"
+
+
+def render_page(user_ctx: dict | None = None) -> None:
+    """Render the Personas page if premium is enabled.
+
+    Args:
+        user_ctx: Optional user context dictionary.
+
+    Raises:
+        PermissionError: If user lacks required roles.
+        RuntimeError: If premium features are disabled.
+        NotImplementedError: Always, because logic is pending.
+    """
+
+    user = user_ctx or get_current_user()
+    if not check_rbac(user, REQUIRED_ROLES):
+        raise PermissionError("Personas page access denied")
+    if not get_flag(FEATURE_FLAG):
+        raise RuntimeError("Persona features disabled")
+    raise NotImplementedError("Personas page not implemented")
+

--- a/src/ui_logic/pages/security.py
+++ b/src/ui_logic/pages/security.py
@@ -1,0 +1,29 @@
+"""Security settings and audit page stub."""
+
+from ui.config.feature_flags import get_flag
+from ui.hooks.auth import get_current_user
+from ui.hooks.rbac import check_rbac
+
+REQUIRED_ROLES = ["admin"]
+FEATURE_FLAG = "enable_enterprise"
+
+
+def render_page(user_ctx: dict | None = None) -> None:
+    """Render the security page if user has access.
+
+    Args:
+        user_ctx: Optional user context dictionary.
+
+    Raises:
+        PermissionError: If RBAC enforcement fails.
+        RuntimeError: If the enterprise feature is disabled.
+        NotImplementedError: Always, as this is a stub.
+    """
+
+    user = user_ctx or get_current_user()
+    if not check_rbac(user, REQUIRED_ROLES):
+        raise PermissionError("Admin role required")
+    if not get_flag(FEATURE_FLAG):
+        raise RuntimeError("Enterprise security features disabled")
+    raise NotImplementedError("Security page not implemented")
+

--- a/src/ui_logic/pages/task_manager.py
+++ b/src/ui_logic/pages/task_manager.py
@@ -1,0 +1,29 @@
+"""Task Manager UI page stub with RBAC and feature gating."""
+
+from ui.config.feature_flags import get_flag
+from ui.hooks.auth import get_current_user
+from ui.hooks.rbac import check_rbac
+
+REQUIRED_ROLES = ["user", "dev"]
+FEATURE_FLAG = "enable_workflows"
+
+
+def render_page(user_ctx: dict | None = None) -> None:
+    """Render the Task Manager page if allowed.
+
+    Args:
+        user_ctx: Optional user context dictionary.
+
+    Raises:
+        PermissionError: If the current user lacks required roles.
+        RuntimeError: If the feature flag is disabled.
+        NotImplementedError: Always, this is a placeholder.
+    """
+
+    user = user_ctx or get_current_user()
+    if not check_rbac(user, REQUIRED_ROLES):
+        raise PermissionError("Access denied for Task Manager page")
+    if not get_flag(FEATURE_FLAG):
+        raise RuntimeError("Task Manager feature is disabled")
+    raise NotImplementedError("Task Manager page not implemented")
+

--- a/src/ui_logic/pages/vision.py
+++ b/src/ui_logic/pages/vision.py
@@ -1,0 +1,29 @@
+"""Computer vision and OCR page stub."""
+
+from ui.config.feature_flags import get_flag
+from ui.hooks.auth import get_current_user
+from ui.hooks.rbac import check_rbac
+
+REQUIRED_ROLES = ["user", "admin"]
+FEATURE_FLAG = "enable_multimodal"
+
+
+def render_page(user_ctx: dict | None = None) -> None:
+    """Render the Vision page for image analysis.
+
+    Args:
+        user_ctx: Optional user context.
+
+    Raises:
+        PermissionError: If RBAC check fails.
+        RuntimeError: If vision features are disabled.
+        NotImplementedError: Always raised as this module is a stub.
+    """
+
+    user = user_ctx or get_current_user()
+    if not check_rbac(user, REQUIRED_ROLES):
+        raise PermissionError("Vision page access denied")
+    if not get_flag(FEATURE_FLAG):
+        raise RuntimeError("Vision features disabled")
+    raise NotImplementedError("Vision page not implemented")
+

--- a/src/ui_logic/pages/voice.py
+++ b/src/ui_logic/pages/voice.py
@@ -1,0 +1,29 @@
+"""Voice interface control page stub."""
+
+from ui.config.feature_flags import get_flag
+from ui.hooks.auth import get_current_user
+from ui.hooks.rbac import check_rbac
+
+REQUIRED_ROLES = ["user", "admin"]
+FEATURE_FLAG = "enable_voice_io"
+
+
+def render_page(user_ctx: dict | None = None) -> None:
+    """Render the Voice settings page.
+
+    Args:
+        user_ctx: Optional user context dictionary.
+
+    Raises:
+        PermissionError: If required roles are missing.
+        RuntimeError: If voice IO is disabled.
+        NotImplementedError: Always raised as this module is a placeholder.
+    """
+
+    user = user_ctx or get_current_user()
+    if not check_rbac(user, REQUIRED_ROLES):
+        raise PermissionError("Voice page access denied")
+    if not get_flag(FEATURE_FLAG):
+        raise RuntimeError("Voice I/O disabled")
+    raise NotImplementedError("Voice page not implemented")
+

--- a/src/ui_logic/pages/white_label.py
+++ b/src/ui_logic/pages/white_label.py
@@ -1,0 +1,29 @@
+"""Enterprise white‑label configuration UI stub."""
+
+from ui.config.feature_flags import get_flag
+from ui.hooks.auth import get_current_user
+from ui.hooks.rbac import check_rbac
+
+REQUIRED_ROLES = ["enterprise"]
+FEATURE_FLAG = "show_branding_controls"
+
+
+def render_page(user_ctx: dict | None = None) -> None:
+    """Render the white‑label page for enterprise tenants.
+
+    Args:
+        user_ctx: Optional user context dictionary.
+
+    Raises:
+        PermissionError: If RBAC checks fail.
+        RuntimeError: If the feature flag is disabled.
+        NotImplementedError: Always, placeholder stub.
+    """
+
+    user = user_ctx or get_current_user()
+    if not check_rbac(user, REQUIRED_ROLES):
+        raise PermissionError("Enterprise role required")
+    if not get_flag(FEATURE_FLAG):
+        raise RuntimeError("Branding controls disabled")
+    raise NotImplementedError("White‑label page not implemented")
+

--- a/src/ui_logic/pages/workflows.py
+++ b/src/ui_logic/pages/workflows.py
@@ -1,0 +1,29 @@
+"""Workflow builder and management page stub."""
+
+from ui.config.feature_flags import get_flag
+from ui.hooks.auth import get_current_user
+from ui.hooks.rbac import check_rbac
+
+REQUIRED_ROLES = ["admin"]
+FEATURE_FLAG = "enable_workflows"
+
+
+def render_page(user_ctx: dict | None = None) -> None:
+    """Render the Workflows page if enabled.
+
+    Args:
+        user_ctx: Optional user context dictionary.
+
+    Raises:
+        PermissionError: If RBAC check fails.
+        RuntimeError: If workflow features are disabled.
+        NotImplementedError: Always raised as this is a placeholder.
+    """
+
+    user = user_ctx or get_current_user()
+    if not check_rbac(user, REQUIRED_ROLES):
+        raise PermissionError("Workflows page requires admin role")
+    if not get_flag(FEATURE_FLAG):
+        raise RuntimeError("Workflow feature disabled")
+    raise NotImplementedError("Workflows page not implemented")
+


### PR DESCRIPTION
## Summary
- add RBAC gated stub pages under `ui_logic/pages`
- enforce feature flags and role checks in each stub
- raise `NotImplementedError` as placeholder

## Testing
- `pre-commit` *(fails: command not found)*
- `pytest tests/test_api.py::test_ping -q` *(fails: ModuleNotFoundError: No module named 'jinja2')*

------
https://chatgpt.com/codex/tasks/task_e_6868dd99b19c8324bcbe4e605b20f60a