### PR TITLE
Remove obsolete announcement hooks

### DIFF
--- a/tests/test_pages_announcement_usage.py
+++ b/tests/test_pages_announcement_usage.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+
+
+def test_only_home_references_fetch_announcements():
+    pages_dir = Path(__file__).resolve().parents[1] / "ui_launchers" / "streamlit_ui" / "pages"
+    found = []
+    for py in pages_dir.glob("*.py"):
+        text = py.read_text()
+        if "fetch_announcements" in text:
+            found.append(py.name)
+    assert found == ["home.py"]

--- a/ui_launchers/streamlit_ui/pages/chat.py
+++ b/ui_launchers/streamlit_ui/pages/chat.py
@@ -16,10 +16,7 @@ def _auto_refresh(interval: int = 1000, key: str = "chat_refresh") -> None:
         st.session_state[key] = now
         st.experimental_rerun()
 from ui_logic.hooks.rbac import user_has_role
-from ui_logic.utils.api import (
-    fetch_user_profile,
-    ping_services,
-)
+from ui_logic.utils.api import fetch_user_profile
 from ui_logic.components.analytics.chart_builder import render_quick_charts
 from ui_logic.components.memory.session_explorer import render_session_explorer
 from ui_logic.components.plugins.plugin_manager import render_plugin_manager
@@ -88,9 +85,8 @@ def provider_model_select():
     }
     model = st.selectbox("Model", model_map[provider], index=0)
     st.session_state["model"] = model
+# Announcement panel removed
     evil_toast(f"Provider: {provider} | Model: {model}", "🧠")
-
-# ========== Announcements/Observability Panel ==========
 
 # ========== Main Chat Logic ==========
 def chat_panel(user_ctx):


### PR DESCRIPTION
## Summary
- clean up chat page imports and comments
- ensure only home page fetches announcements
- add regression test

## Testing
- `pytest tests/test_ui_api_utils.py tests/test_pages_announcement_usage.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687918f1ed6883249f6dc401c52580b7