### PR TITLE
Add MCP clients and registry

### DIFF
--- a/src/ai_karen_engine/mcp/__init__.py
+++ b/src/ai_karen_engine/mcp/__init__.py
@@ -1,0 +1,20 @@
+"""MCP module providing gRPC/JSON-RPC clients and service wrappers."""
+
+from .registry import ServiceRegistry
+from .base import BaseMCPClient, AuthorizationError
+from .grpc_client import GRPCClient
+from .json_rpc_client import JSONRPCClient
+try:
+    from .services import KnowledgeGraphService, LLMService
+except Exception:  # pragma: no cover - optional deps
+    KnowledgeGraphService = LLMService = None
+
+__all__ = [
+    "ServiceRegistry",
+    "BaseMCPClient",
+    "AuthorizationError",
+    "GRPCClient",
+    "JSONRPCClient",
+    "KnowledgeGraphService",
+    "LLMService",
+]

--- a/src/ai_karen_engine/mcp/base.py
+++ b/src/ai_karen_engine/mcp/base.py
@@ -1,0 +1,67 @@
+"""Base classes and utilities for MCP clients."""
+
+from __future__ import annotations
+
+import time
+from typing import Iterable, Optional
+
+try:
+    from prometheus_client import Counter, Histogram
+    METRICS_ENABLED = True
+except Exception:  # pragma: no cover - optional dep
+    METRICS_ENABLED = False
+
+    class _DummyMetric:
+        def labels(self, **_kw):
+            return self
+
+        def inc(self, _n: int = 1) -> None:
+            pass
+
+        def observe(self, _v: float) -> None:
+            pass
+
+    Counter = Histogram = _DummyMetric
+
+MCP_CALLS_TOTAL = Counter(
+    "mcp_calls_total",
+    "Total MCP calls",
+    ["service", "success"],
+) if METRICS_ENABLED else Counter()
+
+MCP_AUTH_FAILURES = Counter(
+    "mcp_auth_failures",
+    "MCP authentication failures",
+    ["service"],
+) if METRICS_ENABLED else Counter()
+
+MCP_LATENCY = Histogram(
+    "mcp_latency_seconds",
+    "Latency of MCP calls (seconds)",
+    ["service", "success"],
+) if METRICS_ENABLED else Histogram()
+
+
+class AuthorizationError(Exception):
+    """Raised when authentication or RBAC checks fail."""
+
+
+class BaseMCPClient:
+    """Common functionality for MCP clients."""
+
+    def __init__(self, registry: "ServiceRegistry", token: str, role: str):
+        self.registry = registry
+        self.token = token
+        self.role = role
+
+    def _record_metric(self, service: str, duration: float, success: bool) -> None:
+        label_success = "true" if success else "false"
+        MCP_CALLS_TOTAL.labels(service=service, success=label_success).inc()
+        MCP_LATENCY.labels(service=service, success=label_success).observe(duration)
+
+    def _auth(self, service: str, token: str, roles: Optional[Iterable[str]]) -> None:
+        if token != self.token or (roles and self.role not in roles):
+            MCP_AUTH_FAILURES.labels(service=service).inc()
+            raise AuthorizationError("Invalid token or insufficient role")
+
+

--- a/src/ai_karen_engine/mcp/grpc_client.py
+++ b/src/ai_karen_engine/mcp/grpc_client.py
@@ -1,0 +1,33 @@
+"""Generic gRPC client for MCP."""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from .base import BaseMCPClient
+
+
+class GRPCClient(BaseMCPClient):
+    """Call gRPC services discovered via the service registry."""
+
+    def call(self, service: str, method: str, payload: bytes, token: str) -> Any:
+        svc = self.registry.lookup(service)
+        if not svc or svc.get("kind") != "grpc":
+            raise ValueError(f"Service '{service}' not found")
+        self._auth(service, token, svc.get("roles"))
+        start = time.time()
+        try:
+            import grpc  # type: ignore
+        except Exception as exc:  # pragma: no cover - optional dep
+            raise RuntimeError("grpcio is required for GRPCClient") from exc
+        channel = grpc.insecure_channel(svc["endpoint"])
+        stub = channel.unary_unary(method)
+        try:
+            resp = stub(payload)
+            self._record_metric(service, time.time() - start, True)
+            return resp
+        except Exception:
+            self._record_metric(service, time.time() - start, False)
+            raise
+

--- a/src/ai_karen_engine/mcp/json_rpc_client.py
+++ b/src/ai_karen_engine/mcp/json_rpc_client.py
@@ -1,0 +1,40 @@
+"""JSON-RPC client implementation for MCP."""
+
+from __future__ import annotations
+
+import time
+import uuid
+from typing import Any, Dict, Optional
+
+try:
+    import httpx
+except Exception:  # pragma: no cover - optional dep
+    httpx = None
+
+from .base import BaseMCPClient
+
+
+class JSONRPCClient(BaseMCPClient):
+    """Perform JSON-RPC calls to services in the registry."""
+
+    def call(self, service: str, method: str, params: Optional[Dict] = None, token: str = "") -> Any:
+        svc = self.registry.lookup(service)
+        if not svc or svc.get("kind") != "jsonrpc":
+            raise ValueError(f"Service '{service}' not found")
+        self._auth(service, token, svc.get("roles"))
+        if httpx is None:
+            raise RuntimeError("httpx is required for JSONRPCClient")
+        payload = {"jsonrpc": "2.0", "id": str(uuid.uuid4()), "method": method, "params": params or {}}
+        start = time.time()
+        try:
+            resp = httpx.post(svc["endpoint"], json=payload, timeout=svc.get("timeout", 10))
+            resp.raise_for_status()
+            self._record_metric(service, time.time() - start, True)
+            data = resp.json()
+            if "error" in data:
+                raise RuntimeError(data["error"])
+            return data.get("result")
+        except Exception:
+            self._record_metric(service, time.time() - start, False)
+            raise
+

--- a/src/ai_karen_engine/mcp/registry.py
+++ b/src/ai_karen_engine/mcp/registry.py
@@ -1,0 +1,47 @@
+"""Redis-backed service registry for MCP."""
+
+from __future__ import annotations
+from typing import Iterable, Optional
+import json
+
+try:
+    import redis  # type: ignore
+except Exception:  # pragma: no cover - optional dep
+    redis = None
+
+
+
+class ServiceRegistry:
+    """Register and lookup MCP services in Redis."""
+
+    def __init__(self, redis_client: Optional[redis.Redis] = None, prefix: str = "mcp"):
+        if redis_client is not None:
+            self.redis = redis_client
+        else:
+            if redis is None:
+                raise ImportError("redis package is required for ServiceRegistry")
+            self.redis = redis.Redis(host="localhost", port=6379, db=0, decode_responses=True)
+        self.prefix = prefix
+
+    def _k(self, name: str) -> str:
+        return f"{self.prefix}:svc:{name}"
+
+    def register(self, name: str, endpoint: str, kind: str, roles: Optional[Iterable[str]] = None) -> None:
+        data = {"endpoint": endpoint, "kind": kind, "roles": list(roles or [])}
+        self.redis.set(self._k(name), json.dumps(data))
+
+    def deregister(self, name: str) -> None:
+        self.redis.delete(self._k(name))
+
+    def lookup(self, name: str) -> Optional[dict]:
+        val = self.redis.get(self._k(name))
+        return json.loads(val) if val else None
+
+    def list(self) -> dict:
+        services = {}
+        for key in self.redis.keys(f"{self.prefix}:svc:*"):
+            val = self.redis.get(key)
+            if val:
+                services[key.split(":")[-1]] = json.loads(val)
+        return services
+

--- a/src/ai_karen_engine/mcp/services.py
+++ b/src/ai_karen_engine/mcp/services.py
@@ -1,0 +1,43 @@
+"""Wrapper services exposing internal tools via MCP."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from .registry import ServiceRegistry
+from .base import AuthorizationError
+from ai_karen_engine.services.knowledge_graph_client import KnowledgeGraphClient
+from ai_karen_engine.integrations.llm_utils import LLMUtils
+
+
+class KnowledgeGraphService:
+    """Expose KnowledgeGraphClient methods as MCP service."""
+
+    def __init__(self, kg_client: KnowledgeGraphClient, registry: ServiceRegistry, name: str = "knowledge_graph"):
+        self.kg_client = kg_client
+        self.registry = registry
+        self.registry.register(name, "local", "local", roles=["admin", "user"])
+        self.name = name
+
+    def execute_cypher(self, query: str, params: Optional[Dict[str, Any]] = None, rbac_ctx: Optional[Dict[str, Any]] = None) -> Any:
+        roles = rbac_ctx.get("roles") if rbac_ctx else []
+        if "admin" not in roles and "user" not in roles:
+            raise AuthorizationError("RBAC denied")
+        return self.kg_client.execute_cypher(query, params)
+
+
+class LLMService:
+    """Expose LLMUtils via MCP."""
+
+    def __init__(self, llm: LLMUtils, registry: ServiceRegistry, name: str = "llm"):
+        self.llm = llm
+        self.registry = registry
+        self.registry.register(name, "local", "local", roles=["admin", "user"])
+        self.name = name
+
+    def generate_text(self, prompt: str, provider: Optional[str] = None, rbac_ctx: Optional[Dict[str, Any]] = None) -> str:
+        roles = rbac_ctx.get("roles") if rbac_ctx else []
+        if "admin" not in roles and "user" not in roles:
+            raise AuthorizationError("RBAC denied")
+        return self.llm.generate_text(prompt, provider=provider)
+

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -1,0 +1,60 @@
+import pytest
+import sys
+import types
+from ai_karen_engine.mcp.registry import ServiceRegistry
+from ai_karen_engine.mcp.base import MCP_CALLS_TOTAL, MCP_AUTH_FAILURES, AuthorizationError
+
+
+class FakeRedis:
+    def __init__(self):
+        self.store = {}
+
+    def set(self, k, v):
+        self.store[k] = v
+
+    def get(self, k):
+        return self.store.get(k)
+
+    def delete(self, k):
+        self.store.pop(k, None)
+
+    def keys(self, pattern):
+        prefix = pattern.rstrip('*')
+        return [k for k in self.store if k.startswith(prefix)]
+
+
+def test_registry():
+    r = FakeRedis()
+    reg = ServiceRegistry(redis_client=r)
+    reg.register('svc', 'http://x', 'jsonrpc', roles=['user'])
+    assert reg.lookup('svc')['endpoint'] == 'http://x'
+    assert 'svc' in reg.list()
+    reg.deregister('svc')
+    assert reg.lookup('svc') is None
+
+
+def test_jsonrpc_client_auth(monkeypatch):
+    r = FakeRedis()
+    reg = ServiceRegistry(redis_client=r)
+    reg.register('svc', 'http://test', 'jsonrpc', roles=['user'])
+    calls = {}
+
+    fake_httpx = types.ModuleType('httpx')
+    def fake_post(url, json=None, timeout=10):
+        calls['called'] = True
+        return types.SimpleNamespace(status_code=200, json=lambda: {'result': 1}, raise_for_status=lambda: None)
+    fake_httpx.post = fake_post
+    monkeypatch.setitem(sys.modules, 'httpx', fake_httpx)
+
+    import importlib
+    JSONRPCClient = importlib.reload(importlib.import_module('ai_karen_engine.mcp.json_rpc_client')).JSONRPCClient
+    client = JSONRPCClient(reg, token='secret', role='user')
+
+    result = client.call('svc', 'sum', {'a': 1}, token='secret')
+    assert result == 1
+    assert MCP_CALLS_TOTAL.labels(service='svc', success='true')
+
+    with pytest.raises(AuthorizationError):
+        client.call('svc', 'sum', {}, token='bad')
+    assert MCP_AUTH_FAILURES.labels(service='svc')
+


### PR DESCRIPTION
## Summary
- implement gRPC and JSON-RPC clients under `ai_karen_engine.mcp`
- add redis-backed `ServiceRegistry`
- enforce token auth and RBAC in `BaseMCPClient`
- expose simple wrappers for internal services
- test registry and JSONRPC client

## Testing
- `PYTHONPATH=$PWD/src pytest tests/test_mcp.py -q`
- `PYTHONPATH=$PWD/src pytest -q` *(fails: duckdb & py2neo missing)*

------
https://chatgpt.com/codex/tasks/task_e_687853ffa9548324841798b2d8c172ab