### PR TITLE
Fix relative imports

### DIFF
--- a/src/ai_karen_engine/plugins/llm_services/deepseek/__init__.py
+++ b/src/ai_karen_engine/plugins/llm_services/deepseek/__init__.py
@@ -1,1 +1,3 @@
-from .handler import run
+from ai_karen_engine.plugins.llm_services.deepseek.handler import run
+
+__all__ = ["run"]

--- a/src/ai_karen_engine/plugins/llm_services/gemini/__init__.py
+++ b/src/ai_karen_engine/plugins/llm_services/gemini/__init__.py
@@ -1,1 +1,3 @@
-from .handler import run
+from ai_karen_engine.plugins.llm_services.gemini.handler import run
+
+__all__ = ["run"]

--- a/src/ai_karen_engine/plugins/llm_services/ollama/__init__.py
+++ b/src/ai_karen_engine/plugins/llm_services/ollama/__init__.py
@@ -1,1 +1,3 @@
-from .handler import run
+from ai_karen_engine.plugins.llm_services.ollama.handler import run
+
+__all__ = ["run"]

--- a/src/ai_karen_engine/plugins/llm_services/openai/__init__.py
+++ b/src/ai_karen_engine/plugins/llm_services/openai/__init__.py
@@ -1,1 +1,3 @@
-from .handler import run
+from ai_karen_engine.plugins.llm_services.openai.handler import run
+
+__all__ = ["run"]

--- a/src/ui_logic/__init__.py
+++ b/src/ui_logic/__init__.py
@@ -1,3 +1,3 @@
-from .ui_core import get_page_manifest, dispatch_page
+from ui_logic.ui_core import get_page_manifest, dispatch_page
 
 __all__ = ["get_page_manifest", "dispatch_page"]

--- a/src/ui_logic/components/memory/session_explorer.py
+++ b/src/ui_logic/components/memory/session_explorer.py
@@ -7,9 +7,12 @@ import streamlit as st
 import pandas as pd
 import traceback
 from datetime import datetime, timedelta
-from typing import Optional, Dict, Any
+from typing import Dict, Any
 
-from .session_core import get_session_records, get_audit_logs_for_entry, SessionExplorerError
+from ui_logic.components.memory.session_core import (
+    get_session_records,
+    get_audit_logs_for_entry,
+)
 
 def render_session_explorer(user_ctx: Dict[str, Any]):
     try:
@@ -50,7 +53,7 @@ def render_session_explorer(user_ctx: Dict[str, Any]):
                     end_date=datetime.combine(end_date, datetime.max.time()),
                     limit=limit
                 )
-            except PermissionError as e:
+            except PermissionError:
                 st.error("🔒 You don't have permission to view memory sessions.")
                 return
             except Exception as ex:
@@ -90,7 +93,7 @@ def render_session_explorer(user_ctx: Dict[str, Any]):
                     else:
                         st.info("No audit logs for this entry.")
 
-    except Exception as e:
+    except Exception:
         st.error("Critical error in Session Explorer.")
         st.code(traceback.format_exc())
 

--- a/tests/ui/test_chat_hub.py
+++ b/tests/ui/test_chat_hub.py
@@ -1,6 +1,6 @@
 import asyncio
 
-from ..ui_launchers.backend.chat_hub import ChatHub, SlashCommand, NeuroVault
+from ui_launchers.backend.chat_hub import ChatHub
 
 
 class DummyRouter:


### PR DESCRIPTION
## Summary
- rewrite plugins to use absolute imports
- fix session explorer imports
- clean up UI test imports

## Testing
- `ruff check src/ui_logic/__init__.py src/ui_logic/components/memory/session_explorer.py src/ai_karen_engine/plugins/llm_services/openai/__init__.py src/ai_karen_engine/plugins/llm_services/ollama/__init__.py src/ai_karen_engine/plugins/llm_services/deepseek/__init__.py src/ai_karen_engine/plugins/llm_services/gemini/__init__.py tests/ui/test_chat_hub.py`
- `pytest tests/ui/test_chat_hub.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686b218a48708324ada1ab8da21284fd