### PR TITLE
Add Prometheus metrics for LLM utilities

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import sys
 import os
 
-from ai_karen_engine.core.cortex.dispatch import dispatch, CortexDispatchError
+from ai_karen_engine.core.cortex.dispatch import dispatch
 from ai_karen_engine.core.embedding_manager import _METRICS as METRICS
 from ai_karen_engine.core.soft_reasoning_engine import SoftReasoningEngine
 
@@ -47,6 +47,7 @@ import asyncio
 import logging
 from ai_karen_engine.integrations.llm_registry import registry as llm_registry
 from ai_karen_engine.integrations.model_discovery import sync_registry
+from ai_karen_engine.integrations.llm_utils import PROM_REGISTRY
 
 app = FastAPI()
 logger = logging.getLogger("kari")
@@ -189,7 +190,7 @@ def metrics() -> MetricsResponse:
 
 @app.get("/metrics/prometheus")
 def metrics_prometheus() -> Response:
-    data = generate_latest()
+    data = generate_latest(PROM_REGISTRY) if PROM_REGISTRY is not None else generate_latest()
     try:
         return Response(data, media_type=CONTENT_TYPE_LATEST)
     except TypeError:

--- a/tests/test_llm_utils.py
+++ b/tests/test_llm_utils.py
@@ -1,8 +1,34 @@
-from integrations.llm_utils import LLMUtils
+import importlib
+import sys
+
+from ai_karen_engine.integrations import llm_utils
+from ai_karen_engine.integrations.llm_utils import LLMUtils, LLMProviderBase
+
+
+class _DummyProvider(LLMProviderBase):
+    def generate_text(self, prompt: str, **kwargs):
+        return prompt
+
+    def embed(self, text, **kwargs):
+        return [0.0]
 
 
 def test_llm_utils_fallback():
-    llm = LLMUtils(model_name="nonexistent-model")
+    llm = LLMUtils(providers={"dummy": _DummyProvider()}, default="dummy")
     out = llm.generate_text("hello")
     assert "hello" in out
-    assert llm.generator is None
+    assert hasattr(llm, "providers")
+
+
+def test_record_llm_metric_without_prometheus(monkeypatch):
+    for mod in list(sys.modules):
+        if mod.startswith("prometheus_client"):
+            monkeypatch.delitem(sys.modules, mod, raising=False)
+    monkeypatch.setitem(sys.modules, "prometheus_client", None)
+
+    importlib.reload(llm_utils)
+    llm_utils.record_llm_metric("test", 0.01, True, "dummy")
+    importlib.reload(llm_utils)
+
+
+


### PR DESCRIPTION
## Summary
- instrument `record_llm_metric` with Prometheus counters and histograms
- export a module level `PROM_REGISTRY`
- expose metrics in `main.py` using that registry
- ensure `record_llm_metric` works without prometheus

## Testing
- `ruff check main.py src/ai_karen_engine/integrations/llm_utils.py tests/test_llm_utils.py`
- `pytest tests/test_llm_utils.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686b2965a2f08324bcbe9b3abc35e27c