### PR TITLE
Fix imports for ui_logic modules

### DIFF
--- a/src/ui_logic/components/admin/audit_log.py
+++ b/src/ui_logic/components/admin/audit_log.py
@@ -5,7 +5,7 @@ Kari Audit Log Logic
 """
 
 from typing import List, Dict, Any, Optional
-from ui.utils.api import fetch_audit_logs
+from ui_logic.utils.api import fetch_audit_logs
 
 def get_audit_log(user_ctx: Dict, filter: Optional[Dict] = None, limit: int = 100) -> List[Dict]:
     """

--- a/src/ui_logic/components/admin/diagnostics.py
+++ b/src/ui_logic/components/admin/diagnostics.py
@@ -6,7 +6,7 @@ Kari Diagnostics Logic
 
 import psutil
 from typing import Dict, Any
-from ui.utils.api import ping_services
+from ui_logic.utils.api import ping_services
 
 def get_system_diagnostics() -> Dict[str, Any]:
     """Returns system health/metrics for the dashboard."""

--- a/src/ui_logic/components/admin/org_admin.py
+++ b/src/ui_logic/components/admin/org_admin.py
@@ -5,7 +5,7 @@ Kari Organization Admin Logic
 """
 
 from typing import Dict, List, Optional
-from ui.utils.api import (
+from ui_logic.utils.api import (
     fetch_org_users, add_org_user, update_org_user, remove_org_user, 
     fetch_org_settings, update_org_settings
 )

--- a/src/ui_logic/components/admin/rbac_panel.py
+++ b/src/ui_logic/components/admin/rbac_panel.py
@@ -5,7 +5,7 @@ Kari RBAC Panel Logic
 """
 
 from typing import Dict, List
-from ui.utils.api import (
+from ui_logic.utils.api import (
     fetch_user_roles, update_user_roles, fetch_role_policies, update_role_policies
 )
 

--- a/src/ui_logic/components/admin/system_status.py
+++ b/src/ui_logic/components/admin/system_status.py
@@ -5,7 +5,7 @@ Kari System Status Logic
 """
 
 from typing import Dict
-from ui.utils.api import fetch_system_status
+from ui_logic.utils.api import fetch_system_status
 
 def get_system_status() -> Dict:
     return fetch_system_status()

--- a/src/ui_logic/components/analytics/auto_parser.py
+++ b/src/ui_logic/components/analytics/auto_parser.py
@@ -6,7 +6,7 @@ Kari Auto-Parser Logic
 
 import pandas as pd
 from typing import Dict, Any, Tuple, Optional
-from ui.utils.file_utils import secure_read_file, parse_csv_excel
+from ui_logic.utils.file_utils import secure_read_file, parse_csv_excel
 
 def auto_parse_data(file_bytes: bytes, filename: str, options: Optional[Dict[str, Any]] = None) -> Tuple[pd.DataFrame, Dict[str, Any]]:
     """

--- a/src/ui_logic/components/analytics/chart_builder.py
+++ b/src/ui_logic/components/analytics/chart_builder.py
@@ -6,7 +6,7 @@ Kari Chart Builder Logic
 
 import pandas as pd
 from typing import Dict, Any
-from ui.utils.chart_utils import create_chart, get_supported_chart_types
+from ui_logic.utils.chart_utils import create_chart, get_supported_chart_types
 
 def build_chart(data: pd.DataFrame, chart_type: str, config: Dict[str, Any]) -> Any:
     """

--- a/src/ui_logic/components/analytics/data_explorer.py
+++ b/src/ui_logic/components/analytics/data_explorer.py
@@ -6,7 +6,7 @@ Kari Data Explorer Logic
 
 import pandas as pd
 from typing import Dict, Any, Optional
-from ui.utils.api import semantic_search_df, summarize_dataframe
+from ui_logic.utils.api import semantic_search_df, summarize_dataframe
 
 def explore_data(df: pd.DataFrame, query: Optional[str] = None, actions: Optional[Dict[str, Any]] = None) -> Dict:
     """

--- a/src/ui_logic/components/chat/chat_input.py
+++ b/src/ui_logic/components/chat/chat_input.py
@@ -5,8 +5,8 @@ Kari Chat Input Logic
 """
 
 from typing import Dict, Any
-from ui.hooks.rbac import require_roles
-from ui.utils.api import submit_message, fetch_input_audit
+from ui_logic.hooks.rbac import require_roles
+from ui_logic.utils.api import submit_message, fetch_input_audit
 
 def handle_chat_input(user_ctx: Dict, message: str, attachments: list = None, meta: Dict = None) -> str:
     if not user_ctx or not require_roles(user_ctx, ["user", "admin"]):

--- a/src/ui_logic/components/chat/chat_window.py
+++ b/src/ui_logic/components/chat/chat_window.py
@@ -5,8 +5,8 @@ Kari Chat Window Logic
 """
 
 from typing import Dict, List, Any
-from ui.hooks.rbac import require_roles
-from ui.utils.api import fetch_chat_history
+from ui_logic.hooks.rbac import require_roles
+from ui_logic.utils.api import fetch_chat_history
 
 def get_chat_history(user_ctx: Dict, limit: int = 50) -> List[Dict]:
     if not user_ctx or not require_roles(user_ctx, ["user", "admin"]):

--- a/src/ui_logic/components/chat/context_panel.py
+++ b/src/ui_logic/components/chat/context_panel.py
@@ -5,8 +5,8 @@ Kari Chat Context Panel Logic
 """
 
 from typing import Dict, Any
-from ui.hooks.rbac import require_roles
-from ui.hooks.memory_hook import fetch_session_memory
+from ui_logic.hooks.rbac import require_roles
+from ui_logic.hooks.memory_hook import fetch_session_memory
 
 def get_session_context(user_ctx: Dict) -> Dict:
     if not user_ctx or not require_roles(user_ctx, ["user", "admin", "analyst"]):

--- a/src/ui_logic/components/chat/voice_controls.py
+++ b/src/ui_logic/components/chat/voice_controls.py
@@ -5,8 +5,8 @@ Kari Voice Controls Logic
 """
 
 from typing import Dict, Any
-from ui.hooks.rbac import require_roles
-from ui.utils.api import run_stt, run_tts, fetch_voice_logs
+from ui_logic.hooks.rbac import require_roles
+from ui_logic.utils.api import run_stt, run_tts, fetch_voice_logs
 
 def transcribe_voice(user_ctx: Dict, audio_bytes: bytes, meta: Dict = None) -> str:
     if not user_ctx or not require_roles(user_ctx, ["user", "admin"]):

--- a/src/ui_logic/components/files/code_sandbox.py
+++ b/src/ui_logic/components/files/code_sandbox.py
@@ -6,8 +6,8 @@ Kari Code Sandbox Logic
 """
 
 from typing import Dict, Any
-from ui.hooks.rbac import require_roles
-from ui.utils.api import run_code_safely, fetch_audit_logs
+from ui_logic.hooks.rbac import require_roles
+from ui_logic.utils.api import run_code_safely, fetch_audit_logs
 
 def execute_code(user_ctx: Dict, code: str, input_data: Any = None, language: str = "python") -> Dict:
     if not user_ctx or not require_roles(user_ctx, ["user", "developer", "admin"]):

--- a/src/ui_logic/components/files/doc_summary.py
+++ b/src/ui_logic/components/files/doc_summary.py
@@ -5,8 +5,8 @@ Kari Doc Summary Logic
 """
 
 from typing import Dict, Any
-from ui.hooks.rbac import require_roles
-from ui.utils.api import (
+from ui_logic.hooks.rbac import require_roles
+from ui_logic.utils.api import (
     extract_doc_content,
     summarize_document,
     fetch_audit_logs

--- a/src/ui_logic/components/files/file_dropper.py
+++ b/src/ui_logic/components/files/file_dropper.py
@@ -4,8 +4,8 @@ Kari File Dropper Logic
 """
 
 from typing import Dict, Any, List
-from ui.hooks.rbac import require_roles
-from ui.utils.api import save_file, fetch_upload_logs
+from ui_logic.hooks.rbac import require_roles
+from ui_logic.utils.api import save_file, fetch_upload_logs
 
 def upload_file(user_ctx: Dict, file_bytes: bytes, filename: str, filetype: str, meta: Dict = None) -> str:
     if not user_ctx or not require_roles(user_ctx, ["user", "admin", "analyst"]):

--- a/src/ui_logic/components/files/multimodal_upload.py
+++ b/src/ui_logic/components/files/multimodal_upload.py
@@ -6,8 +6,8 @@ Kari Multi-Modal Upload Logic
 """
 
 from typing import Dict, Any
-from ui.hooks.rbac import require_roles
-from ui.utils.api import (
+from ui_logic.hooks.rbac import require_roles
+from ui_logic.utils.api import (
     save_file,
     run_ocr,
     run_transcription,

--- a/src/ui_logic/components/files/ocr_panel.py
+++ b/src/ui_logic/components/files/ocr_panel.py
@@ -6,8 +6,8 @@ Kari OCR Panel Logic
 """
 
 from typing import Dict, Any
-from ui.hooks.rbac import require_roles
-from ui.utils.api import run_ocr, fetch_audit_logs
+from ui_logic.hooks.rbac import require_roles
+from ui_logic.utils.api import run_ocr, fetch_audit_logs
 
 def extract_ocr(user_ctx: Dict, file_id: str) -> Dict:
     if not user_ctx or not require_roles(user_ctx, ["user", "admin", "analyst"]):

--- a/src/ui_logic/components/iot/device_manager.py
+++ b/src/ui_logic/components/iot/device_manager.py
@@ -6,8 +6,8 @@ Kari IoT Device Manager Logic
 """
 
 from typing import Dict, Any, List
-from ui.hooks.rbac import require_roles
-from ui.utils.api import (
+from ui_logic.hooks.rbac import require_roles
+from ui_logic.utils.api import (
     fetch_devices, pair_device, control_device, fetch_audit_logs
 )
 

--- a/src/ui_logic/components/iot/iot_logs.py
+++ b/src/ui_logic/components/iot/iot_logs.py
@@ -6,8 +6,8 @@ Kari IoT Device Manager Logic
 """
 
 from typing import Dict, Any, List
-from ui.hooks.rbac import require_roles
-from ui.utils.api import (
+from ui_logic.hooks.rbac import require_roles
+from ui_logic.utils.api import (
     fetch_devices, pair_device, control_device, fetch_audit_logs
 )
 

--- a/src/ui_logic/components/iot/scene_builder.py
+++ b/src/ui_logic/components/iot/scene_builder.py
@@ -5,8 +5,8 @@ Kari IoT Logs Panel
 """
 
 from typing import Dict, List, Any
-from ui.hooks.rbac import require_roles
-from ui.utils.api import fetch_iot_logs, fetch_audit_logs
+from ui_logic.hooks.rbac import require_roles
+from ui_logic.utils.api import fetch_iot_logs, fetch_audit_logs
 
 def get_iot_logs(user_ctx: Dict, device_id: str = None, search: str = "") -> List[Dict]:
     if not user_ctx or not require_roles(user_ctx, ["user", "admin", "devops"]):

--- a/src/ui_logic/components/memory/knowledge_graph.py
+++ b/src/ui_logic/components/memory/knowledge_graph.py
@@ -6,8 +6,8 @@ Kari Knowledge Graph Panel Logic
 """
 
 from typing import Dict, Any, List
-from ui.hooks.rbac import require_roles
-from ui.utils.api import fetch_knowledge_graph, fetch_audit_logs
+from ui_logic.hooks.rbac import require_roles
+from ui_logic.utils.api import fetch_knowledge_graph, fetch_audit_logs
 
 def get_knowledge_graph(user_ctx: Dict, query: str = "") -> Dict[str, Any]:
     if not user_ctx or not require_roles(user_ctx, ["user", "admin", "analyst"]):

--- a/src/ui_logic/components/memory/memory_analytics.py
+++ b/src/ui_logic/components/memory/memory_analytics.py
@@ -5,8 +5,8 @@ Kari Memory Analytics Logic
 """
 
 from typing import Dict, Any, List
-from ui.hooks.rbac import require_roles
-from ui.utils.api import fetch_memory_analytics, fetch_audit_logs
+from ui_logic.hooks.rbac import require_roles
+from ui_logic.utils.api import fetch_memory_analytics, fetch_audit_logs
 
 def get_memory_analytics(user_ctx: Dict) -> Dict[str, Any]:
     if not user_ctx or not require_roles(user_ctx, ["admin", "analyst", "user"]):

--- a/src/ui_logic/components/memory/profile_panel.py
+++ b/src/ui_logic/components/memory/profile_panel.py
@@ -5,8 +5,8 @@ Kari Profile Panel Logic
 """
 
 from typing import Dict, Any
-from ui.hooks.rbac import require_roles
-from ui.utils.api import fetch_user_profile, save_user_profile, fetch_audit_logs
+from ui_logic.hooks.rbac import require_roles
+from ui_logic.utils.api import fetch_user_profile, save_user_profile, fetch_audit_logs
 
 def get_user_profile(user_ctx: Dict) -> Dict[str, Any]:
     if not user_ctx or not require_roles(user_ctx, ["user", "admin"]):

--- a/src/ui_logic/components/memory/session_explorer.py
+++ b/src/ui_logic/components/memory/session_explorer.py
@@ -5,8 +5,8 @@ Kari Session Explorer Logic
 """
 
 from typing import Dict, Any, List
-from ui.hooks.rbac import require_roles
-from ui.utils.api import fetch_session_memory, fetch_audit_logs
+from ui_logic.hooks.rbac import require_roles
+from ui_logic.utils.api import fetch_session_memory, fetch_audit_logs
 
 def get_session_memory(user_ctx: Dict, session_id: str = None) -> List[Dict]:
     if not user_ctx or not require_roles(user_ctx, ["user", "admin", "analyst"]):

--- a/src/ui_logic/components/model/benchmark_panel.py
+++ b/src/ui_logic/components/model/benchmark_panel.py
@@ -6,8 +6,8 @@ Kari Model Benchmark Panel Logic
 """
 
 from typing import Dict, Any, List
-from ui.hooks.rbac import require_roles
-from ui.utils.api import (
+from ui_logic.hooks.rbac import require_roles
+from ui_logic.utils.api import (
     fetch_model_benchmarks, 
     run_model_benchmark, 
     fetch_audit_logs

--- a/src/ui_logic/components/model/model_selector.py
+++ b/src/ui_logic/components/model/model_selector.py
@@ -5,8 +5,8 @@ Kari Model Selector Logic
 """
 
 from typing import Dict, List
-from ui.hooks.rbac import require_roles
-from ui.utils.api import fetch_available_models
+from ui_logic.hooks.rbac import require_roles
+from ui_logic.utils.api import fetch_available_models
 
 def get_available_models(user_ctx: Dict) -> List[Dict]:
     if not user_ctx or not require_roles(user_ctx, ["user", "admin"]):

--- a/src/ui_logic/components/model/provider_selector.py
+++ b/src/ui_logic/components/model/provider_selector.py
@@ -4,8 +4,8 @@ Kari LLM Provider Selector Logic
 """
 
 from typing import Dict, List
-from ui.hooks.rbac import require_roles
-from ui.utils.api import fetch_providers
+from ui_logic.hooks.rbac import require_roles
+from ui_logic.utils.api import fetch_providers
 
 def get_available_providers(user_ctx: Dict) -> List[Dict]:
     if not user_ctx or not require_roles(user_ctx, ["user", "admin"]):

--- a/src/ui_logic/components/persona/emotion_style_panel.py
+++ b/src/ui_logic/components/persona/emotion_style_panel.py
@@ -6,8 +6,8 @@ Kari Persona: Emotion & Style Panel Logic
 """
 
 from typing import Dict, List
-from ui.hooks.rbac import require_roles
-from ui.utils.api import fetch_emotion_styles, save_emotion_style, fetch_audit_logs
+from ui_logic.hooks.rbac import require_roles
+from ui_logic.utils.api import fetch_emotion_styles, save_emotion_style, fetch_audit_logs
 
 def get_emotion_styles(user_ctx: Dict) -> List[Dict]:
     if not user_ctx or not require_roles(user_ctx, ["user", "admin", "branding"]):

--- a/src/ui_logic/components/persona/persona_analytics.py
+++ b/src/ui_logic/components/persona/persona_analytics.py
@@ -6,8 +6,8 @@ Kari Persona Analytics Logic
 """
 
 from typing import Dict, List
-from ui.hooks.rbac import require_roles
-from ui.utils.api import fetch_persona_analytics, fetch_audit_logs
+from ui_logic.hooks.rbac import require_roles
+from ui_logic.utils.api import fetch_persona_analytics, fetch_audit_logs
 
 def get_persona_analytics(user_ctx: Dict) -> List[Dict]:
     if not user_ctx or not require_roles(user_ctx, ["user", "admin", "analyst"]):

--- a/src/ui_logic/components/persona/persona_switcher.py
+++ b/src/ui_logic/components/persona/persona_switcher.py
@@ -5,8 +5,8 @@ Kari Persona Switcher Logic
 """
 
 from typing import Dict, List
-from ui.hooks.rbac import require_roles
-from ui.utils.api import fetch_personas, switch_persona, fetch_audit_logs
+from ui_logic.hooks.rbac import require_roles
+from ui_logic.utils.api import fetch_personas, switch_persona, fetch_audit_logs
 
 def get_available_personas(user_ctx: Dict) -> List[Dict]:
     if not user_ctx or not require_roles(user_ctx, ["user", "admin", "branding"]):

--- a/src/ui_logic/components/plugins/plugin_manager.py
+++ b/src/ui_logic/components/plugins/plugin_manager.py
@@ -4,8 +4,8 @@ Kari Plugin Manager Logic
 """
 
 from typing import Dict, List
-from ui.hooks.rbac import require_roles
-from ui.utils.api import (
+from ui_logic.hooks.rbac import require_roles
+from ui_logic.utils.api import (
     list_plugins,
     install_plugin,
     uninstall_plugin,

--- a/src/ui_logic/components/plugins/plugin_store.py
+++ b/src/ui_logic/components/plugins/plugin_store.py
@@ -4,8 +4,8 @@ Kari Plugin Store Logic
 """
 
 from typing import Dict, List
-from ui.hooks.rbac import require_roles
-from ui.utils.api import (
+from ui_logic.hooks.rbac import require_roles
+from ui_logic.utils.api import (
     fetch_store_plugins,
     search_plugins,
     fetch_audit_logs,

--- a/src/ui_logic/components/plugins/workflow_builder.py
+++ b/src/ui_logic/components/plugins/workflow_builder.py
@@ -4,8 +4,8 @@ Kari Workflow Builder Logic
 """
 
 from typing import Dict, List
-from ui.hooks.rbac import require_roles
-from ui.utils.api import (
+from ui_logic.hooks.rbac import require_roles
+from ui_logic.utils.api import (
     fetch_user_workflows,
     create_workflow,
     delete_workflow,

--- a/src/ui_logic/components/scheduling/calendar_panel.py
+++ b/src/ui_logic/components/scheduling/calendar_panel.py
@@ -4,8 +4,8 @@ Kari Calendar Panel Business Logic
 """
 
 from typing import Dict, List
-from ui.hooks.rbac import require_roles
-from ui.utils.api import (
+from ui_logic.hooks.rbac import require_roles
+from ui_logic.utils.api import (
     fetch_user_calendar,
     add_event_to_calendar,
     remove_event_from_calendar,

--- a/src/ui_logic/components/scheduling/follow_up.py
+++ b/src/ui_logic/components/scheduling/follow_up.py
@@ -4,8 +4,8 @@ Kari Follow-Up Engine Logic
 """
 
 from typing import Dict, List
-from ui.hooks.rbac import require_roles
-from ui.utils.api import (
+from ui_logic.hooks.rbac import require_roles
+from ui_logic.utils.api import (
     fetch_follow_ups,
     create_follow_up,
     remove_follow_up,

--- a/src/ui_logic/components/scheduling/reminders_panel.py
+++ b/src/ui_logic/components/scheduling/reminders_panel.py
@@ -4,8 +4,8 @@ Kari Reminders Panel Logic
 """
 
 from typing import Dict, List
-from ui.hooks.rbac import require_roles
-from ui.utils.api import (
+from ui_logic.hooks.rbac import require_roles
+from ui_logic.utils.api import (
     fetch_reminders,
     add_reminder,
     remove_reminder,

--- a/src/ui_logic/components/settings/api_vault.py
+++ b/src/ui_logic/components/settings/api_vault.py
@@ -4,8 +4,8 @@ Kari API Vault Logic (Framework-Agnostic)
 - RBAC logic only (no UI)
 """
 
-from ui.hooks.rbac import require_roles
-from ui.config.ui_config import get_api_keys, save_api_key, delete_api_key
+from ui_logic.hooks.rbac import require_roles
+from ui_logic.config.ui_config import get_api_keys, save_api_key, delete_api_key
 
 def list_api_keys(user_ctx):
     if not user_ctx or not require_roles(user_ctx, ["user", "admin"]):

--- a/src/ui_logic/components/settings/privacy_console.py
+++ b/src/ui_logic/components/settings/privacy_console.py
@@ -4,8 +4,8 @@ Kari Privacy Console Logic (Framework-Agnostic)
 - NO UI code—logic only
 """
 
-from ui.hooks.rbac import require_roles
-from ui.config.ui_config import get_privacy_data, anonymize_user_data, export_user_data, delete_user_data
+from ui_logic.hooks.rbac import require_roles
+from ui_logic.config.ui_config import get_privacy_data, anonymize_user_data, export_user_data, delete_user_data
 
 def fetch_privacy_data(user_ctx):
     if not user_ctx or not require_roles(user_ctx, ["user", "admin"]):

--- a/src/ui_logic/components/settings/settings_panel.py
+++ b/src/ui_logic/components/settings/settings_panel.py
@@ -5,8 +5,8 @@ Kari Settings Panel Logic (Framework-Agnostic)
 - To be used by any UI skin (Streamlit, Gradio, CLI, etc)
 """
 
-from ui.hooks.rbac import require_roles
-from ui.config.ui_config import get_settings, update_settings, get_feature_flags
+from ui_logic.hooks.rbac import require_roles
+from ui_logic.config.ui_config import get_settings, update_settings, get_feature_flags
 
 def fetch_settings(user_ctx):
     """Retrieve all settings for the given user context."""

--- a/src/ui_logic/components/settings/theme_switcher.py
+++ b/src/ui_logic/components/settings/theme_switcher.py
@@ -4,8 +4,8 @@ Kari Theme Switcher Logic (Framework-Agnostic)
 - Never renders UI (import in UI skin only)
 """
 
-from ui.config.branding import get_available_themes, set_theme_for_user
-from ui.hooks.rbac import require_roles
+from ui_logic.config.branding import get_available_themes, set_theme_for_user
+from ui_logic.hooks.rbac import require_roles
 
 def fetch_available_themes(user_ctx):
     if not user_ctx or not require_roles(user_ctx, ["user", "admin"]):

--- a/src/ui_logic/components/white_label/api_tokens_panel.py
+++ b/src/ui_logic/components/white_label/api_tokens_panel.py
@@ -7,8 +7,8 @@ Kari API Tokens Management Logic (Framework-Agnostic)
 import uuid
 import datetime
 from typing import List, Dict, Optional
-from ui.hooks.rbac import require_roles
-from ui.utils.api import get_api_token_store, save_api_token, revoke_api_token, fetch_audit_logs
+from ui_logic.hooks.rbac import require_roles
+from ui_logic.utils.api import get_api_token_store, save_api_token, revoke_api_token, fetch_audit_logs
 
 def list_api_tokens(user_ctx: Dict) -> List[Dict]:
     """Return all API tokens for the user (RBAC: admin/developer only)."""

--- a/src/ui_logic/components/white_label/branding_center.py
+++ b/src/ui_logic/components/white_label/branding_center.py
@@ -5,8 +5,8 @@ Kari Branding Center Logic (Framework-Agnostic)
 """
 
 from typing import Dict, Optional
-from ui.hooks.rbac import require_roles
-from ui.utils.api import (
+from ui_logic.hooks.rbac import require_roles
+from ui_logic.utils.api import (
     fetch_branding_config,
     save_branding_config,
     fetch_audit_logs

--- a/src/ui_logic/components/white_label/widget_builder.py
+++ b/src/ui_logic/components/white_label/widget_builder.py
@@ -5,8 +5,8 @@ Kari Widget Builder Logic (Framework-Agnostic)
 """
 
 from typing import Dict, List, Optional
-from ui.hooks.rbac import require_roles
-from ui.utils.api import (
+from ui_logic.hooks.rbac import require_roles
+from ui_logic.utils.api import (
     list_widgets, 
     save_widget, 
     delete_widget, 

--- a/src/ui_logic/pages/automation.py
+++ b/src/ui_logic/pages/automation.py
@@ -1,8 +1,8 @@
 """Automation dashboard stub with role and feature gating."""
 
-from ui.config.feature_flags import get_flag
-from ui.hooks.auth import get_current_user
-from ui.hooks.rbac import check_rbac
+from ui_logic.config.feature_flags import get_flag
+from ui_logic.hooks.auth import get_current_user
+from ui_logic.hooks.rbac import check_rbac
 
 REQUIRED_ROLES = ["user", "admin"]
 FEATURE_FLAG = "enable_workflows"

--- a/src/ui_logic/pages/code_lab.py
+++ b/src/ui_logic/pages/code_lab.py
@@ -1,8 +1,8 @@
 """In-browser code lab page stub for experimentation."""
 
-from ui.config.feature_flags import get_flag
-from ui.hooks.auth import get_current_user
-from ui.hooks.rbac import check_rbac
+from ui_logic.config.feature_flags import get_flag
+from ui_logic.hooks.auth import get_current_user
+from ui_logic.hooks.rbac import check_rbac
 
 REQUIRED_ROLES = ["dev", "admin"]
 FEATURE_FLAG = "show_experimental"

--- a/src/ui_logic/pages/context.py
+++ b/src/ui_logic/pages/context.py
@@ -1,8 +1,8 @@
 """Session context explorer page stub."""
 
-from ui.config.feature_flags import get_flag
-from ui.hooks.auth import get_current_user
-from ui.hooks.rbac import check_rbac
+from ui_logic.config.feature_flags import get_flag
+from ui_logic.hooks.auth import get_current_user
+from ui_logic.hooks.rbac import check_rbac
 
 REQUIRED_ROLES = ["user", "admin"]
 FEATURE_FLAG = "enable_memory_graph"

--- a/src/ui_logic/pages/diagnostics.py
+++ b/src/ui_logic/pages/diagnostics.py
@@ -1,8 +1,8 @@
 """System diagnostics and metrics page stub."""
 
-from ui.config.feature_flags import get_flag
-from ui.hooks.auth import get_current_user
-from ui.hooks.rbac import check_rbac
+from ui_logic.config.feature_flags import get_flag
+from ui_logic.hooks.auth import get_current_user
+from ui_logic.hooks.rbac import check_rbac
 
 REQUIRED_ROLES = ["admin"]
 FEATURE_FLAG = "enable_admin_panel"

--- a/src/ui_logic/pages/echo_core.py
+++ b/src/ui_logic/pages/echo_core.py
@@ -1,8 +1,8 @@
 """EchoCore profile and tuning page stub."""
 
-from ui.config.feature_flags import get_flag
-from ui.hooks.auth import get_current_user
-from ui.hooks.rbac import check_rbac
+from ui_logic.config.feature_flags import get_flag
+from ui_logic.hooks.auth import get_current_user
+from ui_logic.hooks.rbac import check_rbac
 
 REQUIRED_ROLES = ["admin"]
 FEATURE_FLAG = "enable_premium"

--- a/src/ui_logic/pages/files.py
+++ b/src/ui_logic/pages/files.py
@@ -1,8 +1,8 @@
 """File management and upload page stub."""
 
-from ui.config.feature_flags import get_flag
-from ui.hooks.auth import get_current_user
-from ui.hooks.rbac import check_rbac
+from ui_logic.config.feature_flags import get_flag
+from ui_logic.hooks.auth import get_current_user
+from ui_logic.hooks.rbac import check_rbac
 
 REQUIRED_ROLES = ["user", "admin"]
 FEATURE_FLAG = "enable_multimodal"

--- a/src/ui_logic/pages/integrations.py
+++ b/src/ui_logic/pages/integrations.py
@@ -1,8 +1,8 @@
 """Third‑party integrations management stub."""
 
-from ui.config.feature_flags import get_flag
-from ui.hooks.auth import get_current_user
-from ui.hooks.rbac import check_rbac
+from ui_logic.config.feature_flags import get_flag
+from ui_logic.hooks.auth import get_current_user
+from ui_logic.hooks.rbac import check_rbac
 
 REQUIRED_ROLES = ["admin", "dev"]
 FEATURE_FLAG = "enable_plugins"

--- a/src/ui_logic/pages/labs.py
+++ b/src/ui_logic/pages/labs.py
@@ -1,8 +1,8 @@
 """Experimental labs UI stub gated by feature flags."""
 
-from ui.config.feature_flags import get_flag
-from ui.hooks.auth import get_current_user
-from ui.hooks.rbac import check_rbac
+from ui_logic.config.feature_flags import get_flag
+from ui_logic.hooks.auth import get_current_user
+from ui_logic.hooks.rbac import check_rbac
 
 REQUIRED_ROLES = ["dev", "admin"]
 FEATURE_FLAG = "show_experimental"

--- a/src/ui_logic/pages/personas.py
+++ b/src/ui_logic/pages/personas.py
@@ -1,8 +1,8 @@
 """Persona library and editor stub."""
 
-from ui.config.feature_flags import get_flag
-from ui.hooks.auth import get_current_user
-from ui.hooks.rbac import check_rbac
+from ui_logic.config.feature_flags import get_flag
+from ui_logic.hooks.auth import get_current_user
+from ui_logic.hooks.rbac import check_rbac
 
 REQUIRED_ROLES = ["user", "admin"]
 FEATURE_FLAG = "enable_premium"

--- a/src/ui_logic/pages/security.py
+++ b/src/ui_logic/pages/security.py
@@ -1,8 +1,8 @@
 """Security settings and audit page stub."""
 
-from ui.config.feature_flags import get_flag
-from ui.hooks.auth import get_current_user
-from ui.hooks.rbac import check_rbac
+from ui_logic.config.feature_flags import get_flag
+from ui_logic.hooks.auth import get_current_user
+from ui_logic.hooks.rbac import check_rbac
 
 REQUIRED_ROLES = ["admin"]
 FEATURE_FLAG = "enable_enterprise"

--- a/src/ui_logic/pages/task_manager.py
+++ b/src/ui_logic/pages/task_manager.py
@@ -1,8 +1,8 @@
 """Task Manager UI page stub with RBAC and feature gating."""
 
-from ui.config.feature_flags import get_flag
-from ui.hooks.auth import get_current_user
-from ui.hooks.rbac import check_rbac
+from ui_logic.config.feature_flags import get_flag
+from ui_logic.hooks.auth import get_current_user
+from ui_logic.hooks.rbac import check_rbac
 
 REQUIRED_ROLES = ["user", "dev"]
 FEATURE_FLAG = "enable_workflows"

--- a/src/ui_logic/pages/vision.py
+++ b/src/ui_logic/pages/vision.py
@@ -1,8 +1,8 @@
 """Computer vision and OCR page stub."""
 
-from ui.config.feature_flags import get_flag
-from ui.hooks.auth import get_current_user
-from ui.hooks.rbac import check_rbac
+from ui_logic.config.feature_flags import get_flag
+from ui_logic.hooks.auth import get_current_user
+from ui_logic.hooks.rbac import check_rbac
 
 REQUIRED_ROLES = ["user", "admin"]
 FEATURE_FLAG = "enable_multimodal"

--- a/src/ui_logic/pages/voice.py
+++ b/src/ui_logic/pages/voice.py
@@ -1,8 +1,8 @@
 """Voice interface control page stub."""
 
-from ui.config.feature_flags import get_flag
-from ui.hooks.auth import get_current_user
-from ui.hooks.rbac import check_rbac
+from ui_logic.config.feature_flags import get_flag
+from ui_logic.hooks.auth import get_current_user
+from ui_logic.hooks.rbac import check_rbac
 
 REQUIRED_ROLES = ["user", "admin"]
 FEATURE_FLAG = "enable_voice_io"

--- a/src/ui_logic/pages/white_label.py
+++ b/src/ui_logic/pages/white_label.py
@@ -1,8 +1,8 @@
 """Enterprise white‑label configuration UI stub."""
 
-from ui.config.feature_flags import get_flag
-from ui.hooks.auth import get_current_user
-from ui.hooks.rbac import check_rbac
+from ui_logic.config.feature_flags import get_flag
+from ui_logic.hooks.auth import get_current_user
+from ui_logic.hooks.rbac import check_rbac
 
 REQUIRED_ROLES = ["enterprise"]
 FEATURE_FLAG = "show_branding_controls"

--- a/src/ui_logic/pages/workflows.py
+++ b/src/ui_logic/pages/workflows.py
@@ -1,8 +1,8 @@
 """Workflow builder and management page stub."""
 
-from ui.config.feature_flags import get_flag
-from ui.hooks.auth import get_current_user
-from ui.hooks.rbac import check_rbac
+from ui_logic.config.feature_flags import get_flag
+from ui_logic.hooks.auth import get_current_user
+from ui_logic.hooks.rbac import check_rbac
 
 REQUIRED_ROLES = ["admin"]
 FEATURE_FLAG = "enable_workflows"


### PR DESCRIPTION
## Summary
- switch imports from deprecated `ui.` prefix to `ui_logic.` across components and pages

## Testing
- `pytest -q` *(fails: ModuleNotFoundError and other import errors)*

------
https://chatgpt.com/codex/tasks/task_e_6868f8cd567083249253934674a4de40