### PR TITLE
Add health checker service

### DIFF
--- a/src/services/__init__.py
+++ b/src/services/__init__.py
@@ -1,0 +1,3 @@
+from . import health_checker
+
+__all__ = ["health_checker"]

--- a/src/services/health_checker.py
+++ b/src/services/health_checker.py
@@ -1,0 +1,36 @@
+"""Utilities for reporting system health."""
+
+from __future__ import annotations
+
+import os
+import platform
+import time
+
+try:  # pragma: no cover - optional dependency
+    import psutil
+except Exception:  # pragma: no cover - optional dependency
+    psutil = None
+
+_START_TIME = time.time()
+
+
+def get_system_health() -> dict:
+    """Return runtime and memory statistics."""
+    runtime = {
+        "pid": os.getpid(),
+        "python_version": platform.python_version(),
+        "uptime": time.time() - _START_TIME,
+    }
+
+    memory = {}
+    if psutil:
+        vm = psutil.virtual_memory()
+        memory = {
+            "total": vm.total,
+            "available": vm.available,
+            "percent": vm.percent,
+            "used": vm.used,
+            "free": vm.free,
+        }
+
+    return {"runtime": runtime, "memory": memory}


### PR DESCRIPTION
## Summary
- add utilities to gather runtime and memory metrics
- expose `health_checker` from `services`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for optional dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6868de3b160c8324898879b8c8836f2e