### PR TITLE
Implement create_plugin_manager factory

### DIFF
--- a/docs/features_usage.md
+++ b/docs/features_usage.md
@@ -60,6 +60,8 @@ Plugins extend Kari with new intents, memory hooks, and optional UI.
 ```bash
 curl -X POST http://localhost:8000/plugins/reload
 ```
+3. Programmatically manage plugins using `create_plugin_manager()` from
+   `ai_karen_engine.plugin_manager`.
 
 > 🔐 Note: Plugins with UI components only render if `ADVANCED_MODE=true`.
 

--- a/src/ai_karen_engine/plugin_manager.py
+++ b/src/ai_karen_engine/plugin_manager.py
@@ -86,6 +86,11 @@ class PluginManager:
 _plugin_manager: Optional[PluginManager] = None
 
 
+def create_plugin_manager(router: Optional[PluginRouter] = None) -> PluginManager:
+    """Return a new :class:`PluginManager` instance."""
+    return PluginManager(router=router)
+
+
 def get_plugin_manager() -> PluginManager:
     """Return cached PluginManager instance."""
     global _plugin_manager
@@ -97,6 +102,7 @@ def get_plugin_manager() -> PluginManager:
 __all__ = [
     "PluginManager",
     "get_plugin_manager",
+    "create_plugin_manager",
     "PLUGIN_CALLS",
     "PLUGIN_FAILURES",
     "MEMORY_WRITES",


### PR DESCRIPTION
## Summary
- add a `create_plugin_manager` helper returning a new PluginManager
- export it via `__all__`
- document the helper in the feature guide

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cryptography')*
- `pre-commit run --files src/ai_karen_engine/plugin_manager.py docs/features_usage.md` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68791ed3a9588324bb3fa8915fa05c0d