### PR TITLE
Fix Prometheus fallback in plugin metrics

### DIFF
--- a/src/ai_karen_engine/core/plugin_registry.py
+++ b/src/ai_karen_engine/core/plugin_registry.py
@@ -38,7 +38,10 @@ try:
     )
 except Exception:  # pragma: no cover - optional dep
     class _Dummy:
-        def inc(self, n: int = 1) -> None:
+        def labels(self, *_, **__):
+            return self
+
+        def inc(self, *_args, **_kwargs) -> None:
             pass
 
     PLUGIN_EXEC_COUNT = PLUGIN_LOADED_COUNT = PLUGIN_IMPORT_ERROR_COUNT = _Dummy()

--- a/tests/test_plugin_metrics.py
+++ b/tests/test_plugin_metrics.py
@@ -1,4 +1,5 @@
 import importlib
+import sys
 from ai_karen_engine.core import plugin_registry as pr
 
 
@@ -7,8 +8,25 @@ def test_plugin_metrics():
     importlib.reload(pr)
     handler = pr.plugin_registry.get('hello_world')
     assert handler is not None
+    handler['handler'].run = lambda *_a, **_k: 'ok'
     result = pr.execute_plugin(handler, {}, 'hi')
-    assert result
+    assert result == 'ok'
     assert pr._METRICS['plugin_exec_total'] > 0
     assert pr._METRICS['plugins_loaded'] > 0
+
+
+def test_plugin_metrics_without_prometheus(monkeypatch):
+    for mod in list(sys.modules):
+        if mod.startswith("prometheus_client"):
+            monkeypatch.delitem(sys.modules, mod, raising=False)
+    monkeypatch.setitem(sys.modules, "prometheus_client", None)
+
+    importlib.reload(pr)
+    handler = pr.plugin_registry.get('hello_world')
+    assert handler is not None
+    handler['handler'].run = lambda *_a, **_k: 'ok'
+    result = pr.execute_plugin(handler, {}, 'hi')
+    assert result == 'ok'
+    assert pr._METRICS['plugin_exec_total'] > 0
+    importlib.reload(pr)
 


### PR DESCRIPTION
## Summary
- ensure dummy Prometheus counters act more like real ones
- patch plugin metrics tests for missing Prometheus

## Testing
- `PYTHONPATH=src pytest tests/test_plugin_metrics.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68791832733083249444bf16c6a39881