### PR TITLE
Fix plugin imports and add basic API routes

### DIFF
--- a/data/announcements.json
+++ b/data/announcements.json
@@ -1,0 +1,8 @@
+[
+  {
+    "id": "1",
+    "title": "Welcome to Kari AI",
+    "body": "Initial release.",
+    "created_at": "2024-01-01T00:00:00Z"
+  }
+]

--- a/src/ai_karen_engine/api_routes/__init__.py
+++ b/src/ai_karen_engine/api_routes/__init__.py
@@ -1,0 +1,1 @@
+# FastAPI routers for Kari

--- a/src/ai_karen_engine/api_routes/system.py
+++ b/src/ai_karen_engine/api_routes/system.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from ai_karen_engine.clients.database.duckdb_client import DuckDBClient
+
+try:
+    from pydantic import BaseModel
+except Exception:  # pragma: no cover - optional dependency
+    from ai_karen_engine.pydantic_stub import BaseModel
+
+router = __import__("fastapi").APIRouter()
+
+db = DuckDBClient()
+ANNOUNCE_PATH = Path(__file__).resolve().parents[3] / "data" / "announcements.json"
+
+
+class Announcement(BaseModel):
+    id: str
+    title: str
+    body: Optional[str] = None
+    created_at: Optional[str] = None
+
+
+class UserProfile(BaseModel):
+    user_id: str
+    name: Optional[str] = None
+    email: Optional[str] = None
+    preferences: Dict[str, Any] = {}
+
+
+@router.get("/health")
+def health() -> Dict[str, str]:
+    return {"status": "ok"}
+
+
+@router.get("/announcements", response_model=List[Announcement])
+def list_announcements(limit: int = 10) -> List[Announcement]:
+    if ANNOUNCE_PATH.exists():
+        data = json.loads(ANNOUNCE_PATH.read_text())
+    else:
+        data = []
+    return [Announcement(**a) for a in data[:limit]]
+
+
+@router.get("/users/{user_id}/profile", response_model=UserProfile)
+def get_profile(user_id: str) -> UserProfile:
+    profile = db.get_profile(user_id)
+    if profile is None:
+        raise (__import__("fastapi").HTTPException)(status_code=404, detail="Profile not found")
+    return UserProfile(user_id=user_id, **profile)

--- a/src/ai_karen_engine/clients/database/postgres_client.py
+++ b/src/ai_karen_engine/clients/database/postgres_client.py
@@ -7,7 +7,17 @@ import json
 from pathlib import Path
 from typing import Dict, Any, List, Optional, Callable
 
-import streamlit as st
+try:
+    import streamlit as st
+except Exception:  # pragma: no cover - optional dependency
+    class _Dummy:
+        def __getattr__(self, name):
+            return self
+
+        def __call__(self, *args, **kwargs):
+            return None
+
+    st = _Dummy()
 from ui_logic.hooks.rbac import require_roles
 from ui_logic.utils.api import (
     list_plugins,

--- a/src/ai_karen_engine/clients/slm_pool.py
+++ b/src/ai_karen_engine/clients/slm_pool.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Dict, Iterable, Optional
 
-from integrations.llm_utils import LLMUtils
+from ai_karen_engine.integrations.llm_utils import LLMUtils
 
 
 class SLMPool:

--- a/src/ai_karen_engine/core/reasoning/ice_integration.py
+++ b/src/ai_karen_engine/core/reasoning/ice_integration.py
@@ -12,9 +12,9 @@ import asyncio
 from typing import Any, Dict
 
  
-from integrations.llm_registry import registry as llm_registry
+from ai_karen_engine.integrations.llm_registry import registry as llm_registry
 
-from integrations.llm_utils import LLMUtils
+from ai_karen_engine.integrations.llm_utils import LLMUtils
 
 from ai_karen_engine.core.soft_reasoning_engine import SoftReasoningEngine
 

--- a/src/ai_karen_engine/integrations/model_discovery.py
+++ b/src/ai_karen_engine/integrations/model_discovery.py
@@ -85,16 +85,21 @@ class OllamaModelSource(ModelSourceBase):
     def list_models(self) -> List[Dict[str, Any]]:
         try:
             info = self.ollama.list()
-            models = [
-                {
-                    "name": m["name"],
-                    "size": m.get("size"),
-                    "digest": m.get("digest"),
-                    "source": "ollama",
-                    "details": m,
-                }
-                for m in info.get("models", [])
-            ]
+            models = []
+            for m in info.get("models", []):
+                name = m.get("name")
+                if not name:
+                    logger.warning(f"Unexpected model entry: {m}")
+                    continue
+                models.append(
+                    {
+                        "name": name,
+                        "size": m.get("size"),
+                        "digest": m.get("digest"),
+                        "source": "ollama",
+                        "details": m,
+                    }
+                )
             return models
         except Exception as ex:
             logger.error(f"Ollama model listing failed: {ex}")

--- a/src/ai_karen_engine/plugins/hf_llm/handler.py
+++ b/src/ai_karen_engine/plugins/hf_llm/handler.py
@@ -1,4 +1,4 @@
-from integrations.llm_utils import LLMUtils
+from ai_karen_engine.integrations.llm_utils import LLMUtils
 
 llm = LLMUtils()
 

--- a/src/ai_karen_engine/plugins/llm_manager/handler.py
+++ b/src/ai_karen_engine/plugins/llm_manager/handler.py
@@ -1,5 +1,5 @@
-from integrations.llm_registry import registry
-from integrations import model_discovery
+from ai_karen_engine.integrations.llm_registry import registry
+from ai_karen_engine.integrations import model_discovery
 
 async def run(params: dict) -> dict:
     action = params.get("action", "list")


### PR DESCRIPTION
## Summary
- fix integrations imports to use absolute path
- gracefully handle missing streamlit dependency
- harden Ollama model listing
- add placeholder announcements data
- implement `/api/health`, `/api/announcements`, and `/api/users/{user_id}/profile`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_687867c32b888324842c29546c762cfa