### PR TITLE
Fix feature flag helper

### DIFF
--- a/src/ui_logic/config/feature_flags.py
+++ b/src/ui_logic/config/feature_flags.py
@@ -81,7 +81,7 @@ def register_plugin_flag(flag: str, default: bool = False):
 
 def is_feature_enabled(key: str, custom_path: str | None = None) -> bool:
     """Return ``True`` if the feature flag ``key`` is enabled."""
-    return bool(get_flag(key, custom_path))
+    return bool(get_flag(key))
 
 # === Public API ===
 __all__ = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,9 @@ import importlib
 import os
 import sys
 import types
-import ai_karen_engine.clients.database.postgres_client as pg_mod
+sys.modules.setdefault("requests", importlib.import_module("tests.stubs.requests"))
+sys.modules.setdefault("tenacity", importlib.import_module("tests.stubs.tenacity"))
+pg_mod = importlib.import_module("tests.stubs.ai_karen_engine.clients.database.postgres_client")
 
 
 # Alias installed-style packages for tests

--- a/tests/test_feature_flags.py
+++ b/tests/test_feature_flags.py
@@ -1,0 +1,17 @@
+import importlib
+from ui_logic.config import feature_flags
+
+
+def test_env_override(monkeypatch):
+    key = "enable_iot"
+    env_var = "KARI_FEATURE_ENABLE_IOT"
+    monkeypatch.delenv(env_var, raising=False)
+    importlib.reload(feature_flags)
+    assert feature_flags.is_feature_enabled(key) is False
+
+    monkeypatch.setenv(env_var, "true")
+    assert feature_flags.is_feature_enabled(key)
+
+    monkeypatch.setenv(env_var, "0")
+    assert not feature_flags.is_feature_enabled(key)
+


### PR DESCRIPTION
## Summary
- fix `is_feature_enabled` to call `get_flag` directly
- stub dependencies for tests
- add unit test for feature flag env override

## Testing
- `ruff check src/ui_logic/config/feature_flags.py tests/conftest.py tests/test_feature_flags.py`
- `PYTHONPATH=src pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68787baf76488324a342a0fabcdbb6d8