### PR TITLE
Fix pytest path

### DIFF
--- a/docs/tests.md
+++ b/docs/tests.md
@@ -9,10 +9,11 @@ Kari includes a pytest suite that covers the core API, plugin router and SelfRef
 - **End-to-End** – store text and retrieve it via search to ensure the memory layer works.
 - **SaaS Tests** – validate tenant isolation and license enforcement.
 
-Run all tests:
+Run all tests (the `ai_karen_engine` sources live under `src/` so add it to
+`PYTHONPATH` when invoking pytest):
 
 ```bash
-pytest -q
+PYTHONPATH=src pytest -q
 ```
 
 Coverage should remain above 85% for core modules.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,12 @@ import importlib
 import os
 import sys
 import types
+from pathlib import Path
+
+try:
+    import ai_karen_engine  # noqa: F401
+except Exception:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 sys.modules.setdefault("requests", importlib.import_module("tests.stubs.requests"))
 sys.modules.setdefault("tenacity", importlib.import_module("tests.stubs.tenacity"))
 pg_mod = importlib.import_module("tests.stubs.ai_karen_engine.clients.database.postgres_client")


### PR DESCRIPTION
## Summary
- make `tests/conftest` fall back to adding the src directory when `ai_karen_engine` isn't importable
- document running tests via `PYTHONPATH=src pytest -q`

## Testing
- `PYTHONPATH=src pytest -q` *(fails: _Dummy object has no attribute 'labels')*

------
https://chatgpt.com/codex/tasks/task_e_68791920c3f08324bc459261c1bc0cc8