### PR TITLE
Minor fix for plugin handler loading

### DIFF
--- a/src/ai_karen_engine/plugin_router.py
+++ b/src/ai_karen_engine/plugin_router.py
@@ -125,6 +125,8 @@ def load_handler(plugin_dir: Path, module_path: str | None = None) -> Callable:
             f"plugin_{plugin_dir.name}_handler",
             str(handler_path),
         )
+        if spec is None or spec.loader is None:
+            raise ImportError(f"Failed loading spec for {handler_path}")
         module = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(module)
 


### PR DESCRIPTION
## Summary
- handle missing loader when loading plugin handlers dynamically

## Testing
- `ruff check src/ai_karen_engine/plugin_router.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687956ebcc008324abdb2e8cf2006dbf