### PR TITLE
Refactor page imports

### DIFF
--- a/src/ui_logic/pages/__init__.py
+++ b/src/ui_logic/pages/__init__.py
@@ -4,14 +4,14 @@ Kari UI Page Loader
 - All page modules imported and registered for central routing
 """
 
-from .admin import *
-from .analytics import *
-from .chat import *
-from .home import *
-from .iot import *
-from .memory import *
-from .plugins import *
-from .settings import *
+from ui_logic.pages.admin import admin_page
+from ui_logic.pages.analytics import analytics_page
+from ui_logic.pages.chat import chat_logic, get_chat_page
+from ui_logic.pages.home import home_page
+from ui_logic.pages.iot import iot_page
+from ui_logic.pages.memory import memory_page
+from ui_logic.pages.plugins import plugins_page
+from ui_logic.pages.settings import settings_page
 
 # Registry for dynamic UI routers
 PAGES = {
@@ -25,15 +25,27 @@ PAGES = {
     "settings": "Settings & Privacy",
 }
 
+
 def list_pages():
     """List all available top-level UI pages for navigation."""
     return list(PAGES.keys())
+
 
 def get_page_label(page: str) -> str:
     """Get the pretty label for any page route."""
     return PAGES.get(page, page.title())
 
+
 __all__ = [
+    "admin_page",
+    "analytics_page",
+    "chat_logic",
+    "get_chat_page",
+    "home_page",
+    "iot_page",
+    "memory_page",
+    "plugins_page",
+    "settings_page",
     "PAGES",
     "list_pages",
     "get_page_label",


### PR DESCRIPTION
## Summary
- import explicit page modules using absolute paths
- export a clean `__all__` list for UI pages

## Testing
- `ruff check src/ui_logic/pages/__init__.py`
- `black src/ui_logic/pages/__init__.py --check` *(after formatting)*
- `isort src/ui_logic/pages/__init__.py --check --profile=black`
- `mypy --strict src/ui_logic/pages/__init__.py` *(fails: module stubs missing)*
- `pytest -q` *(fails: missing environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_6868f8e18ed883249aba49f1ed7a8874