### PR TITLE
Fix duplicate import

### DIFF
--- a/src/ui_logic/utils/api.py
+++ b/src/ui_logic/utils/api.py
@@ -17,7 +17,6 @@ from tenacity import (
 )
 from typing import Any, Dict, List, Optional, Set, Union
 
-import requests
 
 from cachetools import TTLCache, cached
 


### PR DESCRIPTION
## Summary
- tidy imports in `src/ui_logic/utils/api.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'ai_karen_engine')*

------
https://chatgpt.com/codex/tasks/task_e_687864b04f548324b55e5157d71f478e