### PR TITLE
Implement theme switcher hooks and icons

### DIFF
--- a/docs/development_guide.md
+++ b/docs/development_guide.md
@@ -69,3 +69,17 @@ Other variables such as `KARI_MODEL_DIR` or UI branding options have sensible
 defaults and are optional. The above keys must be exported in your shell (or CI
 job) before running the API, Control Room, or `pytest`.
 
+
+## Accessibility Guidelines
+
+To meet WCAG AA requirements, ensure all text maintains a contrast ratio of at least **4.5:1** (or **3:1** for large headings). Interactive widgets must be reachable with the keyboard and provide visible focus outlines.
+
+### Keyboard Shortcuts
+
+| Action | Shortcut |
+| ------ | -------- |
+| Focus search | `/` |
+| Toggle dark mode | `Ctrl+Shift+D` |
+| Open help | `?` |
+
+These shortcuts should be implemented in custom components where possible.

--- a/src/ui_logic/components/plugins/plugin_store.py
+++ b/src/ui_logic/components/plugins/plugin_store.py
@@ -4,6 +4,9 @@ Kari Plugin Store Logic
 """
 
 from typing import Dict, List
+
+import streamlit as st
+
 from ui_logic.hooks.rbac import require_roles
 from ui_logic.utils.api import (
     fetch_store_plugins,
@@ -25,3 +28,19 @@ def get_plugin_store_audit(user_ctx: Dict, limit: int = 25):
     if not user_ctx or not require_roles(user_ctx, ["admin", "developer"]):
         raise PermissionError("Insufficient privileges for plugin store audit.")
     return fetch_audit_logs(category="plugin_store", user_id=user_ctx["user_id"])[-limit:][::-1]
+
+
+def render_plugin_store(user_ctx: Dict) -> None:
+    """Simple placeholder UI until store is implemented."""
+    if not user_ctx or not require_roles(user_ctx, ["user", "admin", "developer"]):
+        st.error("Insufficient privileges to access plugin store.")
+        return
+    st.info("Plugin store not available yet.")
+
+
+__all__ = [
+    "list_store_plugins",
+    "search_plugin_marketplace",
+    "get_plugin_store_audit",
+    "render_plugin_store",
+]

--- a/src/ui_logic/themes/design_tokens.py
+++ b/src/ui_logic/themes/design_tokens.py
@@ -1,0 +1,34 @@
+"""Design tokens for Kari UI themes."""
+
+COLORS = {
+    "light": {
+        "background": "#ffffff",
+        "surface": "#f5f5f5",
+        "accent": "#1e88e5",
+    },
+    "dark": {
+        "background": "#161622",
+        "surface": "#212134",
+        "accent": "#bb00ff",
+    },
+    "enterprise": {
+        "background": "#f3f4f7",
+        "surface": "#ffffff",
+        "accent": "#004578",
+    },
+}
+
+SPACING = {
+    "xs": "4px",
+    "sm": "8px",
+    "md": "12px",
+    "lg": "16px",
+    "xl": "24px",
+}
+
+FONTS = {
+    "base": "Inter, Segoe UI, Arial, sans-serif",
+    "mono": "Consolas, monospace",
+}
+
+__all__ = ["COLORS", "SPACING", "FONTS"]

--- a/src/ui_logic/utils/api.py
+++ b/src/ui_logic/utils/api.py
@@ -510,6 +510,22 @@ def disable_plugin(plugin_name: str) -> bool:
     return True
 
 
+def fetch_store_plugins() -> List[Dict[str, Any]]:
+    """Return a list of plugins available from the store."""
+    try:
+        return api_get("plugin-store")
+    except Exception:
+        return []
+
+
+def search_plugins(query: str) -> List[Dict[str, Any]]:
+    """Search the plugin store."""
+    try:
+        return api_get("plugin-store/search", params={"q": query})
+    except Exception:
+        return []
+
+
 # ========================= MEMORY ANALYTICS =========================
 
 
@@ -649,6 +665,8 @@ __all__ = [
     "uninstall_plugin",
     "enable_plugin",
     "disable_plugin",
+    "fetch_store_plugins",
+    "search_plugins",
     "fetch_memory_metrics",
     "fetch_memory_analytics",
     "fetch_session_memory",

--- a/ui_launchers/streamlit_ui/app.py
+++ b/ui_launchers/streamlit_ui/app.py
@@ -4,22 +4,23 @@ Kari Streamlit UI Entrypoint
 - Only UI layout, page router, session mgmt, and theme injection
 """
 
-import importlib.resources
 import streamlit as st
 from helpers.session import get_user_context
 from config.routing import PAGE_MAP
+from ui_logic.themes.theme_manager import get_current_theme, load_theme_css
 
 # Theme injection (uses streamlit's built-in/theming with CSS from the repo)
-def inject_theme():
-    """Inject the default theme CSS bundled with ``ui_logic``."""
-    css_path = importlib.resources.files("ui_logic.themes").joinpath("light.css")
-    st.markdown(f"<style>{css_path.read_text()}</style>", unsafe_allow_html=True)
+def inject_theme(user_ctx):
+    """Inject the user's current theme CSS."""
+    theme = get_current_theme(user_ctx)
+    css = load_theme_css(theme)
+    st.markdown(f"<style>{css}</style>", unsafe_allow_html=True)
 
 def main():
-    inject_theme()
+    user_ctx = get_user_context()
+    inject_theme(user_ctx)
     st.sidebar.title("Kari AI")
     st.sidebar.markdown("---")
-    user_ctx = get_user_context()
     # Page Routing
     page = st.sidebar.radio("Navigate", list(PAGE_MAP.keys()), index=0)
     st.sidebar.markdown("---")

--- a/ui_launchers/streamlit_ui/helpers/icons.py
+++ b/ui_launchers/streamlit_ui/helpers/icons.py
@@ -1,0 +1,19 @@
+"""Centralized icon definitions for the Streamlit UI."""
+
+ICONS = {
+    "chat": "💬",
+    "memory": "🧠",
+    "analytics": "📊",
+    "plugins": "🧩",
+    "iot": "📡",
+    "task_manager": "✅",
+    "admin": "🛡️",
+    "settings": "⚙️",
+}
+
+
+def get_icon(name: str) -> str:
+    """Return icon string for given name."""
+    return ICONS.get(name, "")
+
+__all__ = ["ICONS", "get_icon"]

--- a/ui_launchers/streamlit_ui/pages/home.py
+++ b/ui_launchers/streamlit_ui/pages/home.py
@@ -13,6 +13,7 @@ from ui_logic.utils.api import fetch_announcements
 from ui_logic.components.memory.profile_panel import render_profile_panel
 from ui_logic.components.analytics.chart_builder import render_quick_charts
 from ui_logic.components.admin.system_status import render_system_status
+from helpers.icons import ICONS
 
 def render_welcome(user_ctx, branding):
     st.markdown(
@@ -48,14 +49,14 @@ def render_shortcuts(user_ctx):
     st.markdown("### Quick Access")
     cols = st.columns(4)
     pages = [
-        {"label": "Chat", "icon": "💬", "page": "chat", "roles": ["user", "admin", "dev"]},
-        {"label": "Memory", "icon": "🧠", "page": "memory", "roles": ["user", "admin"]},
-        {"label": "Analytics", "icon": "📊", "page": "analytics", "roles": ["admin", "dev"]},
-        {"label": "Plugins", "icon": "🧩", "page": "plugins", "roles": ["dev", "admin"]},
-        {"label": "IoT", "icon": "📡", "page": "iot", "roles": ["dev", "admin"]},
-        {"label": "Task Manager", "icon": "✅", "page": "task_manager", "roles": ["admin", "dev"]},
-        {"label": "Admin", "icon": "🛡️", "page": "admin", "roles": ["admin"]},
-        {"label": "Settings", "icon": "⚙️", "page": "settings", "roles": ["user", "admin", "dev"]},
+        {"label": "Chat", "icon": ICONS["chat"], "page": "chat", "roles": ["user", "admin", "dev"]},
+        {"label": "Memory", "icon": ICONS["memory"], "page": "memory", "roles": ["user", "admin"]},
+        {"label": "Analytics", "icon": ICONS["analytics"], "page": "analytics", "roles": ["admin", "dev"]},
+        {"label": "Plugins", "icon": ICONS["plugins"], "page": "plugins", "roles": ["dev", "admin"]},
+        {"label": "IoT", "icon": ICONS["iot"], "page": "iot", "roles": ["dev", "admin"]},
+        {"label": "Task Manager", "icon": ICONS["task_manager"], "page": "task_manager", "roles": ["admin", "dev"]},
+        {"label": "Admin", "icon": ICONS["admin"], "page": "admin", "roles": ["admin"]},
+        {"label": "Settings", "icon": ICONS["settings"], "page": "settings", "roles": ["user", "admin", "dev"]},
     ]
     idx = 0
     for p in pages:


### PR DESCRIPTION
## Summary
- add design tokens and icon helper modules
- instrument theme manager with telemetry and expose `load_theme_css`
- use current theme in Streamlit entrypoint
- centralize quick access icons in `home.py`
- document accessibility guidelines and keyboard shortcuts

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'ai_karen_engine')*

------
https://chatgpt.com/codex/tasks/task_e_6878dc8a6b4083248fdc9b068abe7198