### PR TITLE
Fix relative imports

### DIFF
--- a/src/ai_karen_engine/doc_store/__init__.py
+++ b/src/ai_karen_engine/doc_store/__init__.py
@@ -1,5 +1,5 @@
 """Document ingestion and search utilities."""
 
-from .document_store import DocumentStore
+from ai_karen_engine.doc_store.document_store import DocumentStore
 
 __all__ = ["DocumentStore"]

--- a/src/ai_karen_engine/mcp/__init__.py
+++ b/src/ai_karen_engine/mcp/__init__.py
@@ -1,11 +1,11 @@
 """MCP module providing gRPC/JSON-RPC clients and service wrappers."""
 
-from .registry import ServiceRegistry
-from .base import BaseMCPClient, AuthorizationError
-from .grpc_client import GRPCClient
-from .json_rpc_client import JSONRPCClient
+from ai_karen_engine.mcp.registry import ServiceRegistry
+from ai_karen_engine.mcp.base import BaseMCPClient, AuthorizationError
+from ai_karen_engine.mcp.grpc_client import GRPCClient
+from ai_karen_engine.mcp.json_rpc_client import JSONRPCClient
 try:
-    from .services import KnowledgeGraphService, LLMService
+    from ai_karen_engine.mcp.services import KnowledgeGraphService, LLMService
 except Exception:  # pragma: no cover - optional deps
     KnowledgeGraphService = LLMService = None
 

--- a/src/ai_karen_engine/mcp/grpc_client.py
+++ b/src/ai_karen_engine/mcp/grpc_client.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import time
 from typing import Any
 
-from .base import BaseMCPClient
+from ai_karen_engine.mcp.base import BaseMCPClient
 
 
 class GRPCClient(BaseMCPClient):

--- a/src/ai_karen_engine/mcp/json_rpc_client.py
+++ b/src/ai_karen_engine/mcp/json_rpc_client.py
@@ -11,7 +11,7 @@ try:
 except Exception:  # pragma: no cover - optional dep
     httpx = None
 
-from .base import BaseMCPClient
+from ai_karen_engine.mcp.base import BaseMCPClient
 
 
 class JSONRPCClient(BaseMCPClient):

--- a/src/ai_karen_engine/mcp/services.py
+++ b/src/ai_karen_engine/mcp/services.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from typing import Any, Dict, Optional
 
-from .registry import ServiceRegistry
-from .base import AuthorizationError
+from ai_karen_engine.mcp.registry import ServiceRegistry
+from ai_karen_engine.mcp.base import AuthorizationError
 from ai_karen_engine.services.knowledge_graph_client import KnowledgeGraphClient
 from ai_karen_engine.integrations.llm_utils import LLMUtils
 

--- a/src/ai_karen_engine/plugins/llm_services/llama/__init__.py
+++ b/src/ai_karen_engine/plugins/llm_services/llama/__init__.py
@@ -1,2 +1,4 @@
 # Initialize the plugin for auto-discovery
-from .handler import router  # Expose FastAPI router for plugin registration
+from ai_karen_engine.plugins.llm_services.llama.handler import (
+    router,
+)  # Expose FastAPI router for plugin registration


### PR DESCRIPTION
## Summary
- replace all `from .` imports with absolute `ai_karen_engine` imports

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68787baa3d188324832c48db3bc4f94f