### PR TITLE
Enhance Streamlit UI config helpers

### DIFF
--- a/tests/ui/test_env_theme_config.py
+++ b/tests/ui/test_env_theme_config.py
@@ -1,0 +1,54 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def config_modules(monkeypatch):
+    """Load config modules with a fake ``streamlit`` present."""
+    fake_st = types.ModuleType("streamlit")
+    fake_st.markdown = lambda *a, **k: None
+    monkeypatch.setitem(sys.modules, "streamlit", fake_st)
+    root = Path(__file__).resolve().parents[2]
+    env_path = root / "ui_launchers/streamlit_ui/config/env.py"
+    theme_path = root / "ui_launchers/streamlit_ui/config/theme.py"
+
+    spec_env = importlib.util.spec_from_file_location("env_mod", env_path)
+    env = importlib.util.module_from_spec(spec_env)
+    assert spec_env.loader is not None
+    spec_env.loader.exec_module(env)
+
+    spec_theme = importlib.util.spec_from_file_location("theme_mod", theme_path)
+    theme = importlib.util.module_from_spec(spec_theme)
+    assert spec_theme.loader is not None
+    spec_theme.loader.exec_module(theme)
+    yield env, theme
+    monkeypatch.delitem(sys.modules, "streamlit", raising=False)
+
+
+def test_env_helpers(monkeypatch, config_modules):
+    env, _ = config_modules
+    monkeypatch.setenv("TEST_BOOL", "true")
+    monkeypatch.setenv("TEST_INT", "42")
+    assert env.get_bool_setting("TEST_BOOL") is True
+    assert env.get_bool_setting("MISSING_BOOL", True) is True
+    assert env.get_int_setting("TEST_INT") == 42
+    monkeypatch.setenv("TEST_INT", "oops")
+    assert env.get_int_setting("TEST_INT", 7) == 7
+
+
+def test_available_themes_includes_defaults(config_modules):
+    _, theme = config_modules
+    names = theme.available_themes()
+    assert {"light", "dark"}.issubset(set(names))
+
+
+def test_theme_helpers(monkeypatch, config_modules):
+    _, theme = config_modules
+    assert theme.theme_exists("light")
+    assert not theme.theme_exists("nope")
+    monkeypatch.setenv("KARI_UI_THEME", "dark")
+    assert theme.get_default_theme() == "dark"

--- a/ui_launchers/streamlit_ui/config/__init__.py
+++ b/ui_launchers/streamlit_ui/config/__init__.py
@@ -1,13 +1,31 @@
 """Streamlit UI configuration helpers."""
 
-from ui_launchers.streamlit_ui.config.env import get_data_dir, get_setting
-from ui_launchers.streamlit_ui.config.theme import load_css, apply_theme
+from ui_launchers.streamlit_ui.config.env import (
+    get_data_dir,
+    get_setting,
+    get_bool_setting,
+    get_int_setting,
+)
+from ui_launchers.streamlit_ui.config.theme import (
+    load_css,
+    apply_theme,
+    available_themes,
+    theme_exists,
+    get_default_theme,
+    apply_default_theme,
+)
 from ui_launchers.streamlit_ui.config.routing import PAGE_MAP
 
 __all__ = [
     "get_data_dir",
     "get_setting",
+    "get_bool_setting",
+    "get_int_setting",
     "load_css",
     "apply_theme",
+    "available_themes",
+    "theme_exists",
+    "get_default_theme",
+    "apply_default_theme",
     "PAGE_MAP",
 ]

--- a/ui_launchers/streamlit_ui/config/env.py
+++ b/ui_launchers/streamlit_ui/config/env.py
@@ -15,4 +15,26 @@ def get_setting(name: str, default: str | None = None) -> str | None:
     return os.getenv(name, default)
 
 
-__all__ = ["get_data_dir", "get_setting"]
+def get_bool_setting(name: str, default: bool = False) -> bool:
+    """Return a boolean env var value supporting common truthy strings."""
+    val = os.getenv(name)
+    if val is None:
+        return default
+    return str(val).lower() in {"1", "true", "yes", "y", "on"}
+
+
+def get_int_setting(name: str, default: int = 0) -> int:
+    """Return an integer env var value with fallback on parse error."""
+    val = os.getenv(name)
+    try:
+        return int(val) if val is not None else default
+    except (TypeError, ValueError):
+        return default
+
+
+__all__ = [
+    "get_data_dir",
+    "get_setting",
+    "get_bool_setting",
+    "get_int_setting",
+]

--- a/ui_launchers/streamlit_ui/config/theme.py
+++ b/ui_launchers/streamlit_ui/config/theme.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import importlib.resources
+import os
 from pathlib import Path
 
 import streamlit as st
@@ -24,6 +25,36 @@ def load_css(theme: str = "light") -> str:
         return ""
 
 
+def theme_exists(theme: str) -> bool:
+    """Return ``True`` if a theme CSS file is available."""
+    if (THEME_DIR / f"{theme}.css").exists():
+        return True
+    try:
+        return (
+            importlib.resources.files("ui_logic.themes")
+            .joinpath(f"{theme}.css")
+            .is_file()
+        )
+    except Exception:
+        return False
+
+
+def available_themes() -> list[str]:
+    """Return a sorted list of available theme names."""
+    names = {p.stem for p in THEME_DIR.glob("*.css")}
+    try:
+        pkg = importlib.resources.files("ui_logic.themes")
+        names.update(p.stem for p in pkg.glob("*.css"))
+    except FileNotFoundError:
+        pass
+    return sorted(names)
+
+
+def get_default_theme() -> str:
+    """Return the default theme set via ``KARI_UI_THEME`` or ``light``."""
+    return os.getenv("KARI_UI_THEME", "light")
+
+
 def apply_theme(theme: str = "light") -> None:
     """Inject theme CSS into the page if available."""
     css = load_css(theme)
@@ -31,4 +62,16 @@ def apply_theme(theme: str = "light") -> None:
         st.markdown(f"<style>{css}</style>", unsafe_allow_html=True)
 
 
-__all__ = ["load_css", "apply_theme"]
+def apply_default_theme() -> None:
+    """Apply the theme configured via ``KARI_UI_THEME``."""
+    apply_theme(get_default_theme())
+
+
+__all__ = [
+    "load_css",
+    "apply_theme",
+    "available_themes",
+    "theme_exists",
+    "get_default_theme",
+    "apply_default_theme",
+]


### PR DESCRIPTION
## Summary
- extend Streamlit UI env helpers with boolean & int parsing
- expose available theme listing and default theme utilities
- export new helpers via `config.__init__`
- update tests with fake streamlit module

## Testing
- `pytest tests/ui/test_env_theme_config.py -q`
- `pytest tests/ui/test_chat_hub.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6878e009eb6883248ba7a47c346ce76a