### PR TITLE
Remove duplicate streamlit import

### DIFF
--- a/src/ui_logic/components/plugins/plugin_store.py
+++ b/src/ui_logic/components/plugins/plugin_store.py
@@ -14,7 +14,6 @@ from ui_logic.utils.api import (
     fetch_audit_logs,
 )
 
-import streamlit as st
 
 def list_store_plugins(user_ctx: Dict) -> List[Dict]:
     if not user_ctx or not require_roles(user_ctx, ["user", "admin", "developer"]):


### PR DESCRIPTION
## Summary
- clean up plugin store by removing duplicate `streamlit` import

## Testing
- `ruff check src/ui_logic/components/plugins/plugin_store.py`

------
https://chatgpt.com/codex/tasks/task_e_68791ede4d5883248f44229e38e01b30