### PR TITLE
Add feature flag helper

### DIFF
--- a/src/ui_logic/config/feature_flags.py
+++ b/src/ui_logic/config/feature_flags.py
@@ -75,11 +75,17 @@ def list_flags(custom_path: Optional[str] = None) -> Dict[str, Any]:
     """Get all flags (resolved from config, ENV, or defaults)."""
     return load_feature_flags(custom_path)
 
+
+def is_feature_enabled(key: str, custom_path: str | None = None) -> bool:
+    """Return ``True`` if the feature flag ``key`` is enabled."""
+    return bool(get_flag(key, custom_path))
+
 # === Public API ===
 __all__ = [
     "get_flag",
     "set_flag",
     "list_flags",
     "load_feature_flags",
+    "is_feature_enabled",
     "DEFAULT_FLAGS",
 ]

--- a/src/ui_logic/hooks/plugin_loader.py
+++ b/src/ui_logic/hooks/plugin_loader.py
@@ -12,10 +12,9 @@ import uuid
 from pathlib import Path
 from typing import List, Dict, Any, Optional
 
-from ui.config.feature_flags import is_feature_enabled
-from ui.hooks.rbac import check_rbac
-from ui.hooks.auth import get_current_user
-from ui.utils.api import fetch_json
+from ui_logic.config.feature_flags import is_feature_enabled
+from ui_logic.hooks.rbac import check_rbac
+from ui_logic.hooks.auth import get_current_user
 import logging
 
 PLUGIN_DIR = Path(os.getenv("KARI_PLUGIN_DIR", "src/plugins"))


### PR DESCRIPTION
## Summary
- add `is_feature_enabled` helper for UI logic
- expose new helper in `feature_flags` module
- fix plugin loader imports and remove unused import

## Testing
- `ruff check src/ui_logic/config/feature_flags.py src/ui_logic/hooks/plugin_loader.py`
- `pytest -q` *(fails: ModuleNotFoundError and missing env vars)*

------
https://chatgpt.com/codex/tasks/task_e_6868dde07144832492aa42cf43b915fa