### PR TITLE
Fix page imports

### DIFF
--- a/src/ui_logic/pages/admin.py
+++ b/src/ui_logic/pages/admin.py
@@ -4,11 +4,12 @@ Kari Admin Page
 - Only layout and context passing
 """
 
-from components.admin.diagnostics import render_diagnostics
-from components.admin.org_admin import render_org_admin
-from components.admin.audit_log import render_audit_log
-from components.admin.rbac_panel import render_rbac_panel
-from components.admin.system_status import render_system_status
+from ui_logic.components.admin.audit_log import render_audit_log
+from ui_logic.components.admin.diagnostics import render_diagnostics
+from ui_logic.components.admin.org_admin import render_org_admin
+from ui_logic.components.admin.rbac_panel import render_rbac_panel
+from ui_logic.components.admin.system_status import render_system_status
+
 
 def admin_page(user_ctx=None):
     # Top: System Status + Diagnostics

--- a/src/ui_logic/pages/analytics.py
+++ b/src/ui_logic/pages/analytics.py
@@ -3,9 +3,10 @@ Kari Analytics Page
 - Orchestrates: auto-parser, chart builder, data explorer
 """
 
-from components.analytics.auto_parser import render_auto_parser
-from components.analytics.chart_builder import render_chart_builder
-from components.analytics.data_explorer import render_data_explorer
+from ui_logic.components.analytics.auto_parser import render_auto_parser
+from ui_logic.components.analytics.chart_builder import render_chart_builder
+from ui_logic.components.analytics.data_explorer import render_data_explorer
+
 
 def analytics_page(user_ctx=None):
     render_auto_parser(user_ctx=user_ctx)

--- a/src/ui_logic/pages/home.py
+++ b/src/ui_logic/pages/home.py
@@ -3,7 +3,9 @@ Kari Home Page
 - Orchestrates: Onboarding, activity, branding, news/announcements
 """
 
-from components.white_label.branding_center import render_branding_center
+from ui_logic.components.white_label.branding_center import \
+    render_branding_center
+
 
 def home_page(user_ctx=None):
     # Welcome and Branding

--- a/src/ui_logic/pages/iot.py
+++ b/src/ui_logic/pages/iot.py
@@ -3,9 +3,10 @@ Kari IoT Page
 - Orchestrates: device manager, iot logs, scene builder
 """
 
-from components.iot.device_manager import render_device_manager
-from components.iot.iot_logs import render_iot_logs
-from components.iot.scene_builder import render_scene_builder
+from ui_logic.components.iot.device_manager import render_device_manager
+from ui_logic.components.iot.iot_logs import render_iot_logs
+from ui_logic.components.iot.scene_builder import render_scene_builder
+
 
 def iot_page(user_ctx=None):
     render_device_manager(user_ctx=user_ctx)

--- a/src/ui_logic/pages/memory.py
+++ b/src/ui_logic/pages/memory.py
@@ -3,10 +3,11 @@ Kari Memory Page
 - Orchestrates: knowledge graph, session explorer, profile, analytics
 """
 
-from components.memory.knowledge_graph import render_knowledge_graph
-from components.memory.session_explorer import render_session_explorer
-from components.memory.profile_panel import render_profile_panel
-from components.memory.memory_analytics import render_memory_analytics
+from ui_logic.components.memory.knowledge_graph import render_knowledge_graph
+from ui_logic.components.memory.memory_analytics import render_memory_analytics
+from ui_logic.components.memory.profile_panel import render_profile_panel
+from ui_logic.components.memory.session_explorer import render_session_explorer
+
 
 def memory_page(user_ctx=None):
     render_session_explorer(user_ctx=user_ctx)

--- a/src/ui_logic/pages/plugins.py
+++ b/src/ui_logic/pages/plugins.py
@@ -3,9 +3,11 @@ Kari Plugins Page
 - Orchestrates: plugin manager, plugin store, workflow builder
 """
 
-from components.plugins.plugin_manager import render_plugin_manager
-from components.plugins.plugin_store import render_plugin_store
-from components.plugins.workflow_builder import render_workflow_builder
+from ui_logic.components.plugins.plugin_manager import render_plugin_manager
+from ui_logic.components.plugins.plugin_store import render_plugin_store
+from ui_logic.components.plugins.workflow_builder import \
+    render_workflow_builder
+
 
 def plugins_page(user_ctx=None):
     render_plugin_store(user_ctx=user_ctx)

--- a/src/ui_logic/pages/settings.py
+++ b/src/ui_logic/pages/settings.py
@@ -3,10 +3,11 @@ Kari Settings Page
 - Orchestrates: settings panel, privacy console, API vault, theme switcher
 """
 
-from components.settings.settings_panel import render_settings_panel
-from components.settings.privacy_console import render_privacy_console
-from components.settings.api_vault import render_api_vault
-from components.settings.theme_switcher import render_theme_switcher
+from ui_logic.components.settings.api_vault import render_api_vault
+from ui_logic.components.settings.privacy_console import render_privacy_console
+from ui_logic.components.settings.settings_panel import render_settings_panel
+from ui_logic.components.settings.theme_switcher import render_theme_switcher
+
 
 def settings_page(user_ctx=None):
     render_settings_panel(user_ctx=user_ctx)


### PR DESCRIPTION
## Summary
- reference components through the `ui_logic` package

## Testing
- `black src/ui_logic/pages/home.py src/ui_logic/pages/settings.py src/ui_logic/pages/plugins.py src/ui_logic/pages/analytics.py src/ui_logic/pages/admin.py src/ui_logic/pages/memory.py src/ui_logic/pages/iot.py`
- `isort src/ui_logic/pages/analytics.py src/ui_logic/pages/iot.py`
- `ruff check src/ui_logic/pages/home.py src/ui_logic/pages/settings.py src/ui_logic/pages/plugins.py src/ui_logic/pages/analytics.py src/ui_logic/pages/admin.py src/ui_logic/pages/memory.py src/ui_logic/pages/iot.py`
- `mypy src/ui_logic/pages/home.py src/ui_logic/pages/settings.py src/ui_logic/pages/plugins.py src/ui_logic/pages/analytics.py src/ui_logic/pages/admin.py src/ui_logic/pages/memory.py src/ui_logic/pages/iot.py` *(fails: Cannot find implementation or library stub)*
- `pytest tests/test_cli.py -q` *(fails: KARI_MODEL_SIGNING_KEY must be set in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_6868f8e845248324b9dca6e1455e0400