### PR TITLE
Fix streamlit page imports

### DIFF
--- a/ui_launchers/streamlit_ui/pages/chat.py
+++ b/ui_launchers/streamlit_ui/pages/chat.py
@@ -1,4 +1,5 @@
-from src.ui.pages.chat import chat_page as _chat_page
+from src.ui_logic.pages.chat import chat_page as _chat_page
+
 
 def chat_page(user_ctx=None):
     _chat_page(user_ctx=user_ctx)

--- a/ui_launchers/streamlit_ui/pages/home.py
+++ b/ui_launchers/streamlit_ui/pages/home.py
@@ -1,4 +1,5 @@
-from src.ui.pages.home import home_page as _home_page
+from src.ui_logic.pages.home import home_page as _home_page
+
 
 def home_page(user_ctx=None):
     _home_page(user_ctx=user_ctx)


### PR DESCRIPTION
## Summary
- fix handler imports for Chat and Home pages

## Testing
- `ruff check ui_launchers/streamlit_ui/pages/home.py ui_launchers/streamlit_ui/pages/chat.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jinja2')*

------
https://chatgpt.com/codex/tasks/task_e_6868df0a48e08324a82a13414ddd176c