### PR TITLE
Fix theme config helpers

### DIFF
--- a/ui_launchers/streamlit_ui/config/env.py
+++ b/ui_launchers/streamlit_ui/config/env.py
@@ -3,7 +3,16 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
-from distutils.util import strtobool
+try:
+    from distutils.util import strtobool  # deprecated on Python 3.12
+except Exception:  # pragma: no cover - fallback for environments without distutils
+    def strtobool(val: str) -> int:
+        val = val.lower()
+        if val in {"y", "yes", "t", "true", "on", "1"}:
+            return 1
+        if val in {"n", "no", "f", "false", "off", "0"}:
+            return 0
+        raise ValueError(f"invalid truth value {val!r}")
 
 
 def get_data_dir() -> str:

--- a/ui_launchers/streamlit_ui/config/theme.py
+++ b/ui_launchers/streamlit_ui/config/theme.py
@@ -5,7 +5,6 @@ import importlib.resources
 import os
 from pathlib import Path
 
-import os
 import streamlit as st
 
 THEME_DIR = Path(__file__).resolve().parents[1] / "styles"
@@ -62,14 +61,10 @@ def apply_theme(theme: str = "light") -> None:
     if css:
         st.markdown(f"<style>{css}</style>", unsafe_allow_html=True)
 
-def available_themes() -> list[str]:
-    """Return a list of theme names available in the style directory."""
-    return [p.stem for p in THEME_DIR.glob("*.css")]
 
-
-def get_default_theme() -> str:
-    """Return the default theme name from env or 'light'."""
-    return os.getenv("KARI_DEFAULT_THEME", "light")
+def apply_default_theme() -> None:
+    """Apply the UI theme configured in ``KARI_UI_THEME``."""
+    apply_theme(get_default_theme())
 
 
 __all__ = [


### PR DESCRIPTION
## Summary
- fix `distutils` dependency for env helpers
- consolidate theme functions and implement `apply_default_theme`

## Testing
- `PYTHONPATH=src pytest -q tests/ui/test_env_theme_config.py::test_available_themes_includes_defaults`

------
https://chatgpt.com/codex/tasks/task_e_6878fd5220688324a205c887bfc66bad