### PR TITLE
Fix imports for Streamlit UI pages

### DIFF
--- a/ui_launchers/streamlit_ui/config/routing.py
+++ b/ui_launchers/streamlit_ui/config/routing.py
@@ -2,14 +2,14 @@
 Streamlit UI Routing Table (no business logic)
 Maps display names to page launchers.
 """
-from pages.home import home_page
-from pages.chat import chat_page
-from pages.analytics import analytics_page
-from pages.plugins import plugins_page
-from pages.iot import iot_page
-from pages.memory import memory_page
-from pages.admin import admin_page
-from pages.settings import settings_page
+from ui_logic.pages.home import home_page
+from ui_logic.pages.chat import chat_page
+from ui_logic.pages.analytics import analytics_page
+from ui_logic.pages.plugins import plugins_page
+from ui_logic.pages.iot import iot_page
+from ui_logic.pages.memory import memory_page
+from ui_logic.pages.admin import admin_page
+from ui_logic.pages.settings import settings_page
 
 PAGE_MAP = {
     "Home": home_page,

--- a/ui_launchers/streamlit_ui/pages/admin.py
+++ b/ui_launchers/streamlit_ui/pages/admin.py
@@ -1,0 +1,8 @@
+"""Streamlit launcher for :func:`ui_logic.pages.admin.admin_page`."""
+
+from ui_logic.pages.admin import admin_page as _admin_page
+
+
+def admin_page(user_ctx=None):
+    """Wrapper that forwards to :func:`ui_logic.pages.admin.admin_page`."""
+    _admin_page(user_ctx=user_ctx)

--- a/ui_launchers/streamlit_ui/pages/analytics.py
+++ b/ui_launchers/streamlit_ui/pages/analytics.py
@@ -1,0 +1,8 @@
+"""Streamlit launcher for :func:`ui_logic.pages.analytics.analytics_page`."""
+
+from ui_logic.pages.analytics import analytics_page as _analytics_page
+
+
+def analytics_page(user_ctx=None):
+    """Wrapper that forwards to :func:`ui_logic.pages.analytics.analytics_page`."""
+    _analytics_page(user_ctx=user_ctx)

--- a/ui_launchers/streamlit_ui/pages/chat.py
+++ b/ui_launchers/streamlit_ui/pages/chat.py
@@ -1,5 +1,8 @@
-from pages.chat import chat_page as _chat_page
+"""Streamlit launcher for :func:`ui_logic.pages.chat.chat_page`."""
+
+from ui_logic.pages.chat import chat_page as _chat_page
 
 
 def chat_page(user_ctx=None):
+    """Wrapper that forwards to :func:`ui_logic.pages.chat.chat_page`."""
     _chat_page(user_ctx=user_ctx)

--- a/ui_launchers/streamlit_ui/pages/memory.py
+++ b/ui_launchers/streamlit_ui/pages/memory.py
@@ -1,0 +1,8 @@
+"""Streamlit launcher for :func:`ui_logic.pages.memory.memory_page`."""
+
+from ui_logic.pages.memory import memory_page as _memory_page
+
+
+def memory_page(user_ctx=None):
+    """Wrapper that forwards to :func:`ui_logic.pages.memory.memory_page`."""
+    _memory_page(user_ctx=user_ctx)

--- a/ui_launchers/streamlit_ui/pages/plugins.py
+++ b/ui_launchers/streamlit_ui/pages/plugins.py
@@ -1,0 +1,8 @@
+"""Streamlit launcher for :func:`ui_logic.pages.plugins.plugins_page`."""
+
+from ui_logic.pages.plugins import plugins_page as _plugins_page
+
+
+def plugins_page(user_ctx=None):
+    """Wrapper that forwards to :func:`ui_logic.pages.plugins.plugins_page`."""
+    _plugins_page(user_ctx=user_ctx)


### PR DESCRIPTION
## Summary
- reference ui_logic page functions via absolute paths
- wrap analytics, memory, plugins and admin pages
- document Streamlit page wrappers

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'ui.common')*

------
https://chatgpt.com/codex/tasks/task_e_6868f88df9c483249c8954c32e0cbbf8