### PR TITLE
Resolve lint issues

### DIFF
--- a/src/ai_karen_engine/core/memory/manager.py
+++ b/src/ai_karen_engine/core/memory/manager.py
@@ -13,7 +13,6 @@ import json
 import threading
 
 from ai_karen_engine.core.neuro_vault import NeuroVault
-from ai_karen_engine.core.embedding_manager import record_metric
 
 # ========== Backend Imports ==========
 try:

--- a/src/ai_karen_engine/core/neuro_vault/__init__.py
+++ b/src/ai_karen_engine/core/neuro_vault/__init__.py
@@ -70,8 +70,12 @@ class NeuroVault:
         start = time.time()
         vec = self.embedder.embed(text)
         if faiss is not None:
-            D, I = self.index.search(np.array([vec]), top_k)
-            metas = [self._metas.get(i) for i in I[0] if self._metas.get(i) and self._metas[i]["user_id"] == user_id]
+            distances, indices = self.index.search(np.array([vec]), top_k)
+            metas = [
+                self._metas.get(i)
+                for i in indices[0]
+                if self._metas.get(i) and self._metas[i]["user_id"] == user_id
+            ]
             recall_time = time.time() - start
         else:
             results = self.index.search(vec.tolist(), top_k=top_k, metadata_filter={"user_id": user_id})

--- a/src/ai_karen_engine/doc_store/document_store.py
+++ b/src/ai_karen_engine/doc_store/document_store.py
@@ -26,7 +26,6 @@ class _DocPostgres(PostgresClient):
     """Postgres table for document chunks."""
 
     def _ensure_tables(self) -> None:  # type: ignore[override]
-        ph = self.placeholder
         if self.use_sqlite:
             sql = (
                 "CREATE TABLE IF NOT EXISTS doc_chunks ("

--- a/src/ai_karen_engine/fastapi.py
+++ b/src/ai_karen_engine/fastapi.py
@@ -18,7 +18,6 @@ Features:
 import os
 import logging
 import uuid
-from typing import Optional
 
 from ai_karen_engine.core.memory.manager import init_memory
 


### PR DESCRIPTION
## Summary
- remove unused imports
- fix variable naming in NeuroVault query
- tidy doc store setup
- clean FastAPI imports

## Testing
- `ruff check src/ai_karen_engine/core/neuro_vault/__init__.py src/ai_karen_engine/doc_store/document_store.py src/ai_karen_engine/fastapi.py src/ai_karen_engine/core/memory/manager.py`
- `pytest -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_687934144d908324bd1a88b33f0563a5