### PR TITLE
Add tenacity-based retry wrapper for API utils

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -33,3 +33,4 @@ redis
 psycopg
 chardet
 httpx
+tenacity

--- a/src/ui_logic/utils/api.py
+++ b/src/ui_logic/utils/api.py
@@ -10,6 +10,12 @@ import time
 import datetime
 import threading
 import requests
+from tenacity import (
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+)
 from typing import Any, Dict, List, Optional, Set, Union
 
 # ======= UI/API CONFIG =======
@@ -105,6 +111,16 @@ def handle_response(resp: requests.Response) -> Any:
     except requests.HTTPError as e:
         raise RuntimeError(f"API error: {e.response.status_code} {e.response.text}")
 
+
+@retry(
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=0.5),
+    retry=retry_if_exception_type(requests.RequestException),
+)
+def _safe_request(method: str, url: str, **kwargs) -> requests.Response:
+    """Wrapper around ``requests`` with retry semantics."""
+    return requests.request(method, url, **kwargs)
+
 def api_get(
     path: str,
     params: Optional[Dict[str, Any]] = None,
@@ -114,7 +130,13 @@ def api_get(
 ) -> Any:
     url = f"{API_BASE.rstrip('/')}/{path.lstrip('/')}"
     headers = get_auth_headers(token, org)
-    resp = requests.get(url, headers=headers, params=params, timeout=timeout or TIMEOUT)
+    resp = _safe_request(
+        "get",
+        url,
+        headers=headers,
+        params=params,
+        timeout=timeout or TIMEOUT,
+    )
     return handle_response(resp)
 
 def api_post(
@@ -129,12 +151,31 @@ def api_post(
     url = f"{API_BASE.rstrip('/')}/{path.lstrip('/')}"
     headers = get_auth_headers(token, org)
     if files:
-        resp = requests.post(url, headers=headers, files=files, data=data, timeout=timeout or TIMEOUT)
+        resp = _safe_request(
+            "post",
+            url,
+            headers=headers,
+            files=files,
+            data=data,
+            timeout=timeout or TIMEOUT,
+        )
     else:
         if json:
-            resp = requests.post(url, headers=headers, json=data, timeout=timeout or TIMEOUT)
+            resp = _safe_request(
+                "post",
+                url,
+                headers=headers,
+                json=data,
+                timeout=timeout or TIMEOUT,
+            )
         else:
-            resp = requests.post(url, headers=headers, data=data, timeout=timeout or TIMEOUT)
+            resp = _safe_request(
+                "post",
+                url,
+                headers=headers,
+                data=data,
+                timeout=timeout or TIMEOUT,
+            )
     return handle_response(resp)
 
 def api_put(
@@ -148,9 +189,21 @@ def api_put(
     url = f"{API_BASE.rstrip('/')}/{path.lstrip('/')}"
     headers = get_auth_headers(token, org)
     if json:
-        resp = requests.put(url, headers=headers, json=data, timeout=timeout or TIMEOUT)
+        resp = _safe_request(
+            "put",
+            url,
+            headers=headers,
+            json=data,
+            timeout=timeout or TIMEOUT,
+        )
     else:
-        resp = requests.put(url, headers=headers, data=data, timeout=timeout or TIMEOUT)
+        resp = _safe_request(
+            "put",
+            url,
+            headers=headers,
+            data=data,
+            timeout=timeout or TIMEOUT,
+        )
     return handle_response(resp)
 
 def api_delete(
@@ -161,7 +214,12 @@ def api_delete(
 ) -> Any:
     url = f"{API_BASE.rstrip('/')}/{path.lstrip('/')}"
     headers = get_auth_headers(token, org)
-    resp = requests.delete(url, headers=headers, timeout=timeout or TIMEOUT)
+    resp = _safe_request(
+        "delete",
+        url,
+        headers=headers,
+        timeout=timeout or TIMEOUT,
+    )
     return handle_response(resp)
 
 # ======= HIGH-LEVEL UI LOGIC (AUDIT, PLUGIN, HEALTH, PING, ANNOUNCEMENTS) =======
@@ -255,7 +313,11 @@ def ping_services(timeout: float = 2.0) -> dict:
     llm_url = os.getenv("KARI_LLM_URL")
     if llm_url:
         try:
-            resp = requests.get(f"{llm_url.rstrip('/')}/health", timeout=timeout)
+            resp = _safe_request(
+                "get",
+                f"{llm_url.rstrip('/')}/health",
+                timeout=timeout,
+            )
             status["llm"] = "ok" if resp.status_code == 200 else f"error: {resp.status_code}"
         except Exception as ex:
             status["llm"] = f"error: {ex}"

--- a/tests/test_ui_api_utils.py
+++ b/tests/test_ui_api_utils.py
@@ -1,4 +1,6 @@
 import pytest
+import requests
+import tenacity
 
 import ui_logic.utils.api as api
 
@@ -18,3 +20,45 @@ def test_fetch_announcements_other_error(monkeypatch):
     monkeypatch.setattr(api, "api_get", fake_api_get)
     with pytest.raises(RuntimeError):
         api.fetch_announcements()
+
+
+class DummyResponse:
+    def __init__(self, status_code: int = 200, text: str = "ok"):
+        self.status_code = status_code
+        self.text = text
+        self.headers = {"Content-Type": "text/plain"}
+
+    def json(self):
+        return self.text
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.HTTPError(response=self)
+
+
+def test_safe_request_retries(monkeypatch):
+    calls = {"count": 0}
+
+    def flaky_request(*args, **kwargs):
+        calls["count"] += 1
+        if calls["count"] < 3:
+            raise requests.RequestException("temp fail")
+        return DummyResponse()
+
+    monkeypatch.setattr(api.requests, "request", flaky_request)
+    monkeypatch.setattr(tenacity, "nap", lambda _: None)
+
+    resp = api._safe_request("get", "http://x")
+    assert calls["count"] == 3
+    assert resp.status_code == 200
+
+
+def test_safe_request_failure(monkeypatch):
+    def always_fail(*_, **__):
+        raise requests.RequestException("boom")
+
+    monkeypatch.setattr(api.requests, "request", always_fail)
+    monkeypatch.setattr(tenacity, "nap", lambda _: None)
+
+    with pytest.raises(requests.RequestException):
+        api._safe_request("get", "http://x")


### PR DESCRIPTION
## Summary
- add `tenacity` dependency
- wrap API utils with `_safe_request` that retries HTTP calls
- use `_safe_request` for API GET/POST/PUT/DELETE and health checks
- test retry behaviour with monkeypatched `requests.request`

## Testing
- `ruff check tests/test_ui_api_utils.py src/ui_logic/utils/api.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'streamlit')*

------
https://chatgpt.com/codex/tasks/task_e_68785ee27a88832491aa91524a130607