### PR TITLE
Add packaging metadata and dev setup note

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,16 @@ npm install -g pnpm
 cargo install tauri-cli
 ```
 
+Before launching any Python entrypoints, make sure the packages under `src/`
+are on your `PYTHONPATH`. The easiest way is to install the repo in editable
+mode:
+
+```bash
+pip install -e .
+```
+
+Alternatively, set `PYTHONPATH=src` in your environment.
+
 ### 2. Start FastAPI
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,21 @@
 [tool.ruff]
 line-length = 100
 
+[project]
+name = "ai-karen"
+version = "0.1.0"
+description = "Kari AI modular engine"
+readme = "README.md"
+requires-python = ">=3.10"
+authors = [{ name = "Kari AI Team" }]
+license = { file = "LICENSE" }
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
 [tool.ruff.lint]
 extend-select = ["TID252", "TID251"]
 


### PR DESCRIPTION
## Summary
- include a `[project]` table with packaging metadata
- configure setuptools to find packages under `src/`
- document installing the repo in editable mode before running the app

## Testing
- `pip install -e . --no-deps --no-build-isolation` *(fails: BackendUnavailable: Cannot import 'setuptools.build_meta')*
- `python -m uvicorn main:app --port 8000` *(fails: No module named uvicorn)*
- `streamlit run ui_launchers/streamlit_ui/app.py` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6869194bec908324a0a2c73b37fde2ee