### PR TITLE
Add placeholders and theme CSS for Streamlit UI

### DIFF
--- a/ui_launchers/streamlit_ui/pages/automation.py
+++ b/ui_launchers/streamlit_ui/pages/automation.py
@@ -1,0 +1,3 @@
+import streamlit as st
+
+st.info("Page under construction.")

--- a/ui_launchers/streamlit_ui/pages/autonomous.py
+++ b/ui_launchers/streamlit_ui/pages/autonomous.py
@@ -1,0 +1,3 @@
+import streamlit as st
+
+st.info("Page under construction.")

--- a/ui_launchers/streamlit_ui/pages/code_lab.py
+++ b/ui_launchers/streamlit_ui/pages/code_lab.py
@@ -1,0 +1,3 @@
+import streamlit as st
+
+st.info("Page under construction.")

--- a/ui_launchers/streamlit_ui/pages/context.py
+++ b/ui_launchers/streamlit_ui/pages/context.py
@@ -1,0 +1,3 @@
+import streamlit as st
+
+st.info("Page under construction.")

--- a/ui_launchers/streamlit_ui/pages/diagnostics.py
+++ b/ui_launchers/streamlit_ui/pages/diagnostics.py
@@ -1,0 +1,3 @@
+import streamlit as st
+
+st.info("Page under construction.")

--- a/ui_launchers/streamlit_ui/pages/echo_core.py
+++ b/ui_launchers/streamlit_ui/pages/echo_core.py
@@ -1,0 +1,3 @@
+import streamlit as st
+
+st.info("Page under construction.")

--- a/ui_launchers/streamlit_ui/pages/files.py
+++ b/ui_launchers/streamlit_ui/pages/files.py
@@ -1,0 +1,3 @@
+import streamlit as st
+
+st.info("Page under construction.")

--- a/ui_launchers/streamlit_ui/pages/integrations.py
+++ b/ui_launchers/streamlit_ui/pages/integrations.py
@@ -1,0 +1,3 @@
+import streamlit as st
+
+st.info("Page under construction.")

--- a/ui_launchers/streamlit_ui/pages/personas.py
+++ b/ui_launchers/streamlit_ui/pages/personas.py
@@ -1,0 +1,3 @@
+import streamlit as st
+
+st.info("Page under construction.")

--- a/ui_launchers/streamlit_ui/pages/presence.py
+++ b/ui_launchers/streamlit_ui/pages/presence.py
@@ -1,0 +1,3 @@
+import streamlit as st
+
+st.info("Page under construction.")

--- a/ui_launchers/streamlit_ui/pages/security.py
+++ b/ui_launchers/streamlit_ui/pages/security.py
@@ -1,0 +1,3 @@
+import streamlit as st
+
+st.info("Page under construction.")

--- a/ui_launchers/streamlit_ui/pages/vision.py
+++ b/ui_launchers/streamlit_ui/pages/vision.py
@@ -1,0 +1,3 @@
+import streamlit as st
+
+st.info("Page under construction.")

--- a/ui_launchers/streamlit_ui/pages/voice.py
+++ b/ui_launchers/streamlit_ui/pages/voice.py
@@ -1,0 +1,3 @@
+import streamlit as st
+
+st.info("Page under construction.")

--- a/ui_launchers/streamlit_ui/pages/white_label.py
+++ b/ui_launchers/streamlit_ui/pages/white_label.py
@@ -1,0 +1,3 @@
+import streamlit as st
+
+st.info("Page under construction.")

--- a/ui_launchers/streamlit_ui/pages/workflows.py
+++ b/ui_launchers/streamlit_ui/pages/workflows.py
@@ -1,0 +1,3 @@
+import streamlit as st
+
+st.info("Page under construction.")

--- a/ui_launchers/streamlit_ui/styles/dark.css
+++ b/ui_launchers/streamlit_ui/styles/dark.css
@@ -1,0 +1,11 @@
+/* Basic dark theme */
+:root {
+    --background: #161622;
+    --surface: #212134;
+    --accent: #bb00ff;
+    --text: #e6e7fb;
+}
+body {
+    background: var(--surface);
+    color: var(--text);
+}

--- a/ui_launchers/streamlit_ui/styles/enterprise.css
+++ b/ui_launchers/streamlit_ui/styles/enterprise.css
@@ -1,9 +1,15 @@
+/* Basic enterprise theme */
+:root {
+    --background: #0b0c10;
+    --surface: #101215;
+    --accent: #5cdb95;
+    --text: #f8f8f2;
+}
 body {
-    background-color: #0b0c10;
-    color: #f8f8f2;
+    background: var(--surface);
+    color: var(--text);
 }
 .stButton>button {
-    background-color: #5cdb95;
+    background-color: var(--accent);
     color: black;
 }
-

--- a/ui_launchers/streamlit_ui/styles/light.css
+++ b/ui_launchers/streamlit_ui/styles/light.css
@@ -1,0 +1,11 @@
+/* Basic light theme */
+:root {
+    --background: #ffffff;
+    --surface: #f5f5f5;
+    --accent: #1e88e5;
+    --text: #222222;
+}
+body {
+    background: var(--surface);
+    color: var(--text);
+}


### PR DESCRIPTION
## Summary
- add stub message to empty Streamlit page modules
- define simple theme variables for `dark`, `light`, and `enterprise` themes

## Testing
- `pytest tests/test_theme_manager.py::test_get_available_themes -q` *(fails: ModuleNotFoundError: No module named 'ai_karen_engine')*

------
https://chatgpt.com/codex/tasks/task_e_6878fdcb095883249f653e0c42666a43