### PR TITLE
Fix plugin router role check

### DIFF
--- a/src/ai_karen_engine/plugin_router.py
+++ b/src/ai_karen_engine/plugin_router.py
@@ -209,8 +209,8 @@ class PluginRouter:
         rec = self.get_plugin(intent)
         if not rec:
             raise RuntimeError(f"Plugin '{intent}' not found or failed validation.")
-        allowed = rec.manifest.get("required_roles", [])
-        if roles is not None and not set(roles).intersection(allowed):
+        allowed = rec.manifest.get("required_roles") or []
+        if allowed and roles is not None and not set(roles).intersection(allowed):
             raise AccessDenied(intent)
 
         prompt_template = jinja_env.from_string(rec.manifest.get("prompt", "{{prompt}}"))


### PR DESCRIPTION
## Summary
- avoid raising AccessDenied when plugin has no required roles
- update dispatch access logic

## Testing
- `PYTHONPATH=src pytest -q tests/test_plugin_router.py::test_dispatch_with_rbac tests/test_plugin_router.py::test_dispatch_denied -q`
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687934353c04832488453e9923aad33c