### PR TITLE
Add init_memory to memory manager

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,6 +6,7 @@ import os
 from ai_karen_engine.core.cortex.dispatch import dispatch
 from ai_karen_engine.core.embedding_manager import _METRICS as METRICS
 from ai_karen_engine.core.soft_reasoning_engine import SoftReasoningEngine
+from ai_karen_engine.core.memory.manager import init_memory
 
 if (Path(__file__).resolve().parent / "fastapi").is_dir():
     sys.stderr.write(
@@ -54,6 +55,7 @@ logger = logging.getLogger("kari")
 
 @app.on_event("startup")
 async def _refresh_registry_on_start() -> None:
+    init_memory()
     sync_registry()
     interval = int(os.getenv("LLM_REFRESH_INTERVAL", "0"))
     if interval > 0:

--- a/src/ai_karen_engine/fastapi.py
+++ b/src/ai_karen_engine/fastapi.py
@@ -20,6 +20,8 @@ import logging
 import uuid
 from typing import Optional
 
+from ai_karen_engine.core.memory.manager import init_memory
+
 try:
     from fastapi import FastAPI, APIRouter, Request, Response, status
     from fastapi.responses import JSONResponse, RedirectResponse, PlainTextResponse
@@ -51,6 +53,10 @@ app = FastAPI(
     openapi_url="/openapi.json",
     root_path=os.getenv("KARI_API_ROOT", ""),
 )
+
+@app.on_event("startup")
+async def _init_memory() -> None:
+    init_memory()
 
 # -- Prometheus Metrics (optional) --
 try:

--- a/tests/test_memory_manager.py
+++ b/tests/test_memory_manager.py
@@ -114,6 +114,11 @@ def test_recall_priority_order(monkeypatch):
 
     pg.recall_memory = recall_memory
     monkeypatch.setattr(mm, "postgres", pg)
+    monkeypatch.setattr(
+        mm,
+        "pg_syncer",
+        types.SimpleNamespace(postgres_available=True, mark_unavailable=lambda: None),
+    )
 
     fake_redis = FakeRedisModule()
 
@@ -148,6 +153,11 @@ def test_recall_returns_first_available(monkeypatch):
 
     monkeypatch.setattr(mm, "recall_vectors", mv)
     monkeypatch.setattr(mm, "postgres", RecordingPostgres())
+    monkeypatch.setattr(
+        mm,
+        "pg_syncer",
+        types.SimpleNamespace(postgres_available=True, mark_unavailable=lambda: None),
+    )
     monkeypatch.setattr(mm, "redis", FakeRedisModule())
     monkeypatch.setattr(mm, "duckdb", duckdb_stub(store))
 
@@ -163,6 +173,11 @@ def test_update_memory_success(monkeypatch):
     fake_redis = FakeRedisModule()
 
     monkeypatch.setattr(mm, "postgres", pg)
+    monkeypatch.setattr(
+        mm,
+        "pg_syncer",
+        types.SimpleNamespace(postgres_available=True, mark_unavailable=lambda: None),
+    )
     monkeypatch.setattr(mm, "redis", fake_redis)
     monkeypatch.setattr(mm, "duckdb", duckdb_stub(store))
     monkeypatch.setattr(mm, "store_vector", lambda u, q, r: 1)
@@ -181,6 +196,11 @@ def test_update_memory_postgres_failure(monkeypatch):
     fake_redis = FakeRedisModule()
 
     monkeypatch.setattr(mm, "postgres", pg)
+    monkeypatch.setattr(
+        mm,
+        "pg_syncer",
+        types.SimpleNamespace(postgres_available=True, mark_unavailable=lambda: None),
+    )
     monkeypatch.setattr(mm, "redis", fake_redis)
     monkeypatch.setattr(mm, "duckdb", duckdb_stub(store))
     monkeypatch.setattr(mm, "store_vector", lambda u, q, r: 1)

--- a/tests/test_memory_sync.py
+++ b/tests/test_memory_sync.py
@@ -23,7 +23,8 @@ def test_flush_after_reconnect(tmp_path, monkeypatch):
     importlib.reload(mm)
     fake = FakePostgres()
     monkeypatch.setattr(mm, "postgres", fake)
-    mm.pg_syncer.stop()
+    if getattr(mm, "pg_syncer", None):
+        mm.pg_syncer.stop()
     mm.pg_syncer = mm.PostgresSyncer(fake, str(db_path), interval=0.01)
     mm.pg_syncer.postgres_available = False
 


### PR DESCRIPTION
## Summary
- start memory sync lazily with `init_memory`
- call `init_memory` from `main.py` and from `fastapi.py`
- adjust memory manager tests for new init behavior
- guard Postgres syncer setup in tests

## Testing
- `pytest -q tests/test_memory_manager.py` *(passes)*
- ❌ `pytest -q tests/test_memory_sync.py` *(failed: ModuleNotFoundError: No module named 'duckdb')*

------
https://chatgpt.com/codex/tasks/task_e_68785400e0488324a2d4f980393cc48e