### PR TITLE
Fix Milvus reset check

### DIFF
--- a/src/ui_logic/components/memory/memory_manager.py
+++ b/src/ui_logic/components/memory/memory_manager.py
@@ -90,7 +90,7 @@ def reset_profile(user_id: str):
     require_user(user_id)
     duckdb.delete_profile(user_id)
     duckdb.delete_profile_history(user_id)
-    if milvus:
+    if milvus is not None:
         milvus.delete_persona_embedding(user_id)
     redis.flush_short_term(user_id)
     redis.flush_long_term(user_id)


### PR DESCRIPTION
## Summary
- ensure Milvus availability is checked explicitly before deleting embeddings

## Testing
- `pre-commit` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6878fda31ce88324acdea2d404d2dbbe