### PR TITLE
Update streamlit launcher imports

### DIFF
--- a/ui_launchers/common/components/__init__.py
+++ b/ui_launchers/common/components/__init__.py
@@ -1,4 +1,4 @@
-from ui.common.components.rbac import has_role, require_role
+from ui_launchers.common.components.rbac import has_role, require_role
 
 __all__ = ["has_role", "require_role"]
 

--- a/ui_launchers/streamlit_ui/pages/chat.py
+++ b/ui_launchers/streamlit_ui/pages/chat.py
@@ -1,4 +1,4 @@
-from src.ui_logic.pages.chat import chat_page as _chat_page
+from ui_logic.pages.chat import chat_page as _chat_page
 
 
 def chat_page(user_ctx=None):

--- a/ui_launchers/streamlit_ui/pages/home.py
+++ b/ui_launchers/streamlit_ui/pages/home.py
@@ -1,4 +1,4 @@
-from src.ui_logic.pages.home import home_page as _home_page
+from ui_logic.pages.home import home_page as _home_page
 
 
 def home_page(user_ctx=None):


### PR DESCRIPTION
## Summary
- import from `ui_logic.pages` directly in streamlit launcher pages
- fix components package to avoid expecting a `ui` package

## Testing
- `ruff check .` *(fails: unrecognized subcommand)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'ui.common')*
- `python cli.py --self-test` *(fails: KARI_MODEL_SIGNING_KEY must be set in the environment!)*

------
https://chatgpt.com/codex/tasks/task_e_6868e8719ba8832495aa61a6c85b6747