### PR TITLE
Add ElasticSearch client and integrate with MemoryManager

### DIFF
--- a/docs/memory_arch.md
+++ b/docs/memory_arch.md
@@ -34,3 +34,15 @@ Results are ranked by cosine similarity and recency using an exponential decay c
 - **Surprise score** prevents storing data too similar to existing vectors.
 
 This system keeps the memory footprint small while allowing high recall accuracy. See [docs/observability.md](observability.md) for metrics exposed during upsert and search operations.
+
+## ElasticSearch Integration
+
+When ElasticSearch is available the memory manager uses it as the first lookup layer. Configure the connection via environment variables:
+
+- `ELASTIC_HOST` – host of the Elastic cluster (default `localhost`)
+- `ELASTIC_PORT` – port of the cluster (default `9200`)
+- `ELASTIC_USER` – basic auth user (optional)
+- `ELASTIC_PASSWORD` – password for the user (optional)
+- `ELASTIC_INDEX` – index name for Kari memory (default `kari_memory`)
+
+If these variables are unset the client falls back to its in-memory stub.

--- a/src/ai_karen_engine/clients/database/elastic_client.py
+++ b/src/ai_karen_engine/clients/database/elastic_client.py
@@ -1,0 +1,101 @@
+"""Lightweight ElasticSearch client with optional in-memory fallback."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+try:
+    from elasticsearch import Elasticsearch
+except Exception:  # pragma: no cover - optional dependency
+    Elasticsearch = None
+
+
+class ElasticClient:
+    """Simple helper for indexing and searching text documents."""
+
+    def __init__(
+        self,
+        host: str = "localhost",
+        port: int = 9200,
+        index: str = "kari_memory",
+        user: Optional[str] = None,
+        password: Optional[str] = None,
+        use_memory: bool = False,
+    ) -> None:
+        self.host = host
+        self.port = port
+        self.index = index
+        self.user = user
+        self.password = password
+        self.use_memory = use_memory or Elasticsearch is None
+        if not self.use_memory:
+            auth = (user, password) if user else None
+            self.es = Elasticsearch(
+                [{"host": host, "port": port, "scheme": "http"}],
+                basic_auth=auth,
+            )
+        else:
+            self._docs: List[Dict[str, Any]] = []
+
+    # ------------------------------------------------------------------
+    def ensure_index(self) -> None:
+        if self.use_memory:
+            return
+        if not self.es.indices.exists(index=self.index):  # type: ignore[union-attr]
+            mapping = {
+                "mappings": {
+                    "properties": {
+                        "user_id": {"type": "keyword"},
+                        "session_id": {"type": "keyword"},
+                        "query": {"type": "text"},
+                        "result": {"type": "text"},
+                        "timestamp": {"type": "long"},
+                    }
+                }
+            }
+            self.es.indices.create(index=self.index, **mapping)  # type: ignore[union-attr]
+
+    # ------------------------------------------------------------------
+    def index_entry(self, entry: Dict[str, Any]) -> None:
+        self.ensure_index()
+        if self.use_memory:
+            self._docs.append(entry)
+        else:
+            self.es.index(index=self.index, document=entry)  # type: ignore[union-attr]
+
+    # ------------------------------------------------------------------
+    def search(self, user_id: str, query: str, limit: int = 10) -> List[Dict[str, Any]]:
+        self.ensure_index()
+        if self.use_memory:
+            hits = [
+                d
+                for d in self._docs
+                if d.get("user_id") == user_id
+                and query.lower() in d.get("query", "").lower()
+            ]
+            return hits[:limit]
+        body = {
+            "size": limit,
+            "query": {
+                "bool": {
+                    "must": [
+                        {"match": {"user_id": user_id}},
+                        {"match": {"query": query}},
+                    ]
+                }
+            },
+        }
+        resp = self.es.search(index=self.index, body=body)  # type: ignore[union-attr]
+        hits = resp.get("hits", {}).get("hits", [])
+        return [h["_source"] for h in hits]
+
+    # ------------------------------------------------------------------
+    def delete_index(self) -> None:
+        if self.use_memory:
+            self._docs = []
+        else:
+            if self.es.indices.exists(index=self.index):  # type: ignore[union-attr]
+                self.es.indices.delete(index=self.index)  # type: ignore[union-attr]
+
+
+__all__ = ["ElasticClient"]

--- a/tests/test_elastic_client.py
+++ b/tests/test_elastic_client.py
@@ -1,0 +1,31 @@
+from ai_karen_engine.clients.database.elastic_client import ElasticClient
+
+
+def test_index_and_search_in_memory():
+    client = ElasticClient(use_memory=True)
+    client.ensure_index()
+    entry = {
+        "user_id": "u1",
+        "session_id": "s1",
+        "query": "hello world",
+        "result": "r1",
+        "timestamp": 1,
+    }
+    client.index_entry(entry)
+    hits = client.search("u1", "hello")
+    assert hits and hits[0]["result"] == "r1"
+
+
+def test_search_no_results():
+    client = ElasticClient(use_memory=True)
+    client.ensure_index()
+    client.index_entry(
+        {
+            "user_id": "u2",
+            "session_id": "s2",
+            "query": "foo",
+            "result": "bar",
+            "timestamp": 1,
+        }
+    )
+    assert client.search("u2", "baz") == []


### PR DESCRIPTION
## Summary
- create ElasticClient abstraction with in-memory fallback
- use ElasticClient from MemoryManager and query Elastic before vector search
- document Elastic environment variables
- add tests for storing and retrieving text via Elastic

## Testing
- `ruff check src/ai_karen_engine/core/memory/manager.py src/ai_karen_engine/clients/database/elastic_client.py tests/test_elastic_client.py`
- `pytest tests/test_elastic_client.py -q`


------
https://chatgpt.com/codex/tasks/task_e_686b211e94bc83248109cb0576f93014