### PR TITLE
Update dev docs for new UI paths

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ Every “agent”—human, AI, or meta-agent—in this repo is bound by one Law:
 ## 1. **Agent Core Principle**
 
 * **All core runtime logic, plugins, clients, integrations, and engines live under `src/ai_karen_engine/` as independent, importable modules.**
-* **UI is always at repo root under `/ui/{mobile_ui,desktop_ui,admin_ui}/`—never mixed with backend or core.**
+* **UI launchers live under `/ui_launchers/{streamlit_ui,desktop_ui,admin_ui}/`—never mixed with backend or core.**
 * **No relative imports. No sys.path hacks. All imports are absolute: `ai_karen_engine.<module>...`**
 
 ---
@@ -86,7 +86,7 @@ from ai_karen_engine.echocore.fine_tuner import FineTuner
 * All core runtime logic lives under `src/ai_karen_engine/`.
 * Every major subsystem (plugins, clients, integrations, core, event\_bus, self\_refactor, echocore, etc.) is its own subfolder—pip and repo ready.
 * Repo-level configs, docs, Docker, scripts, tests, and bootstraps stay top-level.
-* UI folders (`ui/mobile_ui`, `ui/desktop_ui`, `ui/admin_ui`) remain top-level only.
+* UI launcher folders (`ui_launchers/streamlit_ui`, `ui_launchers/desktop_ui`, `ui_launchers/admin_ui`) remain top-level only.
 
 #### Example Tree
 
@@ -104,12 +104,11 @@ AI-Karen/
 │       ├── plugins/
 │       ├── self_refactor/
 │       ├── event_bus/
-│       ├── echocore/
-│       └── ui/
-└── ui/
+│       └── echocore/
+ui_launchers/
     ├── admin_ui/
     ├── desktop_ui/
-    └── mobile_ui/
+    └── streamlit_ui/
 ```
 
 ### Import Rules

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ guardrails/    # YAML validators
 capsules/      # domain-specific micro agents
 src/integrations/  # helper utilities (RPA, automation)
 src/plugins/       # drop-in plugins (manifest + handler)
-ui/            # Frontend UIs (desktop, mobile, admin)
+ui_launchers/  # Frontend UIs (desktop, mobile, admin)
 src/fastapi_stub/  # lightweight stubs for tests
 src/pydantic_stub/ # lightweight stubs for tests
 tests/         # pytest suite
@@ -93,8 +93,8 @@ guardrails/    # YAML validators & rule engine
 capsules/      # domain-specific agents (DevOps, Finance, …)
 src/integrations/  # NANDA client, RPA helpers, external bridges
 src/plugins/       # drop-in plugins (manifest + handler + ui)
-ui/desktop_ui/ # Tauri Control Room (Rust + React)
-ui/mobile_ui/config/config_ui.py # Streamlit UI settings (ConfigUI class)
+ui_launchers/desktop_ui/ # Tauri Control Room (Rust + React)
+ui_launchers/streamlit_ui/config/config_ui.py # Streamlit UI settings (ConfigUI class)
 src/fastapi_stub/  # API entrypoints, chat & metrics
 src/pydantic_stub/ # DTOs & schemas
 tests/         # pytest suite
@@ -123,16 +123,16 @@ python scripts/install_models.py
 cargo install tauri-cli
 
 # 3 · Install Control Room packages
-cd ui/desktop_ui && npm install
+cd ui_launchers/desktop_ui && npm install
 
-# The Tauri configuration lives in `ui/desktop_ui/src-tauri/tauri.config.json`.
+# The Tauri configuration lives in `ui_launchers/desktop_ui/src-tauri/tauri.config.json`.
 # Make sure this file exists before running desktop commands.
 
 # 4 · Launch backend API + dependencies
 ./scripts/start.sh
 
 # 5 · Run desktop Control Room (dev mode)
-cd ui/desktop_ui && tauri dev  # uses src-tauri/tauri.config.json
+cd ui_launchers/desktop_ui && tauri dev  # uses src-tauri/tauri.config.json
 ```
 
 # Optional: run everything with one command
@@ -147,7 +147,7 @@ cd ui/desktop_ui && tauri dev  # uses src-tauri/tauri.config.json
 
 Build signed desktop binaries:
 ```bash
-cd ui/desktop_ui
+cd ui_launchers/desktop_ui
 tauri build          # outputs .app / .exe / .AppImage using src-tauri/tauri.config.json
 
 ```
@@ -174,7 +174,6 @@ cargo install tauri-cli
 ### 2. Start FastAPI
 
 ```bash
-cd backend
 uvicorn main:app --reload
 ```
 
@@ -201,7 +200,7 @@ package. The server now exits with an error if such a folder exists.
 ### 3. Start Frontend (optional)
 
 ```bash
-cd ui/desktop_ui
+cd ui_launchers/desktop_ui
 pnpm install
 pnpm run dev
 ```
@@ -209,12 +208,12 @@ pnpm run dev
 ### 4. Start Tauri Desktop App
 
 ```bash
-cd ui/desktop_ui
+cd ui_launchers/desktop_ui
 pnpm install
 npx tauri dev
 ```
 
-📦 Ensure `tauri.config.json` is under `ui/desktop_ui/src-tauri/`
+📦 Ensure `tauri.config.json` is under `ui_launchers/desktop_ui/src-tauri/`
 
 ### API Usage
 
@@ -228,7 +227,7 @@ commands.
 
  
 # Launch Control Room
-cd ui/desktop_ui && tauri dev  # hot reloads the desktop shell using src-tauri/tauri.config.json
+cd ui_launchers/desktop_ui && tauri dev  # hot reloads the desktop shell using src-tauri/tauri.config.json
 
 | Task               | Command                                |
 | ------------------ | -------------------------------------- |
@@ -245,8 +244,8 @@ pre-commit install
 ```
 Ruff also enforces the UI boundaries described in `AGENTS.md`:
 
-* relative imports are forbidden inside `ui/`
-* modules under `src/ui/` may not import from the top-level `ui` package
+* relative imports are forbidden inside `ui_launchers/`
+* modules under `src/ui_logic/` may not import from the top-level `ui_launchers` package
 
 See `pyproject.toml` for the full configuration.
 ### Advanced / Unrestricted Mode
@@ -293,7 +292,7 @@ Drop the folder—Kari discovers it, registers routes, and injects UI automatica
 * **Memory Matrix** – inspect vector hits & decay curves
 * **Logs & Trace** – Prometheus charts, OT spans, SRE patch history
 
-Updates are typically released once a month. See `ui/desktop_ui/README.md` for the latest cycle notes.
+Updates are typically released once a month. See `ui_launchers/desktop_ui/README.md` for the latest cycle notes.
 
 Runs as a native Tauri app; all traffic stays on `localhost`.
 
@@ -398,5 +397,5 @@ The Hydra-Ops capsule design is further detailed in `docs/mesh_arch.md`.
 * Example plugins: hello-world, desktop agent, HF LLM, OpenAI LLM
 * Tests: `pytest -q`
 * More in `DEV_SHEET.md` — happy hacking!
-* See `ui/desktop_ui/README.md` for Control Room navigation tips.
+* See `ui_launchers/desktop_ui/README.md` for Control Room navigation tips.
  

--- a/docs/development_guide.md
+++ b/docs/development_guide.md
@@ -16,10 +16,10 @@ uvicorn main:app --reload --port 8000
 xdg-open http://localhost:8000/docs
 
 # run the Streamlit UI
-streamlit run ui/mobile_ui/app.py
+streamlit run ui_launchers/streamlit_ui/app.py
 ```
 The Streamlit UI reads environment variables via
-`ui/mobile_ui/config/config_ui.py`.
+`ui_launchers/streamlit_ui/config/config_ui.py`.
 If you previously imported `config/config_ui.py`, switch to this new path.
 
 ## Build Mode (Tauri App)
@@ -31,7 +31,7 @@ Use this path to compile the full Tauri desktop application.
 source "$HOME/.cargo/env"
 cargo install tauri-cli
 
-# Both `tauri dev` and `tauri build` use `desktop_ui/src-tauri/tauri.config.json`
+# Both `tauri dev` and `tauri build` use `ui_launchers/desktop_ui/src-tauri/tauri.config.json`
 # as the configuration file.
 
 # run in development mode with hot reload
@@ -46,7 +46,7 @@ tauri build
 | Mode          | Command                             | Description                         |
 | ------------- | ----------------------------------- | ----------------------------------- |
 | Dev (API)     | `uvicorn main:app --reload`         | Hot reload the backend              |
-| Dev (UI)      | `streamlit run ui/mobile_ui/app.py` | Streamlit UI for quick tests        |
+| Dev (UI)      | `streamlit run ui_launchers/streamlit_ui/app.py` | Streamlit UI for quick tests        |
 | Tauri Dev     | `tauri dev`                         | Desktop shell with live reload      |
 | Build         | `tauri build`                       | Create installable binaries         |
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -28,5 +28,5 @@ Grafana dashboards should include:
 | Vector Search     | `vector_search_latency_seconds` |
 | Memory Usage      | Custom Python gauge or system metric |
 
-See `ui/desktop_ui/README.md` for adding the metrics dashboard to the Control Room.
+See `ui_launchers/desktop_ui/README.md` for adding the metrics dashboard to the Control Room.
 The new Diagnostics page surfaces the output of `get_system_health()` with a JSON viewer.

--- a/docs/security.md
+++ b/docs/security.md
@@ -30,5 +30,5 @@ Build artifacts are signed using ed25519 keys. Verify signatures before deployin
 gpg --verify kari-desktop.tar.gz.sig kari-desktop.tar.gz
 ```
 
-See `ui/desktop_ui/README.md` for secure UI practices and [docs/plugin_spec.md](plugin_spec.md) for plugin-level permissions.
+See `ui_launchers/desktop_ui/README.md` for secure UI practices and [docs/plugin_spec.md](plugin_spec.md) for plugin-level permissions.
 

--- a/docs/ui_blueprint.md
+++ b/docs/ui_blueprint.md
@@ -33,4 +33,4 @@ This document outlines the high level design goals for the Kari user interface. 
 - Transparency log of what Kari has stored with delete/export options.
 - Consent flows for personal profiling and EchoCore learning.
 
-This blueprint acts as a guideline for building a modular, user focused interface. Features should remain configurable through feature flags and developed as independent components under the `ui/` directory.
+This blueprint acts as a guideline for building a modular, user focused interface. Features should remain configurable through feature flags and developed as independent components under the `ui_launchers/` directory.

--- a/ui_launchers/README.md
+++ b/ui_launchers/README.md
@@ -3,17 +3,17 @@
 This directory groups all frontend user interfaces.
 
 ```
-ui/
-├── common/      # shared widgets, hooks, themes
-├── desktop_ui/  # Tauri React desktop shell
-├── mobile_ui/   # Streamlit mobile interface
-├── admin_ui/    # Admin dashboard
+ui_launchers/
+├── common/        # shared widgets, hooks, themes
+├── desktop_ui/    # Tauri React desktop shell
+├── streamlit_ui/  # Streamlit mobile interface
+├── admin_ui/      # Admin dashboard
 ```
 
 Run the mobile UI with:
 
 ```bash
-streamlit run ui/mobile_ui/app.py
+streamlit run ui_launchers/streamlit_ui/app.py
 ```
 
-The desktop UI uses Tauri and lives under `ui/desktop_ui`.
+The desktop UI uses Tauri and lives under `ui_launchers/desktop_ui`.

--- a/ui_launchers/streamlit_ui/README.md
+++ b/ui_launchers/streamlit_ui/README.md
@@ -8,10 +8,10 @@ Run the FastAPI backend and launch the UI:
 
 ```bash
 uvicorn main:app --reload
-streamlit run ui/mobile_ui/app.py
+streamlit run ui_launchers/streamlit_ui/app.py
 ```
 
 The UI includes chat and a task dashboard out of the box. A configuration panel
 lets you choose an LLM provider, model, and memory options. These widgets live in
-`ui/mobile_ui/components/` and can be reused across future pages. Settings are kept
+`ui_launchers/streamlit_ui/components/` and can be reused across future pages. Settings are kept
 locally in session state and can later be persisted to disk.


### PR DESCRIPTION
## Summary
- align AGENTS doctrine with `ui_launchers/` folder names
- refresh development guide, security, observability and UI blueprint docs
- fix streamlit UI README to use updated path

## Testing
- `pytest -q` *(fails: missing modules and configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6868df948adc83249a3bc00514758058