### PR TITLE
Handle 404 on announcements API

### DIFF
--- a/src/ui_logic/utils/api.py
+++ b/src/ui_logic/utils/api.py
@@ -182,8 +182,16 @@ def fetch_audit_logs(
         params["search"] = search
     return api_get("audit/logs", params=params, token=token, org=org)
 
-def fetch_announcements(limit: int = 10, token: Optional[str] = None, org: Optional[str] = None) -> Any:
-    return api_get("announcements", params={"limit": limit}, token=token, org=org)
+def fetch_announcements(
+    limit: int = 10, token: Optional[str] = None, org: Optional[str] = None
+) -> Any:
+    """Return a list of announcements or an empty list if the endpoint is missing."""
+    try:
+        return api_get("announcements", params={"limit": limit}, token=token, org=org)
+    except RuntimeError as e:  # 404 when endpoint isn't implemented
+        if "404" in str(e):
+            return []
+        raise
 
 def api_plugin_action(plugin: str, action: str, payload: Optional[dict] = None, token: Optional[str] = None, org: Optional[str] = None) -> Any:
     return api_post(f"plugins/{plugin}/{action}", data=payload, token=token, org=org)

--- a/tests/test_ui_api_utils.py
+++ b/tests/test_ui_api_utils.py
@@ -1,0 +1,20 @@
+import pytest
+
+import ui_logic.utils.api as api
+
+
+def test_fetch_announcements_404(monkeypatch):
+    def fake_api_get(*_, **__):
+        raise RuntimeError('API error: 404 {"detail":"Not Found"}')
+
+    monkeypatch.setattr(api, "api_get", fake_api_get)
+    assert api.fetch_announcements(limit=3) == []
+
+
+def test_fetch_announcements_other_error(monkeypatch):
+    def fake_api_get(*_, **__):
+        raise RuntimeError('API error: 500 {"detail":"oops"}')
+
+    monkeypatch.setattr(api, "api_get", fake_api_get)
+    with pytest.raises(RuntimeError):
+        api.fetch_announcements()


### PR DESCRIPTION
## Summary
- gracefully return an empty list when announcements endpoint isn't implemented
- test announcement fetching with 404 handling

## Testing
- `python - <<'EOF'
import types, sys
sys.modules['streamlit'] = types.ModuleType('streamlit')
import pytest
sys.exit(pytest.main(['-q', 'tests/test_ui_api_utils.py']))
EOF` *(fails: ModuleNotFoundError: No module named 'requests')*
- `pip install streamlit` *(fails: Cannot connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68785c5f53008324b2e8507f6ccad082