### PR TITLE
Update Streamlit configs and theme tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ src/integrations/  # NANDA client, RPA helpers, external bridges
  src/ai_karen_engine/plugins/       # drop-in plugins (manifest + handler + ui)
 ui_launchers/desktop_ui/ # Tauri Control Room (Rust + React)
 ui_launchers/streamlit_ui/config/config_ui.py # Streamlit UI settings (ConfigUI class)
+ui_launchers/streamlit_ui/config/env.py      # environment defaults for the Streamlit UI
+ui_launchers/streamlit_ui/config/routing.py  # page routing map for Streamlit
 src/fastapi_stub/  # API entrypoints, chat & metrics
 src/pydantic_stub/ # DTOs & schemas
 tests/         # pytest suite

--- a/docs/development_guide.md
+++ b/docs/development_guide.md
@@ -18,9 +18,12 @@ xdg-open http://localhost:8000/docs
 # run the Streamlit UI
 streamlit run ui_launchers/streamlit_ui/app.py
 ```
-The Streamlit UI reads environment variables via
-`ui_launchers/streamlit_ui/config/config_ui.py`.
-If you previously imported `config/config_ui.py`, switch to this new path.
+The Streamlit UI configuration now lives under
+`ui_launchers/streamlit_ui/config/` with:
+`config_ui.py` for the settings model,
+`env.py` for environment defaults and
+`routing.py` for the page map.
+If you previously imported `config/config_ui.py`, switch to these new paths.
 
 ## Build Mode (Tauri App)
 

--- a/tests/test_persona_controls.py
+++ b/tests/test_persona_controls.py
@@ -29,7 +29,7 @@ class DummySidebar:
 
 MODULE_PATH = (
     Path(__file__).resolve().parents[1]
-    / "ui/mobile_ui/mobile_components/persona_controls.py"
+    / "ui_launchers/streamlit_ui/components/persona_controls.py"
 )
 
 

--- a/tests/test_theme_manager.py
+++ b/tests/test_theme_manager.py
@@ -1,0 +1,48 @@
+import os
+import types
+import sys
+from pathlib import Path
+
+import ui_logic.themes.theme_manager as tm
+
+
+def test_get_available_themes(tmp_path, monkeypatch):
+    theme_dir = tmp_path / "themes"
+    theme_dir.mkdir()
+    (theme_dir / "light.css").write_text("body {}")
+    (theme_dir / "dark.css").write_text("body {}")
+    monkeypatch.setenv("KARI_THEME_CONFIG", str(theme_dir))
+    themes = tm.get_available_themes()
+    assert themes == {
+        "light": str(theme_dir / "light.css"),
+        "dark": str(theme_dir / "dark.css"),
+    }
+
+
+def test_set_theme_writes_audit_and_marks_css(tmp_path, monkeypatch):
+    theme_dir = tmp_path / "themes"
+    theme_dir.mkdir()
+    css_file = theme_dir / "light.css"
+    css_file.write_text("body {color:red}")
+    audit_log = tmp_path / "audit.log"
+    monkeypatch.setenv("KARI_THEME_CONFIG", str(theme_dir))
+    monkeypatch.setenv("KARI_THEME_AUDIT_LOG", str(audit_log))
+
+    fake_st = types.ModuleType("streamlit")
+    recorded = {}
+
+    def markdown(css, unsafe_allow_html=False):
+        recorded["css"] = css
+        recorded["allow"] = unsafe_allow_html
+
+    fake_st.markdown = markdown
+    fake_st.session_state = {}
+    monkeypatch.setitem(sys.modules, "streamlit", fake_st)
+
+    tm.set_theme("light", {"user_id": "tester"})
+
+    assert recorded["allow"]
+    assert "color:red" in recorded["css"]
+    assert audit_log.exists()
+    log = audit_log.read_text()
+    assert "set_theme" in log

--- a/ui_launchers/streamlit_ui/app.py
+++ b/ui_launchers/streamlit_ui/app.py
@@ -4,16 +4,16 @@ Kari Streamlit UI Entrypoint
 - Only UI layout, page router, session mgmt, and theme injection
 """
 
+import importlib.resources
 import streamlit as st
 from helpers.session import get_user_context
 from config.routing import PAGE_MAP
 
 # Theme injection (uses streamlit's built-in/theming with CSS from the repo)
 def inject_theme():
-    from pathlib import Path
-    # Resolve theme path relative to repo root to avoid missing file issues
-    theme_css = Path(__file__).resolve().parents[2] / "src" / "ui_logic" / "themes" / "light.css"
-    st.markdown(f"<style>{theme_css.read_text()}</style>", unsafe_allow_html=True)
+    """Inject the default theme CSS bundled with ``ui_logic``."""
+    css_path = importlib.resources.files("ui_logic.themes").joinpath("light.css")
+    st.markdown(f"<style>{css_path.read_text()}</style>", unsafe_allow_html=True)
 
 def main():
     inject_theme()


### PR DESCRIPTION
## Summary
- document new Streamlit configuration modules
- update dev guide with env.py and routing.py
- load theme CSS via `importlib.resources`
- point persona controls test to new location
- add tests for theme manager

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'ai_karen_engine')*

------
https://chatgpt.com/codex/tasks/task_e_68787c5a32288324b5c0f4e728202a70