### PR TITLE
Expose memory metrics utility

### DIFF
--- a/src/ai_karen_engine/core/memory/manager.py
+++ b/src/ai_karen_engine/core/memory/manager.py
@@ -59,6 +59,11 @@ _METRICS: Dict[str, int] = {
     "memory_recall_total": 0,
 }
 
+
+def get_metrics() -> Dict[str, int]:
+    """Return a copy of the current memory metrics."""
+    return dict(_METRICS)
+
 try:
     from prometheus_client import Counter
     from ai_karen_engine.integrations.llm_utils import PROM_REGISTRY
@@ -411,4 +416,10 @@ def update_memory(user_ctx: Dict[str, Any], query: str, result: Any) -> bool:
             f"[MemoryManager] FAILED to store memory for user {user_id} on all backends"
         )
     return ok
-__all__ = ["recall_context", "update_memory", "flush_duckdb_to_postgres", "_METRICS"]
+__all__ = [
+    "recall_context",
+    "update_memory",
+    "flush_duckdb_to_postgres",
+    "get_metrics",
+    "_METRICS",
+]

--- a/ui_launchers/streamlit_ui/pages/memory.py
+++ b/ui_launchers/streamlit_ui/pages/memory.py
@@ -147,20 +147,11 @@ else:
 # --- Metrics Dashboard ---
 if show_metrics:
     st.subheader("Memory Metrics (live)")
-    # Demo version: mockup stats (implement real metrics from memory_manager.get_metrics() if wired)
-    metrics = {
-        "reads_success": 123,
-        "reads_failure": 4,
-        "writes_success": 76,
-        "writes_failure": 2,
-        "current_time": time.strftime("%Y-%m-%d %H:%M:%S"),
-    }
     try:
-        from ai_karen_engine.core.memory import memory_manager
-        real_metrics = memory_manager.get_metrics()
-        metrics.update(real_metrics)
+        from ai_karen_engine.core.memory.manager import get_metrics
+        metrics = get_metrics()
     except Exception:
-        pass
+        metrics = {}
     st.json(metrics)
 
 # --- Backend Error Logs ---


### PR DESCRIPTION
## Summary
- add `get_metrics` helper to memory manager for introspecting metrics
- export `get_metrics` via `__all__`
- show live metrics on the Streamlit memory page

## Testing
- `PYTHONPATH=src pytest tests/test_memory_manager.py::test_memory_metrics -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6878fd6ea23c8324876139567af9f9e4