### PR TITLE
Fix plugin manager exports

### DIFF
--- a/src/ai_karen_engine/clients/database/postgres_client.py
+++ b/src/ai_karen_engine/clients/database/postgres_client.py
@@ -235,6 +235,5 @@ __all__ = [
     "PluginManifestError",
     "PluginValidationError",
     "PluginRBACError",
-    "create_plugin_manager",
     "render_plugin_manager",
 ]

--- a/src/ui_logic/components/plugins/plugin_manager.py
+++ b/src/ui_logic/components/plugins/plugin_manager.py
@@ -225,6 +225,5 @@ __all__ = [
     "PluginManifestError",
     "PluginValidationError",
     "PluginRBACError",
-    "create_plugin_manager",
     "render_plugin_manager",
 ]


### PR DESCRIPTION
## Summary
- remove unused `create_plugin_manager` from plugin manager modules

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'duckdb')*

------
https://chatgpt.com/codex/tasks/task_e_6878fd5e31388324bf22a148fa642588