### PR TITLE
Add doc store ingestion and search module

### DIFF
--- a/docs/memory_arch.md
+++ b/docs/memory_arch.md
@@ -9,6 +9,7 @@ Kari uses a multi-tier memory system to balance speed and recall quality.
 4. **SessionBuffer** – a DuckDB-backed queue that holds chat logs until they can be flushed to Postgres. Flushes occur on session end or when the buffer reaches a configurable size.
 5. **Postgres** – relational store for structured logs and plugin state. Used when the engine needs ACID compliance or joins across metadata.
 6. **Elasticsearch** – optional full-text index for transcripts and document archives. Provides rich keyword search alongside dense vector recall.
+7. **DocumentStore** – ingests PDF and Word files, chunked by heading via spaCy. Embeddings live in Milvus while chunk metadata is kept in Postgres.
 
 ### Storage Responsibilities
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -11,6 +11,9 @@ Example metrics:
 - `embedding_time_seconds`
 - `vector_upsert_seconds`
 - `vector_search_latency_seconds`
+- `doc_chunks_indexed`
+- `doc_search_latency`
+- `metadata_hit_rate`
 
 Use `docker compose up` to start a Prometheus container that scrapes `http://localhost:8000/metrics`.
 

--- a/src/ai_karen_engine/__init__.py
+++ b/src/ai_karen_engine/__init__.py
@@ -32,6 +32,9 @@ def __getattr__(name):
     if name == "AccessDenied":
         from ai_karen_engine.plugin_router import AccessDenied as _AD
         return _AD
+    if name == "DocumentStore":
+        from ai_karen_engine.doc_store import DocumentStore as _DS
+        return _DS
     raise AttributeError(name)
 
 __all__ = [
@@ -46,4 +49,5 @@ __all__ = [
     "LNMClient",
     "BasicClassifier",
     "SpaCyClient",
+    "DocumentStore",
 ]

--- a/src/ai_karen_engine/doc_store/__init__.py
+++ b/src/ai_karen_engine/doc_store/__init__.py
@@ -1,0 +1,5 @@
+"""Document ingestion and search utilities."""
+
+from .document_store import DocumentStore
+
+__all__ = ["DocumentStore"]

--- a/src/ai_karen_engine/doc_store/document_store.py
+++ b/src/ai_karen_engine/doc_store/document_store.py
@@ -1,0 +1,179 @@
+"""DocumentStore for PDF/Doc ingestion and semantic search."""
+from __future__ import annotations
+
+import math
+import time
+from typing import Any, Dict, Iterable, List, Optional
+
+import spacy
+
+from ai_karen_engine.core.embedding_manager import EmbeddingManager, record_metric
+from ai_karen_engine.core.milvus_client import MilvusClient
+from ai_karen_engine.clients.database.postgres_client import PostgresClient
+
+try:
+    import fitz  # type: ignore
+except Exception:  # pragma: no cover - optional
+    fitz = None
+
+try:
+    from docx import Document  # type: ignore
+except Exception:  # pragma: no cover - optional
+    Document = None
+
+
+class _DocPostgres(PostgresClient):
+    """Postgres table for document chunks."""
+
+    def _ensure_tables(self) -> None:  # type: ignore[override]
+        ph = self.placeholder
+        if self.use_sqlite:
+            sql = (
+                "CREATE TABLE IF NOT EXISTS doc_chunks ("
+                "vector_id INTEGER PRIMARY KEY,"
+                "doc_id TEXT,"
+                "heading TEXT,"
+                "chunk_index INTEGER"
+                ")"
+            )
+        else:
+            sql = (
+                "CREATE TABLE IF NOT EXISTS doc_chunks ("
+                "vector_id INTEGER PRIMARY KEY,"
+                "doc_id VARCHAR,"
+                "heading VARCHAR,"
+                "chunk_index INTEGER"
+                ")"
+            )
+        self._execute(sql)
+
+    def insert_chunk(self, vector_id: int, doc_id: str, heading: str, idx: int) -> None:
+        ph = self.placeholder
+        sql = (
+            f"INSERT INTO doc_chunks (vector_id, doc_id, heading, chunk_index)"
+            f" VALUES ({ph},{ph},{ph},{ph})"
+        )
+        self._execute(sql, [vector_id, doc_id, heading, idx])
+
+    def filter_ids(self, metadata: Dict[str, Any]) -> List[int]:
+        if not metadata:
+            rows = self._execute("SELECT vector_id FROM doc_chunks", fetch=True)
+        else:
+            clauses = []
+            params: List[Any] = []
+            ph = self.placeholder
+            for k, v in metadata.items():
+                clauses.append(f"{k}={ph}")
+                params.append(v)
+            sql = "SELECT vector_id FROM doc_chunks WHERE " + " AND ".join(clauses)
+            rows = self._execute(sql, params, fetch=True)
+        return [r[0] for r in rows]
+
+
+def _read_pdf(path: str) -> str:
+    if not fitz:
+        raise RuntimeError("PyMuPDF not installed")
+    doc = fitz.open(path)
+    text = "\n".join(page.get_text() for page in doc)
+    doc.close()
+    return text
+
+
+def _read_doc(path: str) -> str:
+    if not Document:
+        raise RuntimeError("python-docx not installed")
+    doc = Document(path)
+    return "\n".join(p.text for p in doc.paragraphs)
+
+
+class DocumentStore:
+    """Index PDF/Doc files and perform filtered vector search."""
+
+    def __init__(
+        self,
+        dsn: str = "sqlite:///:memory:",
+        use_sqlite: bool = True,
+    ) -> None:
+        self.nlp = spacy.blank("en")
+        self.nlp.add_pipe("sentencizer")
+        self.embedder = EmbeddingManager()
+        self.vectors = MilvusClient()
+        self.db = _DocPostgres(dsn=dsn, use_sqlite=use_sqlite)
+
+    # ------------------------------------------------------------------
+    def _extract_text(self, path: str) -> str:
+        if path.lower().endswith(".pdf"):
+            return _read_pdf(path)
+        if path.lower().endswith(".doc") or path.lower().endswith(".docx"):
+            return _read_doc(path)
+        with open(path, "r", encoding="utf-8") as f:
+            return f.read()
+
+    def _chunk_by_heading(self, text: str) -> List[tuple[str, str]]:
+        doc = self.nlp(text)
+        chunks: List[tuple[str, str]] = []
+        heading = "Document"
+        for sent in doc.sents:
+            s = sent.text.strip()
+            if not s:
+                continue
+            if s.isupper():
+                heading = s
+                continue
+            if not chunks or chunks[-1][0] != heading:
+                chunks.append((heading, s))
+            else:
+                chunks[-1] = (heading, chunks[-1][1] + " " + s)
+        return chunks
+
+    def ingest(self, path: str, doc_id: str) -> int:
+        text = self._extract_text(path)
+        chunks = self._chunk_by_heading(text)
+        count = 0
+        for idx, (heading, chunk_text) in enumerate(chunks):
+            vec = self.embedder.embed(chunk_text)
+            vid = self.vectors.upsert(vec, {"doc_id": doc_id, "heading": heading})
+            self.db.insert_chunk(vid, doc_id, heading, idx)
+            count += 1
+        record_metric("doc_chunks_indexed", float(count))
+        return count
+
+    # ------------------------------------------------------------------
+    def _similarity(self, v1: List[float], norm1: float, v2: List[float], norm2: float) -> float:
+        if norm1 == 0 or norm2 == 0:
+            return 0.0
+        dot = sum(x * y for x, y in zip(v1, v2))
+        return dot / (norm1 * norm2)
+
+    def _search_vectors(self, vec: List[float], ids: Iterable[int], top_k: int) -> List[Dict[str, Any]]:
+        norm = math.sqrt(sum(v * v for v in vec))
+        results: List[Dict[str, Any]] = []
+        with self.vectors._lock:
+            self.vectors._prune()
+            for vid in ids:
+                rec = self.vectors._data.get(vid)
+                if not rec:
+                    continue
+                sim = self._similarity(vec, norm, rec.vector, rec.norm)
+                results.append({"id": vid, "score": sim, "payload": rec.payload})
+        results.sort(key=lambda r: r["score"], reverse=True)
+        return results[:top_k]
+
+    def query(
+        self,
+        query: str,
+        metadata_filter: Optional[Dict[str, Any]] = None,
+        top_k: int = 3,
+    ) -> List[Dict[str, Any]]:
+        start = time.time()
+        ids = self.db.filter_ids(metadata_filter or {})
+        record_metric("metadata_hit_rate", 1.0 if ids else 0.0)
+        if not ids:
+            record_metric("doc_search_latency", time.time() - start)
+            return []
+        vec = self.embedder.embed(query)
+        results = self._search_vectors(vec, ids, top_k)
+        record_metric("doc_search_latency", time.time() - start)
+        return results
+
+__all__ = ["DocumentStore"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -77,3 +77,21 @@ class IntentEngine:
         return "greet" if "hello" in text else "hf_generate"
 
 intent_stub.IntentEngine = IntentEngine
+sys.modules.setdefault("ai_karen_engine.core.intent_engine", intent_stub)
+
+# Lightweight spaCy stub for document tests
+spacy_stub = types.ModuleType("spacy")
+
+class DummyDoc:
+    def __init__(self, text: str):
+        self.text = text
+        self.sents = [types.SimpleNamespace(text=t) for t in text.split("\n")]
+
+def blank(lang: str = "en"):
+    def nlp(text: str):
+        return DummyDoc(text)
+    nlp.add_pipe = lambda name: None
+    return nlp
+
+spacy_stub.blank = blank
+sys.modules.setdefault("spacy", spacy_stub)

--- a/tests/test_doc_store.py
+++ b/tests/test_doc_store.py
@@ -1,0 +1,19 @@
+from ai_karen_engine.doc_store import DocumentStore
+from ai_karen_engine.core.embedding_manager import _METRICS
+
+
+def test_ingest_and_query(monkeypatch, tmp_path):
+    store = DocumentStore()
+
+    sample_text = "INTRO\nThis is a test.\nSECOND\nAnother section."
+    monkeypatch.setattr(store, "_extract_text", lambda p: sample_text)
+
+    count = store.ingest("dummy.pdf", doc_id="doc1")
+    assert count == 2
+    assert "doc_chunks_indexed" in _METRICS
+
+    results = store.query("test", metadata_filter={"doc_id": "doc1"})
+    assert results
+    assert results[0]["payload"]["doc_id"] == "doc1"
+    assert "doc_search_latency" in _METRICS
+    assert "metadata_hit_rate" in _METRICS


### PR DESCRIPTION
## Summary
- implement `doc_store` module for PDF and Word ingestion
- store chunk embeddings in Milvus and metadata in Postgres
- expose metrics: `doc_chunks_indexed`, `doc_search_latency`, `metadata_hit_rate`
- export `DocumentStore` in package root
- document new metrics and storage layer
- add unit tests with spaCy stub

## Testing
- `PYTHONPATH=src pytest -q tests/test_doc_store.py`
- `PYTHONPATH=src pytest -q` *(fails: ModuleNotFoundError: No module named 'duckdb')*

------
https://chatgpt.com/codex/tasks/task_e_687853fbd8b48324a2e904c4663cc4d8