### PR TITLE
Fix PluginRouter import

### DIFF
--- a/src/ai_karen_engine/__init__.py
+++ b/src/ai_karen_engine/__init__.py
@@ -26,6 +26,12 @@ def __getattr__(name):
     if name == "SpaCyClient":
         from ai_karen_engine.clients.nlp.spacy_client import SpaCyClient as _SC
         return _SC
+    if name == "PluginRouter":
+        from ai_karen_engine.plugin_router import PluginRouter as _PR
+        return _PR
+    if name == "AccessDenied":
+        from ai_karen_engine.plugin_router import AccessDenied as _AD
+        return _AD
     raise AttributeError(name)
 
 __all__ = [


### PR DESCRIPTION
## Summary
- expose `PluginRouter` and `AccessDenied` through the package's `__getattr__`

## Testing
- `ruff check src/ai_karen_engine/__init__.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_686add544d14832496833e9f6933a0a5