### PR TITLE
Add presence event viewer

### DIFF
--- a/src/ai_karen_engine/event_bus/__init__.py
+++ b/src/ai_karen_engine/event_bus/__init__.py
@@ -31,4 +31,16 @@ class EventBus:
         self._queue.clear()
         return events
 
-__all__ = ["Event", "EventBus"]
+
+_global_bus: EventBus | None = None
+
+
+def get_event_bus() -> EventBus:
+    """Return a module-level :class:`EventBus` singleton."""
+    global _global_bus
+    if _global_bus is None:
+        _global_bus = EventBus()
+    return _global_bus
+
+
+__all__ = ["Event", "EventBus", "get_event_bus"]

--- a/src/ui_logic/pages/presence.py
+++ b/src/ui_logic/pages/presence.py
@@ -3,6 +3,7 @@
 from ui_logic.config.feature_flags import get_flag
 from ui_logic.hooks.auth import get_current_user
 from ui_logic.hooks.rbac import check_rbac
+from ai_karen_engine.event_bus import get_event_bus
 
 REQUIRED_ROLES = ["admin", "user"]
 FEATURE_FLAG = "enable_presence"
@@ -18,7 +19,7 @@ def page(user_ctx: dict, **kwargs) -> None:
     Raises:
         PermissionError: If access is denied by RBAC.
         RuntimeError: If the presence feature is disabled.
-        NotImplementedError: Always raised as this is a placeholder.
+        Returns: List of consumed events.
     """
 
     user = user_ctx or get_current_user()
@@ -26,11 +27,18 @@ def page(user_ctx: dict, **kwargs) -> None:
         raise PermissionError("Presence page access denied")
     if not get_flag(FEATURE_FLAG):
         raise RuntimeError("Presence feature disabled")
-    raise NotImplementedError("Coming soon!")
+    bus = get_event_bus()
+    return [
+        {
+            "id": e.id,
+            "capsule": e.capsule,
+            "type": e.event_type,
+            "payload": e.payload,
+            "risk": e.risk,
+        }
+        for e in bus.consume()
+    ]
 
 
 if __name__ == "__main__":
-    try:
-        page({})
-    except NotImplementedError:
-        print("Presence page stub")
+    print(page({"roles": ["admin"]}))

--- a/tests/test_presence.py
+++ b/tests/test_presence.py
@@ -1,0 +1,18 @@
+import time
+import importlib.util
+from ai_karen_engine.event_bus import get_event_bus
+
+spec = importlib.util.spec_from_file_location(
+    "presence", "src/ui_logic/pages/presence.py"
+)
+presence = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(presence)
+page = presence.page
+
+
+def test_presence_page_consumes_events():
+    bus = get_event_bus()
+    bus.publish("caps", "ping", {"ts": time.time()}, risk=0.1)
+    result = page({"roles": ["admin", "user"]})
+    assert isinstance(result, list)
+    assert result and result[0]["capsule"] == "caps"

--- a/ui_launchers/streamlit_ui/app.py
+++ b/ui_launchers/streamlit_ui/app.py
@@ -24,6 +24,7 @@ def render_sidebar(user_ctx) -> str:
         "Home": "home",
         "Memory": "memory",
         "Analytics": "analytics",
+        "Presence": "presence",
     }
     secondary = {
         "Plugins": "plugins",

--- a/ui_launchers/streamlit_ui/config/routing.py
+++ b/ui_launchers/streamlit_ui/config/routing.py
@@ -11,6 +11,7 @@ from ui_logic.pages.memory import memory_page
 from ui_logic.pages.admin import admin_page
 from ui_logic.pages.settings import settings_page
 from ui_logic.pages.settings import settings_page as models_page
+from ui_logic.pages.presence import page as presence_page
 
 PAGE_MAP = {
     "Home": home_page,
@@ -19,6 +20,7 @@ PAGE_MAP = {
     "Analytics": analytics_page,
     "Plugins": plugins_page,
     "Models": models_page,
+    "Presence": presence_page,
     "Admin": admin_page,
 }
 

--- a/ui_launchers/streamlit_ui/helpers/icons.py
+++ b/ui_launchers/streamlit_ui/helpers/icons.py
@@ -5,6 +5,7 @@ ICONS = {
     "memory": "🧠",
     "analytics": "📊",
     "plugins": "🧩",
+    "presence": "👥",
     "iot": "📡",
     "task_manager": "✅",
     "admin": "🛡️",

--- a/ui_launchers/streamlit_ui/pages/presence.py
+++ b/ui_launchers/streamlit_ui/pages/presence.py
@@ -1,3 +1,33 @@
+import time
 import streamlit as st
+from streamlit_autorefresh import st_autorefresh
 
-st.info("Page under construction.")
+from ui_logic.pages.presence import page as presence_logic
+from helpers.session import get_user_context
+from ai_karen_engine.event_bus import get_event_bus
+
+
+def render(user_ctx=None):
+    """Render Presence Monitor with live event feed."""
+    user_ctx = user_ctx or get_user_context()
+    st.title("👥 Presence Monitor")
+    st_autorefresh(interval=3000, key="presence_refresh")
+
+    if st.button("Generate Test Event"):
+        get_event_bus().publish(
+            capsule="demo",
+            event_type="heartbeat",
+            payload={"ts": time.time()},
+        )
+
+    events = presence_logic(user_ctx=user_ctx)
+    if not events:
+        st.info("No recent presence events.")
+    else:
+        for ev in events:
+            with st.expander(f"{ev['capsule']} | {ev['type']}"):
+                st.json(ev)
+
+
+if __name__ == "__main__":
+    render()


### PR DESCRIPTION
## Summary
- expose a singleton `get_event_bus` helper
- implement presence page logic and add a Streamlit UI viewer
- register Presence in routing and sidebar
- add icon for the new page
- test event bus presence flow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687934353c04832488453e9923aad33c