### PR TITLE
Add lazy plugin router accessor

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4,7 +4,7 @@ import sys
 from pathlib import Path
 
 from src.ai_karen_engine import LLMOrchestrator
-from ai_karen_engine.plugin_router import PluginRouter
+from ai_karen_engine.plugin_router import get_plugin_router
 
 
 CONFIG_PATH = Path("config") / "settings.json"
@@ -26,7 +26,7 @@ def self_test() -> None:
             sys.modules[dep] = type(sys)(dep)
 
     orchestrator = LLMOrchestrator()
-    router = PluginRouter()
+    router = get_plugin_router()
 
     summary = {
         "provider": cfg.get("provider", "unknown"),

--- a/src/ai_karen_engine/plugin_router.py
+++ b/src/ai_karen_engine/plugin_router.py
@@ -102,6 +102,16 @@ class PluginRouter:
                 "traceback": traceback_str,
             }
 
-# --- Singleton Instance ---
-plugin_router = PluginRouter()
+# --- Lazy Accessor for Singleton Instance ---
+_plugin_router: Optional[PluginRouter] = None
+
+
+def get_plugin_router() -> PluginRouter:
+    """Return a cached :class:`PluginRouter` instance."""
+    global _plugin_router
+    if _plugin_router is None:
+        _plugin_router = PluginRouter()
+    return _plugin_router
+
+__all__ = ["PluginRouter", "get_plugin_router"]
 

--- a/src/core/cortex/dispatch.py
+++ b/src/core/cortex/dispatch.py
@@ -9,7 +9,7 @@ import asyncio
 from typing import Any, Dict
 
 from ai_karen_engine.core.intent_engine import IntentEngine
-from ai_karen_engine.plugin_router import PluginRouter, AccessDenied
+from ai_karen_engine.plugin_router import get_plugin_router, AccessDenied
 from ai_karen_engine.core.reasoning.ice_integration import KariICEWrapper
 
 
@@ -18,7 +18,7 @@ class CortexDispatcher:
 
     def __init__(self) -> None:
         self.engine = IntentEngine()
-        self.router = PluginRouter()
+        self.router = get_plugin_router()
         self.ice = KariICEWrapper()
 
     async def dispatch(self, text: str, role: str = "user") -> Dict[str, Any]:

--- a/src/core/prompt_router.py
+++ b/src/core/prompt_router.py
@@ -1,5 +1,5 @@
 import asyncio
-from ai_karen_engine.plugin_router import PluginRouter as BaseRouter
+from ai_karen_engine.plugin_router import get_plugin_router
 
 
 class PluginWrapper:
@@ -16,7 +16,7 @@ class PromptRouter:
     """Very small router that always returns the autonomous_task_handler plugin."""
 
     def __init__(self) -> None:
-        self.router = BaseRouter()
+        self.router = get_plugin_router()
 
     def route(self, _text: str) -> PluginWrapper:
         record = self.router.get_plugin("autonomous_task_handler")


### PR DESCRIPTION
## Summary
- create `get_plugin_router()` with lazy caching
- refactor CLI and dispatch logic to use accessor
- update prompt router to share the cached router

## Testing
- `pytest -q` *(fails: KARI_MODEL_SIGNING_KEY must be set)*

------
https://chatgpt.com/codex/tasks/task_e_6868de77a09c83248e75c8c23172236a