### PR TITLE
Implement presence page stub

### DIFF
--- a/src/ui_logic/pages/presence.py
+++ b/src/ui_logic/pages/presence.py
@@ -1,0 +1,36 @@
+"""Presence detection and activity UI stub."""
+
+from ui_logic.config.feature_flags import get_flag
+from ui_logic.hooks.auth import get_current_user
+from ui_logic.hooks.rbac import check_rbac
+
+REQUIRED_ROLES = ["admin", "user"]
+FEATURE_FLAG = "enable_presence"
+
+
+def page(user_ctx: dict, **kwargs) -> None:
+    """Render the presence page if permitted.
+
+    Args:
+        user_ctx: The calling user context.
+        **kwargs: Additional parameters (unused).
+
+    Raises:
+        PermissionError: If access is denied by RBAC.
+        RuntimeError: If the presence feature is disabled.
+        NotImplementedError: Always raised as this is a placeholder.
+    """
+
+    user = user_ctx or get_current_user()
+    if not check_rbac(user, REQUIRED_ROLES):
+        raise PermissionError("Presence page access denied")
+    if not get_flag(FEATURE_FLAG):
+        raise RuntimeError("Presence feature disabled")
+    raise NotImplementedError("Coming soon!")
+
+
+if __name__ == "__main__":
+    try:
+        page({})
+    except NotImplementedError:
+        print("Presence page stub")


### PR DESCRIPTION
## Summary
- implement presence page with RBAC and feature flag checks
- add a small smoke-test entrypoint

## Testing
- `ruff check src/ui_logic/pages/presence.py`
- `mypy src/ui_logic/pages/presence.py` *(fails: Cannot find implementation or library stub for various modules)*
- `pytest -q` *(fails: ModuleNotFoundError and environment errors)*

------
https://chatgpt.com/codex/tasks/task_e_6868e7e85eec8324b5a14fda9e258cf4