### PR TITLE
Update imports away from src.*

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,4 +6,4 @@ import sys
 # Alias installed-style packages for tests
 sys.modules.setdefault("ai_karen_engine", importlib.import_module("src.ai_karen_engine"))
 sys.modules.setdefault("ui_logic", importlib.import_module("src.ui_logic"))
-sys.modules.setdefault("services", importlib.import_module("src.services"))
+sys.modules.setdefault("services", importlib.import_module("ai_karen_engine.services"))

--- a/tests/test_advanced_ui.py
+++ b/tests/test_advanced_ui.py
@@ -1,6 +1,6 @@
 import types
 from ui_launchers.common.components import rbac
-from ..src.services import health_checker
+from ai_karen_engine.services import health_checker
 from fastapi.testclient import TestClient
 from main import app
 

--- a/tests/test_autonomous_agent.py
+++ b/tests/test_autonomous_agent.py
@@ -1,4 +1,4 @@
-from ..src.ai_karen_engine.core.autonomous_agent import AutonomousAgent
+from ai_karen_engine.core.autonomous_agent import AutonomousAgent
 
 
 def test_autonomous_agent(monkeypatch):

--- a/tests/test_echocore_modules.py
+++ b/tests/test_echocore_modules.py
@@ -1,5 +1,5 @@
-from ..src.ai_karen_engine.echocore.echo_vault import EchoVault
-from ..src.ai_karen_engine.echocore.dark_tracker import DarkTracker
+from ai_karen_engine.echocore.echo_vault import EchoVault
+from ai_karen_engine.echocore.dark_tracker import DarkTracker
 
 
 def test_vault_backup_restore(tmp_path):

--- a/tests/test_embedding_client.py
+++ b/tests/test_embedding_client.py
@@ -1,4 +1,4 @@
-from ..src.ai_karen_engine.clients.embedding.embedding_client import get_embedding
+from ai_karen_engine.clients.embedding.embedding_client import get_embedding
 
 
 def test_get_embedding_byte_and_default():

--- a/tests/test_ice_integration.py
+++ b/tests/test_ice_integration.py
@@ -1,6 +1,6 @@
 import asyncio
 
-from ..src.ai_karen_engine.core.reasoning.ice_integration import KariICEWrapper
+from ai_karen_engine.core.reasoning.ice_integration import KariICEWrapper
 
 
 def test_process_returns_keys():

--- a/tests/test_ice_multi_hop.py
+++ b/tests/test_ice_multi_hop.py
@@ -1,6 +1,6 @@
 import asyncio
 
-from ..src.ai_karen_engine.core.reasoning.ice_integration import KariICEWrapper
+from ai_karen_engine.core.reasoning.ice_integration import KariICEWrapper
 
 
 def test_multi_hop_flow():

--- a/tests/test_intent_engine.py
+++ b/tests/test_intent_engine.py
@@ -1,4 +1,4 @@
-from ..src.ai_karen_engine.core.intent_engine import IntentEngine
+from ai_karen_engine.core.intent_engine import IntentEngine
 
 
 def test_detect_intent():

--- a/tests/test_llm_orchestrator.py
+++ b/tests/test_llm_orchestrator.py
@@ -1,4 +1,4 @@
-from ..src.ai_karen_engine import SLMPool, LLMOrchestrator
+from ai_karen_engine import SLMPool, LLMOrchestrator
 from integrations.llm_utils import LLMUtils
 
 

--- a/tests/test_mesh_reasoning.py
+++ b/tests/test_mesh_reasoning.py
@@ -1,4 +1,4 @@
-from ..src.ai_karen_engine.core.mesh_planner import MeshPlanner
+from ai_karen_engine.core.mesh_planner import MeshPlanner
 
 
 def test_graph_crud():

--- a/tests/test_plugin_router.py
+++ b/tests/test_plugin_router.py
@@ -4,8 +4,8 @@ import sys
 from types import ModuleType
 import pytest
 
-from ..src.ai_karen_engine.plugin_router import AccessDenied, PluginRouter
-from ..src.core import plugin_router as core_plugin_router
+from ai_karen_engine.plugin_router import AccessDenied, PluginRouter
+from ai_karen_engine.core import plugin_router as core_plugin_router
 
 
 def ensure_optional_dependency(name: str):

--- a/tests/test_slm_pool.py
+++ b/tests/test_slm_pool.py
@@ -1,4 +1,4 @@
-from ..src.ai_karen_engine.clients.slm_pool import SLMPool
+from ai_karen_engine.clients.slm_pool import SLMPool
 from integrations.llm_utils import LLMUtils
 
 

--- a/tests/test_soft_reasoning.py
+++ b/tests/test_soft_reasoning.py
@@ -7,7 +7,7 @@ import asyncio
 
  
  
-from ..src.ai_karen_engine.core.soft_reasoning_engine import SoftReasoningEngine
+from ai_karen_engine.core.soft_reasoning_engine import SoftReasoningEngine
 
 
 def test_ingest_and_query():

--- a/tests/test_tenant_model_manager.py
+++ b/tests/test_tenant_model_manager.py
@@ -2,8 +2,8 @@ from pathlib import Path
 
 import pytest
 
-from ..src.ai_karen_engine.core import model_manager
-from ..src.ai_karen_engine.core.model_manager import ModelManager, LicenseError
+from ai_karen_engine.core import model_manager
+from ai_karen_engine.core.model_manager import ModelManager, LicenseError
 
 
 def test_tenant_create_and_delete(tmp_path: Path, monkeypatch) -> None:

--- a/tests/test_tokenizer_manager.py
+++ b/tests/test_tokenizer_manager.py
@@ -1,4 +1,4 @@
-from ..src.ai_karen_engine.core.tokenizer_manager import TokenizerManager
+from ai_karen_engine.core.tokenizer_manager import TokenizerManager
 
 
 def test_byte_encoding():


### PR DESCRIPTION
## Summary
- refactor tests to use `ai_karen_engine` imports instead of `src.*`
- keep alias loader but point services to `ai_karen_engine.services`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6869266466e88324836e0ff2acbba9f4