### PR TITLE
Refine Streamlit theme handling and UI

### DIFF
--- a/src/ui_logic/components/plugins/workflow_builder.py
+++ b/src/ui_logic/components/plugins/workflow_builder.py
@@ -4,6 +4,7 @@ Kari Workflow Builder Logic
 """
 
 from typing import Dict, List
+import streamlit as st
 from ui_logic.hooks.rbac import require_roles
 from ui_logic.utils.api import (
     fetch_user_workflows,
@@ -37,3 +38,19 @@ def get_workflow_audit_trail(user_ctx: Dict, limit: int = 25):
     if not user_ctx or not require_roles(user_ctx, ["admin", "developer"]):
         raise PermissionError("Insufficient privileges for workflow audit.")
     return fetch_audit_logs(category="workflow", user_id=user_ctx["user_id"])[-limit:][::-1]
+
+
+def render_workflow_builder(user_ctx: Dict) -> None:
+    """Placeholder UI for workflow building."""
+    st.subheader("Workflow Builder")
+    st.info("Workflow builder under construction.")
+
+
+__all__ = [
+    "get_workflows",
+    "create_new_workflow",
+    "delete_existing_workflow",
+    "update_existing_workflow",
+    "get_workflow_audit_trail",
+    "render_workflow_builder",
+]

--- a/src/ui_logic/themes/theme_manager.py
+++ b/src/ui_logic/themes/theme_manager.py
@@ -18,15 +18,22 @@ from .design_tokens import COLORS
 
 from ui_logic.hooks.telemetry import telemetry_event
 
-THEME_CONFIG_PATH = os.getenv("KARI_THEME_CONFIG", "src/ui/themes/")
-THEME_AUDIT_PATH = os.getenv("KARI_THEME_AUDIT_LOG", "/secure/logs/kari/theme_audit.log")
+def _theme_config_path() -> Path:
+    """Return the directory where theme CSS files reside."""
+    return Path(os.getenv("KARI_THEME_CONFIG", "src/ui/themes/"))
+
+def _audit_log_path() -> Path:
+    """Return the audit log file path."""
+    return Path(os.getenv("KARI_THEME_AUDIT_LOG", "/secure/logs/kari/theme_audit.log"))
+
 THEME_SIGNING_KEY = os.getenv("KARI_THEME_SIGNING_KEY", "change-me-to-secure-key")
 
 
 _theme_lock = threading.Lock()
 
 def _audit_theme_event(event: Dict[str, Any]):
-    os.makedirs(os.path.dirname(THEME_AUDIT_PATH), exist_ok=True)
+    path = _audit_log_path()
+    os.makedirs(path.parent, exist_ok=True)
     timestamp = int(time.time())
     payload = str(event) + str(timestamp)
     signature = hmac.new(THEME_SIGNING_KEY.encode(), payload.encode(), hashlib.sha512).hexdigest()
@@ -36,12 +43,12 @@ def _audit_theme_event(event: Dict[str, Any]):
         "signature": signature
     }
     with _theme_lock:
-        with open(THEME_AUDIT_PATH, "a") as f:
+        with open(path, "a") as f:
             f.write(str(line) + "\n")
 
 def load_theme_css(theme_name: str) -> str:
     """Return raw CSS string for the given theme name."""
-    theme_file = Path(THEME_CONFIG_PATH) / f"{theme_name}.css"
+    theme_file = _theme_config_path() / f"{theme_name}.css"
     if theme_file.exists():
         with open(theme_file, "r") as f:
             return f.read()
@@ -59,7 +66,7 @@ def load_theme_css(theme_name: str) -> str:
 
 def get_available_themes() -> Dict[str, str]:
     """Discover all .css theme files in config dir"""
-    theme_dir = Path(THEME_CONFIG_PATH)
+    theme_dir = _theme_config_path()
     if not theme_dir.exists():
         raise FileNotFoundError("Theme config directory not found")
     return {f.stem: str(f) for f in theme_dir.glob("*.css")}
@@ -79,9 +86,11 @@ def set_theme(theme_name: str, user_ctx: Dict[str, Any]):
     # You may also want to persist session theme choice in user_ctx/session, etc.
 
 def get_current_theme(user_ctx: Dict[str, Any]) -> str:
-    """Return current theme for the user/session (fallback to default)"""
-    # You could tie this to a user/session DB, but here use a cookie/session var
+    """Return the current theme for the user/session (fallback to default)."""
     import streamlit as st
+    params = st.experimental_get_query_params()
+    if params.get("theme"):
+        return params["theme"][0]
     if "kari_theme" in st.session_state:
         return st.session_state["kari_theme"]
     return "light"
@@ -95,8 +104,13 @@ def render_theme_switcher(user_ctx: Dict[str, Any]):
         st.info("No themes available.")
         return
     st.subheader("Theme")
-    selected = st.selectbox("Choose Theme", list(themes.keys()), index=list(themes.keys()).index(current) if current in themes else 0)
+    selected = st.selectbox(
+        "Choose Theme",
+        list(themes.keys()),
+        index=list(themes.keys()).index(current) if current in themes else 0,
+    )
     if st.button("Apply Theme"):
+        st.experimental_set_query_params(theme=selected)
         set_theme(selected, user_ctx)
         st.session_state["kari_theme"] = selected
         st.success(f"Theme changed to '{selected}'")
@@ -109,10 +123,16 @@ def render_theme_switcher(user_ctx: Dict[str, Any]):
     })
     telemetry_event("view_theme_switcher", {"current": current}, user_id=user_ctx.get("user_id"))
 
+def apply_default_theme(user_ctx: Dict[str, Any]) -> None:
+    """Apply the theme resolved from :func:`get_current_theme`."""
+    theme = get_current_theme(user_ctx)
+    set_theme(theme, user_ctx)
+
 __all__ = [
     "get_available_themes",
     "load_theme_css",
     "set_theme",
     "get_current_theme",
-    "render_theme_switcher"
+    "render_theme_switcher",
+    "apply_default_theme",
 ]

--- a/src/ui_logic/utils/api.py
+++ b/src/ui_logic/utils/api.py
@@ -504,6 +504,14 @@ def search_plugins(query: str, limit: int = 50, token: Optional[str] = None, org
         return []
 
 
+def fetch_user_workflows(token: Optional[str] = None, org: Optional[str] = None) -> List[Dict[str, Any]]:
+    """Return workflows for the current user or an empty list on error."""
+    try:
+        return api_get("plugins/user_workflows", token=token, org=org)
+    except Exception:
+        return []
+
+
 def list_plugins() -> list:
     """Return available plugins."""
     return ["evil_plugin", "super_plugin"]
@@ -529,20 +537,6 @@ def disable_plugin(plugin_name: str) -> bool:
     return True
 
 
-def fetch_store_plugins() -> List[Dict[str, Any]]:
-    """Return a list of plugins available from the store."""
-    try:
-        return api_get("plugin-store")
-    except Exception:
-        return []
-
-
-def search_plugins(query: str) -> List[Dict[str, Any]]:
-    """Search the plugin store."""
-    try:
-        return api_get("plugin-store/search", params={"q": query})
-    except Exception:
-        return []
 
 
 # ========================= MEMORY ANALYTICS =========================
@@ -686,6 +680,7 @@ __all__ = [
     "uninstall_plugin",
     "enable_plugin",
     "disable_plugin",
+    "fetch_user_workflows",
     "fetch_store_plugins",
     "search_plugins",
     "fetch_memory_metrics",

--- a/ui_launchers/streamlit_ui/app.py
+++ b/ui_launchers/streamlit_ui/app.py
@@ -7,24 +7,66 @@ Kari Streamlit UI Entrypoint
 import streamlit as st
 from helpers.session import get_user_context
 from config.routing import PAGE_MAP
-from ui_logic.themes.theme_manager import get_current_theme, load_theme_css
+from helpers.icons import ICONS
+from ui_logic.themes.theme_manager import (
+    apply_default_theme,
+    render_theme_switcher,
+)
 
-# Theme injection (uses streamlit's built-in/theming with CSS from the repo)
+def render_sidebar(page: str, user_ctx) -> str:
+    """Render primary and secondary navigation sidebar."""
+    st.sidebar.title("Kari AI")
+    st.sidebar.markdown("---")
+
+    primary = {
+        "Chat": "chat",
+        "Home": "home",
+        "Memory": "memory",
+        "Analytics": "analytics",
+    }
+    secondary = {
+        "Plugins": "plugins",
+        "Settings": "settings",
+        "Admin": "admin",
+    }
+
+    def label(name):
+        key = primary.get(name) or secondary.get(name)
+        return f"{ICONS.get(key, '')} {name}"
+
+    choice = st.sidebar.radio(
+        "Navigate",
+        list(primary.keys()),
+        index=list(primary.keys()).index(page) if page in primary else 0,
+        format_func=label,
+    )
+    with st.sidebar.expander("More"):
+        more = st.radio(
+            "More",
+            list(secondary.keys()),
+            index=list(secondary.keys()).index(page) if page in secondary else 0,
+            format_func=label,
+            label_visibility="collapsed",
+        )
+        if more:
+            choice = more
+
+    st.sidebar.markdown("---")
+    render_theme_switcher(user_ctx)
+    return choice
+
+
 def inject_theme(user_ctx):
-    """Inject the user's current theme CSS."""
-    theme = get_current_theme(user_ctx)
-    css = load_theme_css(theme)
-    st.markdown(f"<style>{css}</style>", unsafe_allow_html=True)
+    """Apply the current theme to the page."""
+    apply_default_theme(user_ctx)
+
 
 def main():
     user_ctx = get_user_context()
     inject_theme(user_ctx)
-    st.sidebar.title("Kari AI")
-    st.sidebar.markdown("---")
-    # Page Routing
-    page = st.sidebar.radio("Navigate", list(PAGE_MAP.keys()), index=0)
-    st.sidebar.markdown("---")
-    # Launch page
+    current_page = st.experimental_get_query_params().get("page", ["Home"])[0]
+    page = render_sidebar(current_page, user_ctx)
+    st.experimental_set_query_params(page=page)
     PAGE_MAP[page](user_ctx=user_ctx)
 
 if __name__ == "__main__":

--- a/ui_launchers/streamlit_ui/pages/chat.py
+++ b/ui_launchers/streamlit_ui/pages/chat.py
@@ -7,6 +7,14 @@ Kari Chat Panel (Evil Twin Enterprise Version)
 import streamlit as st
 import time
 import uuid
+
+def _auto_refresh(interval: int = 1000, key: str = "chat_refresh") -> None:
+    """Lightweight auto-refresh using experimental_rerun."""
+    now = int(time.time() * 1000)
+    last = st.session_state.get(key, now)
+    if now - last >= interval:
+        st.session_state[key] = now
+        st.experimental_rerun()
 from ui_logic.hooks.rbac import user_has_role
 from ui_logic.utils.api import (
     fetch_user_profile, 
@@ -95,6 +103,7 @@ def sys_announce_panel():
 # ========== Main Chat Logic ==========
 def chat_panel(user_ctx):
     st.title("💬 Kari Chat")
+    _auto_refresh()
     get_context_state()
     sys_announce_panel()
     st.sidebar.header("Session Controls")
@@ -161,6 +170,7 @@ def chat_panel(user_ctx):
                 st.session_state["chat_history"].append({"role": "kari", "text": err, "ts": time.time()})
                 evil_toast("LLM error. Check backend.", "💀")
                 st.error(err)
+            st.experimental_rerun()
 
     st.caption("Twin Mode: All interactions are audit-logged. All glory to Kari.")
 

--- a/ui_launchers/streamlit_ui/pages/settings.py
+++ b/ui_launchers/streamlit_ui/pages/settings.py
@@ -132,12 +132,23 @@ def render_model_catalog() -> None:
 
 
 def render_settings() -> None:
-    try:
-        render_model_catalog()
-    except Exception as e:
-        logger.critical(f"Catalog page crashed: {e}")
-        st.error("The model catalog encountered a critical error")
-        st.code(traceback.format_exc())
+    st.title("\U00002699 Settings")
+    tabs = st.tabs(["Profile", "Theme", "Integrations", "Notifications"])
+    with tabs[0]:
+        st.info("Profile settings coming soon.")
+    with tabs[1]:
+        st.info("Theme options below.")
+        from ui_logic.themes.theme_manager import render_theme_switcher
+        render_theme_switcher({})
+    with tabs[2]:
+        try:
+            render_model_catalog()
+        except Exception as e:
+            logger.critical(f"Catalog page crashed: {e}")
+            st.error("The model catalog encountered a critical error")
+            st.code(traceback.format_exc())
+    with tabs[3]:
+        st.warning("Notification settings under construction.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- make theme configuration path dynamic and add theme switcher with query param persistence
- overhaul Streamlit sidebar with primary/secondary pages and theme picker
- refresh chat page automatically and rerun after messages
- group settings page into tabs and expose theme switcher
- stub workflow builder UI and plugin API helpers

## Testing
- `PYTHONPATH=src pytest tests/test_theme_manager.py -q`
- `python -m py_compile ui_launchers/streamlit_ui/app.py ui_launchers/streamlit_ui/pages/chat.py ui_launchers/streamlit_ui/pages/settings.py src/ui_logic/components/plugins/workflow_builder.py src/ui_logic/themes/theme_manager.py src/ui_logic/utils/api.py`

------
https://chatgpt.com/codex/tasks/task_e_6878ef7019108324aa839283966785f6