### PR TITLE
Implement UI config helpers

### DIFF
--- a/ui_launchers/streamlit_ui/config/__init__.py
+++ b/ui_launchers/streamlit_ui/config/__init__.py
@@ -1,7 +1,17 @@
 """Streamlit UI configuration helpers."""
 
-from ui_launchers.streamlit_ui.config.env import get_data_dir, get_setting
-from ui_launchers.streamlit_ui.config.theme import load_css, apply_theme
+from ui_launchers.streamlit_ui.config.env import (
+    get_data_dir,
+    get_setting,
+    get_bool_setting,
+    get_int_setting,
+)
+from ui_launchers.streamlit_ui.config.theme import (
+    load_css,
+    apply_theme,
+    available_themes,
+    get_default_theme,
+)
 from ui_launchers.streamlit_ui.config.routing import PAGE_MAP
 
 __all__ = [
@@ -9,5 +19,9 @@ __all__ = [
     "get_setting",
     "load_css",
     "apply_theme",
+    "available_themes",
+    "get_default_theme",
+    "get_bool_setting",
+    "get_int_setting",
     "PAGE_MAP",
 ]

--- a/ui_launchers/streamlit_ui/config/env.py
+++ b/ui_launchers/streamlit_ui/config/env.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
+from distutils.util import strtobool
 
 
 def get_data_dir() -> str:
@@ -15,4 +16,31 @@ def get_setting(name: str, default: str | None = None) -> str | None:
     return os.getenv(name, default)
 
 
-__all__ = ["get_data_dir", "get_setting"]
+def get_bool_setting(name: str, default: bool = False) -> bool:
+    """Return a boolean env var, accepting common truthy values."""
+    value = os.getenv(name)
+    if value is None:
+        return default
+    try:
+        return bool(strtobool(value))
+    except ValueError:
+        return default
+
+
+def get_int_setting(name: str, default: int | None = None) -> int | None:
+    """Return an integer env var if set and valid."""
+    value = os.getenv(name)
+    if value is None:
+        return default
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+__all__ = [
+    "get_data_dir",
+    "get_setting",
+    "get_bool_setting",
+    "get_int_setting",
+]

--- a/ui_launchers/streamlit_ui/config/theme.py
+++ b/ui_launchers/streamlit_ui/config/theme.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import importlib.resources
 from pathlib import Path
 
+import os
 import streamlit as st
 
 THEME_DIR = Path(__file__).resolve().parents[1] / "styles"
@@ -31,4 +32,19 @@ def apply_theme(theme: str = "light") -> None:
         st.markdown(f"<style>{css}</style>", unsafe_allow_html=True)
 
 
-__all__ = ["load_css", "apply_theme"]
+def available_themes() -> list[str]:
+    """Return a list of theme names available in the style directory."""
+    return [p.stem for p in THEME_DIR.glob("*.css")]
+
+
+def get_default_theme() -> str:
+    """Return the default theme name from env or 'light'."""
+    return os.getenv("KARI_DEFAULT_THEME", "light")
+
+
+__all__ = [
+    "load_css",
+    "apply_theme",
+    "available_themes",
+    "get_default_theme",
+]


### PR DESCRIPTION
## Summary
- expose new `get_bool_setting` and `get_int_setting` helpers
- expose theme utility functions for theme discovery
- update Streamlit UI config exports

## Testing
- `pytest -q tests/ui/test_chat_hub.py` *(fails: ModuleNotFoundError: No module named 'ai_karen_engine')*

------
https://chatgpt.com/codex/tasks/task_e_6878e010660c832484afc88006a37f06