### PR TITLE
Encrypt automation job results

### DIFF
--- a/src/ai_karen_engine/automation_manager/__init__.py
+++ b/src/ai_karen_engine/automation_manager/__init__.py
@@ -13,13 +13,16 @@ import hashlib
 import hmac
 import logging
 import os
-import secrets
-import sys
 import threading
 import time
 import uuid
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict
+
+from ai_karen_engine.automation_manager.encryption_utils import (
+    decrypt_data,
+    encrypt_data,
+)
 
 import duckdb
 
@@ -167,7 +170,7 @@ class AutomationManager:
                     "schedule": job[2],
                     "status": job[3],
                     "last_run": job[4],
-                    "result": job[5],
+                    "result": decrypt_data(job[5]),
                     "signature": job[6],
                     "created_at": job[7],
                     "updated_at": job[8],
@@ -248,7 +251,7 @@ class AutomationManager:
             if job:
                 job["status"] = status
                 job["last_run"] = time.time()
-                job["result"] = result  # TODO: Encrypt result for at-rest
+                job["result"] = encrypt_data(result)
                 job["updated_at"] = time.time()
                 self._persist_job(job_id)
 

--- a/src/ai_karen_engine/automation_manager/encryption_utils.py
+++ b/src/ai_karen_engine/automation_manager/encryption_utils.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from cryptography.fernet import Fernet
+
+import os
+
+
+ENCRYPTION_KEY = os.getenv("KARI_JOB_ENC_KEY")
+if not ENCRYPTION_KEY:
+    raise RuntimeError("KARI_JOB_ENC_KEY must be set in the environment!")
+
+_fernet = Fernet(
+    ENCRYPTION_KEY.encode() if isinstance(ENCRYPTION_KEY, str) else ENCRYPTION_KEY
+)
+
+
+def encrypt_data(data: bytes | str) -> bytes:
+    if isinstance(data, str):
+        data = data.encode()
+    return _fernet.encrypt(data)
+
+
+def decrypt_data(token: bytes | memoryview | None) -> str | None:
+    if token is None:
+        return None
+    if isinstance(token, memoryview):
+        token = token.tobytes()
+    return _fernet.decrypt(token).decode()

--- a/tests/test_automation_job_encryption.py
+++ b/tests/test_automation_job_encryption.py
@@ -1,0 +1,37 @@
+import importlib
+import time
+
+import duckdb
+from cryptography.fernet import Fernet
+
+
+def test_job_result_encrypted(tmp_path, monkeypatch):
+    db = tmp_path / "automation.db"
+    monkeypatch.setenv("KARI_SECURE_DB_PATH", str(db))
+    monkeypatch.setenv("KARI_DUCKDB_PASSWORD", "pw")
+    monkeypatch.setenv("KARI_JOB_SIGNING_KEY", "sign")
+    monkeypatch.setenv("KARI_JOB_ENC_KEY", Fernet.generate_key().decode())
+
+    import ai_karen_engine.automation_manager as am
+
+    importlib.reload(am)
+
+    mgr = am.get_automation_manager()
+
+    def hello():
+        return "secret"
+
+    jid = mgr.register_job("hello", hello, "now")
+    mgr.trigger_job(jid)
+    time.sleep(0.1)
+
+    conn = duckdb.connect(str(db))
+    conn.execute("PRAGMA key='pw'")
+    stored = conn.execute(
+        "SELECT result FROM automation_jobs WHERE job_id=?", (jid,)
+    ).fetchone()[0]
+    conn.close()
+
+    assert stored != b"secret"
+    assert am.decrypt_data(stored) == "secret"
+    mgr.shutdown()


### PR DESCRIPTION
## Summary
- refactor `automation_manager` into package
- add Fernet utilities for symmetric encryption
- encrypt job results before persisting
- decrypt results when loading from DuckDB
- test that job results are stored encrypted

## Testing
- `ruff check src/ai_karen_engine/automation_manager`
- `ruff check tests/test_automation_job_encryption.py`
- `black src/ai_karen_engine/automation_manager/__init__.py src/ai_karen_engine/automation_manager/encryption_utils.py tests/test_automation_job_encryption.py`
- `mypy src/ai_karen_engine/automation_manager/__init__.py src/ai_karen_engine/automation_manager/encryption_utils.py tests/test_automation_job_encryption.py` *(fails: missing dependencies)*
- `pytest tests/test_automation_job_encryption.py -q` *(fails: duckdb missing)*

------
https://chatgpt.com/codex/tasks/task_e_686b2966f97c83248716c44e8270d2d3