### PR TITLE
Improve plugin loading with module path and metrics

### DIFF
--- a/src/ai_karen_engine/plugins/autonomous_task_handler/plugin_manifest.json
+++ b/src/ai_karen_engine/plugins/autonomous_task_handler/plugin_manifest.json
@@ -7,5 +7,6 @@
     "admin",
     "power_user"
   ],
-  "trusted_ui": false
+  "trusted_ui": false,
+  "module": "ai_karen_engine.plugins.autonomous_task_handler.handler"
 }

--- a/src/ai_karen_engine/plugins/desktop_agent/plugin_manifest.json
+++ b/src/ai_karen_engine/plugins/desktop_agent/plugin_manifest.json
@@ -7,5 +7,6 @@
   "intent": [
     "desktop_action"
   ],
-  "trusted_ui": false
+  "trusted_ui": false,
+  "module": "ai_karen_engine.plugins.desktop_agent.handler"
 }

--- a/src/ai_karen_engine/plugins/fine_tune_lnm/plugin_manifest.json
+++ b/src/ai_karen_engine/plugins/fine_tune_lnm/plugin_manifest.json
@@ -1,7 +1,11 @@
 {
   "plugin_api_version": "1.0",
   "enable_external_workflow": false,
-  "required_roles": ["admin", "dev"],
+  "required_roles": [
+    "admin",
+    "dev"
+  ],
   "intent": "fine_tune_lnm",
-  "trusted_ui": false
+  "trusted_ui": false,
+  "module": "ai_karen_engine.plugins.fine_tune_lnm.handler"
 }

--- a/src/ai_karen_engine/plugins/git_merge_safe/plugin_manifest.json
+++ b/src/ai_karen_engine/plugins/git_merge_safe/plugin_manifest.json
@@ -5,5 +5,6 @@
   "required_roles": [
     "devops"
   ],
-  "trusted_ui": false
+  "trusted_ui": false,
+  "module": "ai_karen_engine.plugins.git_merge_safe.handler"
 }

--- a/src/ai_karen_engine/plugins/hello_world/plugin_manifest.json
+++ b/src/ai_karen_engine/plugins/hello_world/plugin_manifest.json
@@ -5,5 +5,6 @@
     "user"
   ],
   "intent": "greet",
-  "trusted_ui": false
+  "trusted_ui": false,
+  "module": "ai_karen_engine.plugins.hello_world.handler"
 }

--- a/src/ai_karen_engine/plugins/hf_llm/plugin_manifest.json
+++ b/src/ai_karen_engine/plugins/hf_llm/plugin_manifest.json
@@ -5,5 +5,6 @@
   "required_roles": [
     "user"
   ],
-  "trusted_ui": false
+  "trusted_ui": false,
+  "module": "ai_karen_engine.plugins.hf_llm.handler"
 }

--- a/src/ai_karen_engine/plugins/k8s_scale/plugin_manifest.json
+++ b/src/ai_karen_engine/plugins/k8s_scale/plugin_manifest.json
@@ -5,5 +5,6 @@
   "required_roles": [
     "devops"
   ],
-  "trusted_ui": false
+  "trusted_ui": false,
+  "module": "ai_karen_engine.plugins.k8s_scale.handler"
 }

--- a/src/ai_karen_engine/plugins/llm_manager/plugin_manifest.json
+++ b/src/ai_karen_engine/plugins/llm_manager/plugin_manifest.json
@@ -2,6 +2,9 @@
   "plugin_api_version": "1.0",
   "intent": "llm_manage",
   "enable_external_workflow": false,
-  "required_roles": ["dev"],
-  "trusted_ui": false
+  "required_roles": [
+    "dev"
+  ],
+  "trusted_ui": false,
+  "module": "ai_karen_engine.plugins.llm_manager.handler"
 }

--- a/src/ai_karen_engine/plugins/llm_services/deepseek/plugin_manifest.json
+++ b/src/ai_karen_engine/plugins/llm_services/deepseek/plugin_manifest.json
@@ -2,6 +2,9 @@
   "plugin_api_version": "1.0",
   "intent": "deepseek_chat",
   "enable_external_workflow": false,
-  "required_roles": ["admin"],
-  "trusted_ui": false
+  "required_roles": [
+    "admin"
+  ],
+  "trusted_ui": false,
+  "module": "ai_karen_engine.plugins.llm_services.deepseek.handler"
 }

--- a/src/ai_karen_engine/plugins/llm_services/gemini/plugin_manifest.json
+++ b/src/ai_karen_engine/plugins/llm_services/gemini/plugin_manifest.json
@@ -2,6 +2,9 @@
   "plugin_api_version": "1.0",
   "intent": "gemini_chat",
   "enable_external_workflow": false,
-  "required_roles": ["admin"],
-  "trusted_ui": false
+  "required_roles": [
+    "admin"
+  ],
+  "trusted_ui": false,
+  "module": "ai_karen_engine.plugins.llm_services.gemini.handler"
 }

--- a/src/ai_karen_engine/plugins/llm_services/llama/plugin_manifest.json
+++ b/src/ai_karen_engine/plugins/llm_services/llama/plugin_manifest.json
@@ -4,13 +4,22 @@
   "type": "llm_provider",
   "entrypoint": "llama.handler:router",
   "description": "Pure in-process LLM using llama-cpp-python. No REST, no server. Hot-reload, async, and streaming.",
-  "runtimes": ["python3.10+", "llama-cpp-python>=0.2.60"],
-  "tags": ["local", "llm", "plugin", "production"],
+  "runtimes": [
+    "python3.10+",
+    "llama-cpp-python>=0.2.60"
+  ],
+  "tags": [
+    "local",
+    "llm",
+    "plugin",
+    "production"
+  ],
   "config": {
     "model_path": "./models/tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf",
     "n_ctx": 2048,
     "n_gpu_layers": 30,
     "max_tokens": 1024,
     "temperature": 0.7
-  }
+  },
+  "module": "ai_karen_engine.plugins.llm_services.llama.handler"
 }

--- a/src/ai_karen_engine/plugins/llm_services/openai/plugin_manifest.json
+++ b/src/ai_karen_engine/plugins/llm_services/openai/plugin_manifest.json
@@ -2,6 +2,9 @@
   "plugin_api_version": "1.0",
   "intent": "openai_chat",
   "enable_external_workflow": false,
-  "required_roles": ["admin"],
-  "trusted_ui": false
+  "required_roles": [
+    "admin"
+  ],
+  "trusted_ui": false,
+  "module": "ai_karen_engine.plugins.llm_services.openai.handler"
 }

--- a/src/ai_karen_engine/plugins/time_query/plugin_manifest.json
+++ b/src/ai_karen_engine/plugins/time_query/plugin_manifest.json
@@ -2,6 +2,9 @@
   "plugin_api_version": "1.0",
   "intent": "time_query",
   "enable_external_workflow": false,
-  "required_roles": ["user"],
-  "trusted_ui": false
+  "required_roles": [
+    "user"
+  ],
+  "trusted_ui": false,
+  "module": "ai_karen_engine.plugins.time_query.handler"
 }

--- a/src/ai_karen_engine/plugins/tui_fallback/plugin_manifest.json
+++ b/src/ai_karen_engine/plugins/tui_fallback/plugin_manifest.json
@@ -7,5 +7,6 @@
   "intent": [
     "tui_diagnostics"
   ],
-  "trusted_ui": false
+  "trusted_ui": false,
+  "module": "ai_karen_engine.plugins.tui_fallback.handler"
 }


### PR DESCRIPTION
## Summary
- support `module` field in plugin manifests and import by module if provided
- emit `plugin_import_error_total` metric for failed imports
- update built-in plugin manifests with `module` field

## Testing
- ❌ `pre-commit` *(failed to run: pre-commit not installed)*
- ❌ `pytest -q` *(failed to run: ModuleNotFoundError for ai_karen_engine)*

------
https://chatgpt.com/codex/tasks/task_e_68786d8e43d88324a17f4e979beee250