### PR TITLE
Fix plugin dispatch memory update

### DIFF
--- a/src/ai_karen_engine/core/cortex/dispatch.py
+++ b/src/ai_karen_engine/core/cortex/dispatch.py
@@ -16,6 +16,7 @@ from ai_karen_engine.core.plugin_metrics import (
 )
 from ai_karen_engine.core.cortex.errors import CortexDispatchError, UnsupportedIntentError
 from ai_karen_engine.core.predictors import predictor_registry, run_predictor
+from ai_karen_engine.plugin_manager import get_plugin_manager
 
 async def dispatch(
     user_ctx: Dict[str, Any],
@@ -63,26 +64,22 @@ async def dispatch(
         if mode == "plugin" or (plugin_enabled and intent in plugin_registry):
             handler = plugin_registry.get(intent)
             if handler is None:
-                raise UnsupportedIntentError(f"No plugin registered for intent '{intent}'")
-            result = await get_plugin_manager().run_plugin(
-                intent,
-                {"prompt": query, "context": context or memory_ctx},
-                user_ctx,
-            )
-            raise UnsupportedIntentError(
+                raise UnsupportedIntentError(
                     f"No plugin registered for intent '{intent}'"
                 )
             try:
-                result = execute_plugin(
-                    handler, user_ctx, query, context or memory_ctx
+                result = await get_plugin_manager().run_plugin(
+                    intent,
+                    {"prompt": query, "context": context or memory_ctx},
+                    user_ctx,
                 )
+                trace.append({"stage": "plugin_executed", "plugin": intent})
                 success = True
             except Exception as ex:  # pragma: no cover - plugin error path
                 result = {"error": str(ex)}
                 trace.append({"stage": "plugin_error", "error": str(ex)})
                 success = False
             record_plugin_call(intent, success)
-            trace.append({"stage": "plugin_executed", "plugin": intent})
 
         elif mode == "predictor" or (predictor_enabled and intent in predictor_registry):
             handler = predictor_registry.get(intent)
@@ -103,11 +100,6 @@ async def dispatch(
         else:
             raise UnsupportedIntentError(f"No handler for intent: {intent}")
 
-        # 4. Optionally update memory for non-plugin paths
-        if memory_enabled and result and not (
-            mode == "plugin" or (plugin_enabled and intent in plugin_registry)
-        ):
-            update_memory(user_ctx, query, result)
         # 4. Optionally update memory
         if memory_enabled and result:
             mem_ok = update_memory(user_ctx, query, result)


### PR DESCRIPTION
## Summary
- clean up plugin dispatch logic in Cortex
- consolidate memory update block

## Testing
- `ruff check src/ai_karen_engine/core/cortex/dispatch.py`
- `mypy src/ai_karen_engine/core/cortex/dispatch.py` *(fails: Cannot find module 'ai_karen_engine' et al.)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'ai_karen_engine')*

------
https://chatgpt.com/codex/tasks/task_e_687917eb06048324942cd0f0bf173a7a