### PR TITLE
Expose new metrics and dashboard

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -11,6 +11,11 @@ Example metrics:
 - `embedding_time_seconds`
 - `vector_upsert_seconds`
 - `vector_search_latency_seconds`
+- `memory_store_total`
+- `memory_recall_total`
+- `plugin_exec_total`
+- `document_index_total`
+- `document_search_total`
 
 Use `docker compose up` to start a Prometheus container that scrapes `http://localhost:8000/metrics`.
 
@@ -27,6 +32,28 @@ Grafana dashboards should include:
 | Embedding Latency | `embedding_time_seconds` |
 | Vector Search     | `vector_search_latency_seconds` |
 | Memory Usage      | Custom Python gauge or system metric |
+| Memory Stores     | `memory_store_total` |
+| Memory Recalls    | `memory_recall_total` |
+| Plugin Calls      | `plugin_exec_total` |
+| Doc Indexes       | `document_index_total` |
+| Doc Searches      | `document_search_total` |
 
 See `ui_launchers/desktop_ui/README.md` for adding the metrics dashboard to the Control Room.
 The new Diagnostics page surfaces the output of `get_system_health()` with a JSON viewer.
+
+### Grafana Dashboard JSON
+
+Import the following snippet into Grafana to create a basic dashboard:
+
+```json
+{
+  "title": "Kari Metrics",
+  "panels": [
+    {"type": "graph", "title": "Requests", "targets": [{"expr": "kari_http_requests_total"}]},
+    {"type": "graph", "title": "Memory Stores", "targets": [{"expr": "memory_store_total"}]},
+    {"type": "graph", "title": "Memory Recalls", "targets": [{"expr": "memory_recall_total"}]},
+    {"type": "graph", "title": "Plugin Calls", "targets": [{"expr": "plugin_exec_total"}]},
+    {"type": "graph", "title": "Doc Searches", "targets": [{"expr": "document_search_total"}]}
+  ]
+}
+```

--- a/tests/test_elastic_metrics.py
+++ b/tests/test_elastic_metrics.py
@@ -1,0 +1,12 @@
+from ai_karen_engine.clients.database.elastic_client import ElasticClient, _METRICS
+
+
+def test_elastic_metrics():
+    client = ElasticClient(use_memory=True)
+    client.index_entry({'user_id': 'u', 'query': 'q', 'result': 'r', 'timestamp': 0})
+    res = client.search('u', 'q')
+    assert res
+    assert _METRICS['document_index_total'] > 0
+    assert _METRICS['document_search_total'] > 0
+
+

--- a/tests/test_memory_manager.py
+++ b/tests/test_memory_manager.py
@@ -190,3 +190,17 @@ def test_update_memory_postgres_failure(monkeypatch):
     assert not pg.upserts
     assert store
 
+
+def test_memory_metrics(monkeypatch):
+    mm = load_manager(monkeypatch)
+    store = []
+    monkeypatch.setattr(mm, "postgres", None)
+    monkeypatch.setattr(mm, "redis", FakeRedisModule())
+    monkeypatch.setattr(mm, "duckdb", duckdb_stub(store))
+    monkeypatch.setattr(mm, "store_vector", lambda u, q, r: 1)
+
+    mm.update_memory({"user_id": "u", "session_id": "s"}, "q", "r")
+    mm.recall_context({"user_id": "u"}, "q")
+    assert mm._METRICS["memory_store_total"] > 0
+    assert mm._METRICS["memory_recall_total"] > 0
+

--- a/tests/test_plugin_metrics.py
+++ b/tests/test_plugin_metrics.py
@@ -1,0 +1,14 @@
+import importlib
+from ai_karen_engine.core import plugin_registry as pr
+
+
+def test_plugin_metrics():
+    # reload to reset metrics
+    importlib.reload(pr)
+    handler = pr.plugin_registry.get('hello_world')
+    assert handler is not None
+    result = pr.execute_plugin(handler, {}, 'hi')
+    assert result
+    assert pr._METRICS['plugin_exec_total'] > 0
+    assert pr._METRICS['plugins_loaded'] > 0
+


### PR DESCRIPTION
## Summary
- add Prometheus counters for memory manager, plugin registry and document layer
- register counters in `main.py` and aggregate all metrics in `/metrics`
- document Grafana setup and new metrics
- cover metrics via new unit tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'duckdb')*

------
https://chatgpt.com/codex/tasks/task_e_687853fcce008324b074ce9e2eb10087