### PR TITLE
Fix core import paths

### DIFF
--- a/src/ai_karen_engine/clients/embedding/embedding_client.py
+++ b/src/ai_karen_engine/clients/embedding/embedding_client.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import hashlib
 from typing import List
 
-from src.core.embedding_manager import EmbeddingManager
+from ai_karen_engine.core.embedding_manager import EmbeddingManager
 
 
 def _byte_embedding_model(byte_input: bytes, dim: int = 8) -> List[float]:

--- a/src/ai_karen_engine/core/autonomous_agent.py
+++ b/src/ai_karen_engine/core/autonomous_agent.py
@@ -1,5 +1,5 @@
 """Autonomous agent loop wrapper."""
 
-from src.core.autonomous_agent import AutonomousAgent
+from ai_karen_engine.core.autonomous_agent import AutonomousAgent
 
 __all__ = ["AutonomousAgent"]

--- a/src/ai_karen_engine/core/cortex/__init__.py
+++ b/src/ai_karen_engine/core/cortex/__init__.py
@@ -1,3 +1,3 @@
-from src.core.cortex.dispatch import CortexDispatcher
+from ai_karen_engine.core.cortex.dispatch import CortexDispatcher
 
 __all__ = ["CortexDispatcher"]

--- a/src/ai_karen_engine/core/cortex/dispatch.py
+++ b/src/ai_karen_engine/core/cortex/dispatch.py
@@ -1,1 +1,1 @@
-from src.core.cortex.dispatch import *  # noqa: F401,F403
+from ai_karen_engine.core.cortex.dispatch import *  # noqa: F401,F403

--- a/src/ai_karen_engine/core/intent_engine.py
+++ b/src/ai_karen_engine/core/intent_engine.py
@@ -1,5 +1,5 @@
 """Intent detection wrapper for Kari."""
 
-from src.core.intent_engine import IntentEngine
+from ai_karen_engine.core.intent_engine import IntentEngine
 
 __all__ = ["IntentEngine"]

--- a/src/ai_karen_engine/core/prompt_router.py
+++ b/src/ai_karen_engine/core/prompt_router.py
@@ -1,3 +1,3 @@
-from src.core.prompt_router import PluginWrapper, PromptRouter
+from ai_karen_engine.core.prompt_router import PluginWrapper, PromptRouter
 
 __all__ = ["PluginWrapper", "PromptRouter"]

--- a/src/ai_karen_engine/core/self_refactor_loop.py
+++ b/src/ai_karen_engine/core/self_refactor_loop.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Optional
 
-from src.self_refactor import SelfRefactorEngine
+from ai_karen_engine.self_refactor import SelfRefactorEngine
 
 
 def run_self_refactor_cycle(

--- a/src/core/model_manager.py
+++ b/src/core/model_manager.py
@@ -1,2 +1,2 @@
 """Backward compatibility wrapper for ModelManager."""
-from src.ai_karen_engine.core.model_manager import *  # noqa: F401,F403
+from ai_karen_engine.core.model_manager import *  # noqa: F401,F403


### PR DESCRIPTION
## Summary
- update embedding client to import EmbeddingManager from ai_karen_engine
- update self-refactor loop client import
- route compatibility modules through ai_karen_engine paths
- adjust model manager wrapper import

## Testing
- `pytest -q` *(fails: KARI_MODEL_SIGNING_KEY must be set)*

------
https://chatgpt.com/codex/tasks/task_e_6868de69d8308324adb7cfe418b532c9