### PR TITLE
Implement get_current_user and improve RBAC handling

### DIFF
--- a/src/ui_logic/hooks/auth.py
+++ b/src/ui_logic/hooks/auth.py
@@ -9,13 +9,29 @@ Kari UI Auth Hook - Enterprise-Grade Auth & Session Management
 
 import os
 import time
-import json
 import hashlib
-import hmac
 from typing import Optional, Dict, Any, List, Callable
-from pathlib import Path
-
 import requests
+
+try:
+    import streamlit as st  # pragma: no cover - optional UI dependency
+except ModuleNotFoundError:  # pragma: no cover - fallback when Streamlit absent
+
+    class _DummyStreamlit:
+        def __init__(self) -> None:
+            self.session_state: Dict[str, Any] = {}
+
+    st = _DummyStreamlit()
+
+_CURRENT_USER_CALLBACK: Optional[Callable[[], Optional[Dict[str, Any]]]] = None
+
+
+def register_current_user_callback(cb: Callable[[], Optional[Dict[str, Any]]]) -> None:
+    """Register a callback used by :func:`get_current_user`."""
+
+    global _CURRENT_USER_CALLBACK
+    _CURRENT_USER_CALLBACK = cb
+
 
 # === Security Constants ===
 AUTH_SIGNING_KEY = os.getenv("KARI_AUTH_SIGNING_KEY", "change-me-in-prod")
@@ -24,21 +40,26 @@ COOKIE_NAME = "kari_session"
 JWT_ALGORITHM = "HS256"
 API_BASE_URL = os.getenv("KARI_API_BASE_URL", "http://localhost:8000")
 
+
 # === Device/Browser Fingerprinting ===
 def _device_fingerprint(user_agent: str, ip: str) -> str:
     """Hash user agent + IP for device-bound session."""
     data = f"{user_agent}:{ip}".encode()
     return hashlib.sha256(data).hexdigest()
 
+
 # === JWT/Session Token Management ===
 def _sign_token(payload: dict) -> str:
     """HMAC-signed JWT or fallback."""
     import jwt
+
     return jwt.encode(payload, AUTH_SIGNING_KEY, algorithm=JWT_ALGORITHM)
+
 
 def _verify_token(token: str) -> Optional[dict]:
     """Verify JWT signature and expiration."""
     import jwt
+
     try:
         decoded = jwt.decode(token, AUTH_SIGNING_KEY, algorithms=[JWT_ALGORITHM])
         if decoded.get("exp", 0) < time.time():
@@ -46,6 +67,7 @@ def _verify_token(token: str) -> Optional[dict]:
         return decoded
     except Exception:
         return None
+
 
 def create_session(user_id: str, roles: List[str], user_agent: str, ip: str) -> str:
     """Create a session JWT token (device-bound, time-limited)."""
@@ -59,6 +81,7 @@ def create_session(user_id: str, roles: List[str], user_agent: str, ip: str) -> 
     }
     return _sign_token(payload)
 
+
 def validate_session(token: str, user_agent: str, ip: str) -> Optional[dict]:
     """Validate session: signature, expiry, device match."""
     decoded = _verify_token(token)
@@ -68,15 +91,18 @@ def validate_session(token: str, user_agent: str, ip: str) -> Optional[dict]:
         return None
     return decoded
 
+
 # === RBAC Fast Check ===
 def has_role(user_ctx: dict, role: str) -> bool:
     """Check if user_ctx has at least one matching role."""
     return role in user_ctx.get("roles", [])
 
+
 def check_permission(user_ctx: dict, required: List[str]) -> bool:
     """Check if user_ctx covers all required roles."""
     roles = set(user_ctx.get("roles", []))
     return roles.issuperset(required)
+
 
 # === Auth API Integration ===
 def api_authenticate(username: str, password: str) -> Optional[dict]:
@@ -90,6 +116,7 @@ def api_authenticate(username: str, password: str) -> Optional[dict]:
         pass
     return None
 
+
 def api_get_user(token: str) -> Optional[dict]:
     """Get user profile/context for current session token."""
     url = f"{API_BASE_URL}/api/auth/me"
@@ -100,6 +127,30 @@ def api_get_user(token: str) -> Optional[dict]:
     except Exception:
         pass
     return None
+
+
+def get_current_user() -> Dict[str, Any]:
+    """Return the active user context.
+
+    Priority:
+    1. Callback registered via :func:`register_current_user_callback`.
+    2. ``st.session_state['user_ctx']`` if present (Streamlit).
+    3. Anonymous guest context.
+    """
+
+    if _CURRENT_USER_CALLBACK is not None:
+        try:
+            ctx = _CURRENT_USER_CALLBACK()
+            if ctx:
+                return ctx
+        except Exception:
+            pass
+
+    if hasattr(st, "session_state") and "user_ctx" in st.session_state:
+        return st.session_state["user_ctx"]
+
+    return {"user_id": "anonymous", "name": "Anonymous", "roles": ["guest"]}
+
 
 # === Secure Context Loader ===
 def get_user_context(cookie: str, user_agent: str, ip: str) -> Optional[dict]:
@@ -114,6 +165,7 @@ def get_user_context(cookie: str, user_agent: str, ip: str) -> Optional[dict]:
         return profile
     return None
 
+
 # === Session Cookie (for Streamlit/FastAPI) ===
 def set_session_cookie(response, token: str):
     """Set a secure session cookie on response (Streamlit or FastAPI)."""
@@ -123,23 +175,26 @@ def set_session_cookie(response, token: str):
         max_age=SESSION_DURATION,
         httponly=True,
         secure=True,
-        samesite="Lax"
+        samesite="Lax",
     )
+
 
 def clear_session_cookie(response):
     """Remove session cookie."""
     response.delete_cookie(COOKIE_NAME)
 
+
 # === Public API ===
 __all__ = [
     "create_session",
     "validate_session",
+    "get_current_user",
     "get_user_context",
     "has_role",
     "check_permission",
     "api_authenticate",
     "api_get_user",
+    "register_current_user_callback",
     "set_session_cookie",
     "clear_session_cookie",
 ]
-


### PR DESCRIPTION
## Summary
- add `get_current_user` and callback registration to `auth` hook
- handle anonymous users gracefully in RBAC
- switch RBAC import to dynamic import to satisfy linter

## Testing
- `ruff check src/ui_logic/hooks/auth.py src/ui_logic/hooks/rbac.py`
- `black src/ui_logic/hooks/auth.py src/ui_logic/hooks/rbac.py`
- `mypy src/ui_logic/hooks/auth.py src/ui_logic/hooks/rbac.py` *(fails: Library stubs not installed)*
- `pytest -q` *(fails: missing env variables)*

------
https://chatgpt.com/codex/tasks/task_e_6868de4f81bc83248366f7912b12d013