### PR TITLE
Add workflow builder stub

### DIFF
--- a/ui_launchers/streamlit_ui/pages/__init__.py
+++ b/ui_launchers/streamlit_ui/pages/__init__.py
@@ -1,5 +1,5 @@
 """Streamlit page wrappers exported for easy access."""
 
-from ui_launchers.streamlit_ui.pages.workflows import render_workflow_builder
+from ui_launchers.streamlit_ui.pages.workflow_builder import render_workflow_builder
 
 __all__ = ["render_workflow_builder"]

--- a/ui_launchers/streamlit_ui/pages/workflow_builder.py
+++ b/ui_launchers/streamlit_ui/pages/workflow_builder.py
@@ -1,0 +1,13 @@
+"""Streamlit placeholder for workflow builder page."""
+
+from typing import Dict
+
+import streamlit as st
+
+
+def render_workflow_builder(user_ctx: Dict | None = None) -> None:
+    """Display an informative message while the workflow UI is in development."""
+    st.info("Workflow builder under construction.")
+
+
+__all__ = ["render_workflow_builder"]


### PR DESCRIPTION
## Summary
- add workflow builder page stub for streamlit launcher
- export stub from pages module

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cryptography')*


------
https://chatgpt.com/codex/tasks/task_e_68791ef425048324959d46ceb3263270