### PR TITLE
Add tenant-aware memory isolation

### DIFF
--- a/tests/stubs/ai_karen_engine/clients/database/postgres_client.py
+++ b/tests/stubs/ai_karen_engine/clients/database/postgres_client.py
@@ -5,61 +5,78 @@ class PostgresClient:
         path = dsn.replace("sqlite://", "") if dsn.startswith("sqlite://") else ":memory:"
         self.conn = sqlite3.connect(path, check_same_thread=False)
         self.conn.execute(
-            "CREATE TABLE IF NOT EXISTS memory (vector_id INTEGER PRIMARY KEY, user_id TEXT, session_id TEXT, query TEXT, result TEXT, timestamp INTEGER)"
+            "CREATE TABLE IF NOT EXISTS memory (vector_id INTEGER PRIMARY KEY, tenant_id TEXT, user_id TEXT, session_id TEXT, query TEXT, result TEXT, timestamp INTEGER)"
         )
 
-    def upsert_memory(self, vector_id, user_id, session_id, query, result, timestamp=0):
+    def upsert_memory(
+        self, vector_id, tenant_id, user_id, session_id, query, result, timestamp=0
+    ):
         self.conn.execute(
-            "INSERT OR REPLACE INTO memory(vector_id,user_id,session_id,query,result,timestamp) VALUES (?,?,?,?,?,?)",
-            (vector_id, user_id, session_id, query, result, timestamp),
+            "INSERT OR REPLACE INTO memory(vector_id,tenant_id,user_id,session_id,query,result,timestamp) VALUES (?,?,?,?,?,?,?)",
+            (vector_id, tenant_id, user_id, session_id, query, result, timestamp),
         )
         self.conn.commit()
 
     def get_by_vector(self, vector_id):
         row = self.conn.execute(
-            "SELECT user_id, session_id, query, result, timestamp FROM memory WHERE vector_id=?",
+            "SELECT tenant_id, user_id, session_id, query, result, timestamp FROM memory WHERE vector_id=?",
             (vector_id,),
         ).fetchone()
         if not row:
             return None
         return {
-            "user_id": row[0],
-            "session_id": row[1],
-            "query": row[2],
-            "result": row[3],
-            "timestamp": row[4],
+            "tenant_id": row[0],
+            "user_id": row[1],
+            "session_id": row[2],
+            "query": row[3],
+            "result": row[4],
+            "timestamp": row[5],
         }
 
-    def get_session_records(self, session_id):
-        rows = self.conn.execute(
-            "SELECT vector_id,user_id,session_id,query,result,timestamp FROM memory WHERE session_id=?",
-            (session_id,),
-        ).fetchall()
+    def get_session_records(self, session_id, tenant_id=None):
+        if tenant_id is None:
+            rows = self.conn.execute(
+                "SELECT vector_id,tenant_id,user_id,session_id,query,result,timestamp FROM memory WHERE session_id=?",
+                (session_id,),
+            ).fetchall()
+        else:
+            rows = self.conn.execute(
+                "SELECT vector_id,tenant_id,user_id,session_id,query,result,timestamp FROM memory WHERE session_id=? AND tenant_id=?",
+                (session_id, tenant_id),
+            ).fetchall()
         return [
             {
                 "vector_id": r[0],
-                "user_id": r[1],
-                "session_id": r[2],
-                "query": r[3],
-                "result": r[4],
-                "timestamp": r[5],
+                "tenant_id": r[1],
+                "user_id": r[2],
+                "session_id": r[3],
+                "query": r[4],
+                "result": r[5],
+                "timestamp": r[6],
             }
             for r in rows
         ]
 
-    def recall_memory(self, user_id, limit=5):
-        rows = self.conn.execute(
-            "SELECT vector_id,user_id,session_id,query,result,timestamp FROM memory WHERE user_id=? ORDER BY timestamp DESC LIMIT ?",
-            (user_id, limit),
-        ).fetchall()
+    def recall_memory(self, user_id, query=None, limit=5, tenant_id=None):
+        if tenant_id is None:
+            rows = self.conn.execute(
+                "SELECT vector_id,tenant_id,user_id,session_id,query,result,timestamp FROM memory WHERE user_id=? ORDER BY timestamp DESC LIMIT ?",
+                (user_id, limit),
+            ).fetchall()
+        else:
+            rows = self.conn.execute(
+                "SELECT vector_id,tenant_id,user_id,session_id,query,result,timestamp FROM memory WHERE user_id=? AND tenant_id=? ORDER BY timestamp DESC LIMIT ?",
+                (user_id, tenant_id, limit),
+            ).fetchall()
         return [
             {
                 "vector_id": r[0],
-                "user_id": r[1],
-                "session_id": r[2],
-                "query": r[3],
-                "result": r[4],
-                "timestamp": r[5],
+                "tenant_id": r[1],
+                "user_id": r[2],
+                "session_id": r[3],
+                "query": r[4],
+                "result": r[5],
+                "timestamp": r[6],
             }
             for r in rows
         ]

--- a/tests/test_memory_sync.py
+++ b/tests/test_memory_sync.py
@@ -28,7 +28,7 @@ def test_flush_after_reconnect(tmp_path, monkeypatch):
     mm.pg_syncer = mm.PostgresSyncer(fake, str(db_path), interval=0.01)
     mm.pg_syncer.postgres_available = False
 
-    mm.update_memory({"user_id": "u1", "session_id": "s1"}, "q1", "r1")
+    mm.update_memory({"user_id": "u1", "session_id": "s1", "tenant_id": "t1"}, "q1", "r1")
     with duckdb.connect(str(db_path)) as con:
         count = con.execute("SELECT COUNT(*) FROM memory WHERE synced=FALSE").fetchone()[0]
     assert count == 1

--- a/tests/test_postgres_client.py
+++ b/tests/test_postgres_client.py
@@ -2,7 +2,7 @@ from ai_karen_engine.clients.database.postgres_client import PostgresClient
 
 def test_upsert_and_recall():
     client = PostgresClient(dsn="sqlite:///:memory:", use_sqlite=True)
-    client.upsert_memory(1, "u1", "s1", "q", "r", timestamp=123)
+    client.upsert_memory(1, "t1", "u1", "s1", "q", "r", timestamp=123)
     rec = client.get_by_vector(1)
     assert rec["user_id"] == "u1"
     assert rec["session_id"] == "s1"
@@ -11,14 +11,14 @@ def test_upsert_and_recall():
     assert rec["timestamp"] == 123
 
     # Overwrite same vector, check update
-    client.upsert_memory(1, "u1", "s1", "q2", "r2", timestamp=124)
+    client.upsert_memory(1, "t1", "u1", "s1", "q2", "r2", timestamp=124)
     rec2 = client.get_by_vector(1)
     assert rec2["query"] == "q2"
     assert rec2["result"] == "r2"
     assert rec2["timestamp"] == 124
 
     # Session fetch
-    sess = client.get_session_records("s1")
+    sess = client.get_session_records("s1", tenant_id="t1")
     assert len(sess) == 1
     assert sess[0]["result"] == "r2"
 
@@ -29,12 +29,16 @@ def test_upsert_and_recall():
 def test_recall_memory_batch():
     client = PostgresClient(dsn="sqlite:///:memory:", use_sqlite=True)
     for i in range(5):
-        client.upsert_memory(i, "u2", "s2", f"q{i}", f"r{i}", timestamp=100 + i)
-    recs = client.recall_memory("u2", limit=3)
+        client.upsert_memory(i, "t2", "u2", "s2", f"q{i}", f"r{i}", timestamp=100 + i)
+    recs = client.recall_memory("u2", limit=3, tenant_id="t2")
     assert len(recs) == 3
     assert recs[0]["query"] == "q4"
     assert recs[1]["query"] == "q3"
     assert recs[2]["query"] == "q2"
+
+    # Ensure cross-tenant isolation
+    other = client.recall_memory("u2", limit=1, tenant_id="other")
+    assert other == []
 
 def test_health_ok():
     client = PostgresClient(dsn="sqlite:///:memory:", use_sqlite=True)
@@ -44,7 +48,7 @@ def test_sqlite_fallback_without_psycopg(monkeypatch):
     import sys
     sys.modules["psycopg"] = None
     client = PostgresClient(dsn="sqlite:///:memory:", use_sqlite=True)
-    client.upsert_memory(2, "u3", "s3", "test_query", "test_result")
+    client.upsert_memory(2, "t3", "u3", "s3", "test_query", "test_result")
     rec = client.get_by_vector(2)
     assert rec["user_id"] == "u3"
     assert rec["query"] == "test_query"

--- a/tests/test_session_buffer.py
+++ b/tests/test_session_buffer.py
@@ -12,7 +12,7 @@ def test_duckdb_persists_when_postgres_down(tmp_path):
     db_path = tmp_path / "buf.db"
     duck = DuckDBClient(db_path=str(db_path))
     buf = SessionBuffer(duck, FailPostgres(), flush_size=1)
-    buf.add_entry("u1", "s1", "q", "r", vector_id=1, timestamp=1)
+    buf.add_entry("u1", "tbuf", "s1", "q", "r", vector_id=1, timestamp=1)
     buf.flush_to_postgres("s1")
     with duck._get_conn() as con:
         count = con.execute("SELECT COUNT(*) FROM session_buffer").fetchone()[0]
@@ -24,11 +24,11 @@ def test_flushing_moves_data(tmp_path):
     duck = DuckDBClient(db_path=str(db_path))
     pg = PostgresClient(dsn="sqlite:///:memory:", use_sqlite=True)
     buf = SessionBuffer(duck, pg, flush_size=1)
-    buf.add_entry("u2", "s2", "q2", "r2", vector_id=2, timestamp=2)
+    buf.add_entry("u2", "tbuf", "s2", "q2", "r2", vector_id=2, timestamp=2)
     buf.flush_to_postgres("s2")
     with duck._get_conn() as con:
         count = con.execute("SELECT COUNT(*) FROM session_buffer").fetchone()[0]
     assert count == 0
-    recs = pg.recall_memory("u2", limit=1)
+    recs = pg.recall_memory("u2", limit=1, tenant_id="tbuf")
     assert recs[0]["query"] == "q2"
     assert buf._pending.get("s2") == []


### PR DESCRIPTION
## Summary
- add `tenant_id` fields to vector store payloads and search filters
- update Postgres schema and APIs to track `tenant_id`
- key Redis memory by tenant and user
- persist tenant info in DuckDB session buffer
- enforce tenant separation in recall logic
- update unit tests for tenant-aware behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68793e25b0008324ae596fee1ef9dd93