### PR TITLE
Fix UI page stubs

### DIFF
--- a/src/ui_logic/pages/autonomous.py
+++ b/src/ui_logic/pages/autonomous.py
@@ -1,6 +1,36 @@
-def get_autonomous_ops(user_ctx):
-    # RBAC and flag check here!
-    if "admin" not in user_ctx.get("roles", []):
-        raise PermissionError("Unauthorized.")
-    # Query running agents, queued tasks, their status.
-    return {"agents": [...], "tasks": [...], "status": "Nominal"}
+"""Autonomous agent operations page stub."""
+
+from ui_logic.config.feature_flags import get_flag
+from ui_logic.hooks.auth import get_current_user
+from ui_logic.hooks.rbac import check_rbac
+
+
+REQUIRED_ROLES = ["admin"]
+FEATURE_FLAG = "enable_autonomous_ops"
+
+
+def render_page(user_ctx: dict | None = None) -> None:
+    """Render the autonomous operations page if permitted.
+
+    Args:
+        user_ctx: Optional user context dictionary.
+
+    Raises:
+        PermissionError: If RBAC check fails.
+        RuntimeError: If the autonomous ops feature is disabled.
+        NotImplementedError: Always raised as this page is a placeholder.
+    """
+
+    user = user_ctx or get_current_user()
+    if not check_rbac(user, REQUIRED_ROLES):
+        raise PermissionError("Unauthorized access to Autonomous page")
+    if not get_flag(FEATURE_FLAG):
+        raise RuntimeError("Autonomous operations disabled")
+    raise NotImplementedError("Autonomous page not implemented")
+
+
+if __name__ == "__main__":
+    try:
+        render_page({})
+    except NotImplementedError:
+        print("Autonomous page stub")

--- a/src/ui_logic/pages/context.py
+++ b/src/ui_logic/pages/context.py
@@ -27,3 +27,10 @@ def render_page(user_ctx: dict | None = None) -> None:
         raise RuntimeError("Memory graph disabled")
     raise NotImplementedError("Context page not implemented")
 
+
+if __name__ == "__main__":
+    try:
+        render_page({})
+    except NotImplementedError:
+        print("Context page stub")
+

--- a/src/ui_logic/pages/task_manager.py
+++ b/src/ui_logic/pages/task_manager.py
@@ -27,3 +27,10 @@ def render_page(user_ctx: dict | None = None) -> None:
         raise RuntimeError("Task Manager feature is disabled")
     raise NotImplementedError("Task Manager page not implemented")
 
+
+if __name__ == "__main__":
+    try:
+        render_page({})
+    except NotImplementedError:
+        print("Task Manager page stub")
+


### PR DESCRIPTION
## Summary
- add RBAC/feature gating stub for `autonomous` page
- add smoke test blocks to `context` and `task_manager`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'ui.common')*

------
https://chatgpt.com/codex/tasks/task_e_6868f89c395c8324a979e8a1ee97cd87