### PR TITLE
Fix theme import path

### DIFF
--- a/src/ui_logic/themes/theme_manager.py
+++ b/src/ui_logic/themes/theme_manager.py
@@ -14,7 +14,7 @@ import hashlib
 from pathlib import Path
 from typing import Dict, Any
 
-from .design_tokens import COLORS
+from ui_logic.themes.design_tokens import COLORS
 
 from ui_logic.hooks.telemetry import telemetry_event
 


### PR DESCRIPTION
## Summary
- use absolute import for design tokens to comply with project guidelines

## Testing
- `PYTHONPATH=src pytest tests/test_theme_manager.py::test_get_available_themes -q`


------
https://chatgpt.com/codex/tasks/task_e_6878fd6835b48324b9b3f61123ba038d