### PR TITLE
Add stubs for numpy and pyautogui

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,21 @@ import types
 sys.modules.setdefault("requests", importlib.import_module("tests.stubs.requests"))
 sys.modules.setdefault("tenacity", importlib.import_module("tests.stubs.tenacity"))
 pg_mod = importlib.import_module("tests.stubs.ai_karen_engine.clients.database.postgres_client")
-sys.modules.setdefault("duckdb", importlib.import_module("tests.stubs.duckdb"))
+
+try:  # Optional dependency
+    import duckdb  # type: ignore
+except Exception:
+    sys.modules.setdefault("duckdb", importlib.import_module("tests.stubs.duckdb"))
+
+try:  # Optional dependency
+    import numpy  # type: ignore
+except Exception:
+    sys.modules.setdefault("numpy", importlib.import_module("tests.stubs.numpy"))
+
+try:  # Optional dependency
+    import pyautogui  # type: ignore
+except Exception:
+    sys.modules.setdefault("pyautogui", importlib.import_module("tests.stubs.pyautogui"))
 
 
 # Alias installed-style packages for tests

--- a/tests/stubs/numpy.py
+++ b/tests/stubs/numpy.py
@@ -1,0 +1,59 @@
+import math
+
+float32 = 'float32'
+uint8 = 'uint8'
+inf = float('inf')
+nan = float('nan')
+
+class _Array(list):
+    def __getitem__(self, item):
+        result = super().__getitem__(item)
+        if isinstance(item, slice):
+            return _Array(result)
+        return result
+
+    def astype(self, dtype):
+        if dtype in ('float32', float32):
+            return _Array([float(x) for x in self])
+        return self
+
+    def __truediv__(self, other):
+        return _Array([x / other for x in self])
+
+
+def array(seq):
+    if isinstance(seq, _Array):
+        return _Array(seq)
+    if any(isinstance(el, (list, tuple, _Array)) for el in seq):
+        return [_Array(el) if not isinstance(el, _Array) else el for el in seq]
+    return _Array(list(seq))
+
+
+def frombuffer(buf, dtype=None):
+    data = [b for b in buf]
+    return _Array(data)
+
+class _Linalg:
+    @staticmethod
+    def norm(v):
+        return math.sqrt(sum(float(x) * float(x) for x in v))
+
+linalg = _Linalg()
+
+
+def dot(a, b):
+    return sum(float(x) * float(y) for x, y in zip(a, b))
+
+
+def argmax(seq):
+    if not seq:
+        raise ValueError('argmax of empty sequence')
+    max_idx = 0
+    max_val = seq[0]
+    for i, val in enumerate(seq[1:], 1):
+        if val > max_val:
+            max_idx, max_val = i, val
+    return max_idx
+
+
+ndarray = _Array

--- a/tests/stubs/pyautogui.py
+++ b/tests/stubs/pyautogui.py
@@ -1,0 +1,13 @@
+"""Minimal PyAutoGUI stub used in tests."""
+
+def click(*args, **kwargs):
+    return None
+
+def typewrite(*args, **kwargs):
+    return None
+
+def screenshot(path="screenshot.png"):
+    return path
+
+def press(*args, **kwargs):
+    return None


### PR DESCRIPTION
## Summary
- add lightweight numpy and pyautogui stubs under `tests/stubs`
- load stub modules in `tests/conftest.py` if optional deps are missing

## Testing
- `PYTHONPATH=./src pytest -q` *(fails: AttributeError: '_Dummy' object has no attribute 'labels')*

------
https://chatgpt.com/codex/tasks/task_e_687918960f288324a4dc0fc66f86f5bc