### PR TITLE
Refactor plugin store helpers

### DIFF
--- a/src/ai_karen_engine/services/plugin_store_client.py
+++ b/src/ai_karen_engine/services/plugin_store_client.py
@@ -1,0 +1,33 @@
+from typing import Any, Dict, List, Optional
+
+from ui_logic.utils.api import api_get
+
+
+def fetch_store_plugins(
+    limit: int = 50,
+    token: Optional[str] = None,
+    org: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    """Return plugin metadata from the store API or an empty list on error."""
+    try:
+        params = {"limit": limit}
+        return api_get("plugins/store", params=params, token=token, org=org)
+    except Exception:
+        return []
+
+
+def search_plugins(
+    query: str,
+    limit: int = 50,
+    token: Optional[str] = None,
+    org: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    """Search public plugin marketplace."""
+    try:
+        params = {"q": query, "limit": limit}
+        return api_get("plugins/search", params=params, token=token, org=org)
+    except Exception:
+        return []
+
+
+__all__ = ["fetch_store_plugins", "search_plugins"]

--- a/src/ui_logic/components/plugins/plugin_store.py
+++ b/src/ui_logic/components/plugins/plugin_store.py
@@ -8,11 +8,11 @@ from typing import Dict, List
 import streamlit as st
 
 from ui_logic.hooks.rbac import require_roles
-from ui_logic.utils.api import (
+from ai_karen_engine.services.plugin_store_client import (
     fetch_store_plugins,
     search_plugins,
-    fetch_audit_logs,
 )
+from ui_logic.utils.api import fetch_audit_logs
 
 import streamlit as st
 

--- a/src/ui_logic/utils/api.py
+++ b/src/ui_logic/utils/api.py
@@ -498,28 +498,6 @@ def fetch_user_workflows(
     except Exception:
         return []
 
-def fetch_store_plugins(
-    limit: int = 50, token: Optional[str] = None, org: Optional[str] = None
-) -> List[Dict[str, Any]]:
-    """Return plugin metadata from the store API or an empty list on error."""
-    try:
-        params = {"limit": limit}
-        return api_get("plugins/store", params=params, token=token, org=org)
-    except Exception:
-        return []
-
-def search_plugins(
-    query: str,
-    limit: int = 50,
-    token: Optional[str] = None,
-    org: Optional[str] = None,
-) -> List[Dict[str, Any]]:
-    """Search public plugin marketplace."""
-    try:
-        params = {"q": query, "limit": limit}
-        return api_get("plugins/search", params=params, token=token, org=org)
-    except Exception:
-        return []
 
 def create_workflow(user_id: str, workflow: Dict[str, Any], token: Optional[str] = None, org: Optional[str] = None) -> bool:
     """Create a new workflow for ``user_id``."""
@@ -716,8 +694,6 @@ __all__ = [
     "fetch_knowledge_graph",
     # Plugins
     "fetch_user_workflows",
-    "fetch_store_plugins",
-    "search_plugins",
     "create_workflow",
     "delete_workflow",
     "update_workflow",

--- a/tests/test_ui_api_utils.py
+++ b/tests/test_ui_api_utils.py
@@ -76,3 +76,11 @@ def test_safe_request_failure(monkeypatch):
 
     with pytest.raises(requests.RequestException):
         api._safe_request("get", "http://x")
+
+
+def test_plugin_store_helpers(monkeypatch):
+    import ai_karen_engine.services.plugin_store_client as store
+
+    monkeypatch.setattr(store, "api_get", lambda *a, **k: [{"name": "demo"}])
+    assert store.fetch_store_plugins(limit=1) == [{"name": "demo"}]
+    assert store.search_plugins("demo") == [{"name": "demo"}]


### PR DESCRIPTION
## Summary
- centralize `fetch_store_plugins` and `search_plugins` under `ai_karen_engine.services`
- clean up `ui_logic.utils.api.__all__`
- update plugin store imports
- add unit test coverage for new helper location

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cryptography')*

------
https://chatgpt.com/codex/tasks/task_e_68791eeea9688324900f6f90d2ca2b5a