### PR TITLE
Refactor plugin discovery without sys.path hacks

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,12 +3,6 @@ from pathlib import Path
 import sys
 import os
 
-# === [Evil Twin] Namespace Correction: Ensure src/ is in sys.path if needed ===
-root = Path(__file__).resolve().parent
-src_path = root / "src"
-if src_path.is_dir() and str(src_path) not in sys.path:
-    sys.path.insert(0, str(src_path))
-
 from ai_karen_engine.core.cortex.dispatch import dispatch, CortexDispatchError
 from ai_karen_engine.core.embedding_manager import _METRICS as METRICS
 from ai_karen_engine.core.soft_reasoning_engine import SoftReasoningEngine


### PR DESCRIPTION
## Summary
- remove sys.path insertions from main module
- refactor plugin registry discovery using `importlib` and `pkgutil`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi'...)*
- `ruff check` *(fails: found 181 errors)*

------
https://chatgpt.com/codex/tasks/task_e_686b21b1fb9883248a0aec871456c1cd