### PR TITLE
Update install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ For a detailed setup and troubleshooting guide, see [docs/install_dev.md](docs/i
 
 ```bash
 # 1 · Install Python deps
-./scripts/install.sh
+./scripts/install.sh  # installs requirements and runs `pip install -e .`
 # Download base models
 python scripts/install_models.py
 
@@ -134,6 +134,8 @@ cd ui_launchers/desktop_ui && npm install
 # 5 · Run desktop Control Room (dev mode)
 cd ui_launchers/desktop_ui && tauri dev  # uses src-tauri/tauri.config.json
 ```
+
+> **Note** The API server and Control Room require the packages under `src/` to be installed. The `install.sh` script runs `pip install -e .` for you.
 
 # Optional: run everything with one command
 ./scripts/bootstrap_ui.sh

--- a/docs/install_dev.md
+++ b/docs/install_dev.md
@@ -14,8 +14,12 @@ This guide walks through setting up Kari for local development and troubleshooti
    python3 -m venv .env
    source .env/bin/activate
    pip install -r requirements.txt
+   # install Kari packages in editable mode
+   pip install -e .
    python scripts/install_models.py
    ```
+
+> The API server and desktop UI both rely on the packages under `src/`. Running `pip install -e .` (or `scripts/install.sh`) ensures they are available before launching.
 2. **Remove any local `fastapi` directory** which would shadow the installed package:
    ```bash
    mv fastapi fastapi_local_backup  # or delete it


### PR DESCRIPTION
## Summary
- document that `install.sh` runs `pip install -e .`
- mention editable install requirement for API and UI
- add `pip install -e .` to install_dev guide

## Testing
- `pre-commit run --files README.md docs/install_dev.md` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_686919811d788324a3ea7f8e8329e9a4