### PR TITLE
Fix workflow API stubs

### DIFF
--- a/src/ui_logic/utils/api.py
+++ b/src/ui_logic/utils/api.py
@@ -487,26 +487,35 @@ def fetch_knowledge_graph(user_id: str = None, query: str = "") -> dict:
 
 # ====== PLUGINS ======
 
-def fetch_user_workflows(token: Optional[str] = None, org: Optional[str] = None) -> List[Dict[str, Any]]:
+def fetch_user_workflows(
+    token: Optional[str] = None, org: Optional[str] = None
+) -> List[Dict[str, Any]]:
     """Return workflows for the authenticated user or ``[]`` on error."""
     try:
         return api_get("plugins/user_workflows", token=token, org=org)
     except Exception:
         return []
-      
-def fetch_store_plugins(token: Optional[str] = None, org: Optional[str] = None) -> List[Dict[str, Any]]:
+
+def fetch_store_plugins(
+    limit: int = 50, token: Optional[str] = None, org: Optional[str] = None
+) -> List[Dict[str, Any]]:
     """Return plugin metadata from the store API or an empty list on error."""
     try:
-        return api_get("plugins/store", token=token, org=org)
+        params = {"limit": limit}
+        return api_get("plugins/store", params=params, token=token, org=org)
     except Exception:
         return []
 
-
-def search_plugins(query: str, token: Optional[str] = None, org: Optional[str] = None) -> List[Dict[str, Any]]:
+def search_plugins(
+    query: str,
+    limit: int = 50,
+    token: Optional[str] = None,
+    org: Optional[str] = None,
+) -> List[Dict[str, Any]]:
     """Search public plugin marketplace."""
     try:
-        return api_get("plugins/search", params={"q": query}, token=token, org=org)
-      
+        params = {"q": query, "limit": limit}
+        return api_get("plugins/search", params=params, token=token, org=org)
     except Exception:
         return []
 
@@ -541,45 +550,6 @@ def update_workflow(user_id: str, workflow_id: str, updates: Dict[str, Any], tok
     except Exception:
         return False
       
-def fetch_user_workflows(token: Optional[str] = None, org: Optional[str] = None) -> List[Dict[str, Any]]:
-    """Return workflows for the current user or an empty list on error."""
-    try:
-        return api_get("plugins/user_workflows", token=token, org=org)
-      
-    except Exception:
-        return []
-
-
-def create_workflow(user_id: str, workflow: Dict[str, Any], token: Optional[str] = None, org: Optional[str] = None) -> bool:
-    """Create a new workflow for ``user_id``."""
-    try:
-        api_post(f"plugins/user_workflows/{user_id}", data=workflow, token=token, org=org)
-        return True
-    except Exception:
-        return False
-
-
-def delete_workflow(user_id: str, workflow_id: str, token: Optional[str] = None, org: Optional[str] = None) -> bool:
-    """Delete a workflow by id."""
-    try:
-        api_delete(f"plugins/user_workflows/{user_id}/{workflow_id}", token=token, org=org)
-        return True
-    except Exception:
-        return False
-
-
-def update_workflow(user_id: str, workflow_id: str, updates: Dict[str, Any], token: Optional[str] = None, org: Optional[str] = None) -> bool:
-    """Update an existing workflow."""
-    try:
-        api_put(
-            f"plugins/user_workflows/{user_id}/{workflow_id}",
-            data=updates,
-            token=token,
-            org=org,
-        )
-        return True
-    except Exception:
-        return False
 
 
 def list_plugins() -> list:
@@ -754,9 +724,6 @@ __all__ = [
     "uninstall_plugin",
     "enable_plugin",
     "disable_plugin",
-    "fetch_user_workflows",
-    "fetch_store_plugins",
-    "search_plugins",
     "fetch_memory_metrics",
     "fetch_memory_analytics",
     "fetch_session_memory",

--- a/tests/stubs/requests.py
+++ b/tests/stubs/requests.py
@@ -32,3 +32,16 @@ def put(*args, **kwargs):
 
 def delete(*args, **kwargs):
     return Response()
+
+
+def request(method, *args, **kwargs):
+    method = method.lower()
+    if method == "get":
+        return get(*args, **kwargs)
+    if method == "post":
+        return post(*args, **kwargs)
+    if method == "put":
+        return put(*args, **kwargs)
+    if method == "delete":
+        return delete(*args, **kwargs)
+    return Response()

--- a/tests/stubs/tenacity.py
+++ b/tests/stubs/tenacity.py
@@ -4,7 +4,18 @@ class RetryError(Exception):
 
 def retry(*dargs, **dkwargs):
     def decorator(fn):
-        return fn
+        def wrapped(*args, **kwargs):
+            attempts = 0
+            max_attempts = 3
+            while True:
+                try:
+                    return fn(*args, **kwargs)
+                except Exception:
+                    attempts += 1
+                    if attempts >= max_attempts:
+                        raise
+                    nap(0)
+        return wrapped
     return decorator
 
 


### PR DESCRIPTION
## Summary
- stub workflow CRUD helpers in `api.py`
- deduplicate plugin helpers and update parameters
- ensure tests use stubbed `requests.request` and basic retry logic for tenacity

## Testing
- `PYTHONPATH=$PWD/src pytest -q tests/test_ui_api_utils.py`
- `PYTHONPATH=$PWD/src pytest -q` *(fails: ModuleNotFoundError: No module named 'duckdb')*

------
https://chatgpt.com/codex/tasks/task_e_6878fd44bbfc83249dbc4d4b240f5384