### PR TITLE
Fix plugin router role check

### DIFF
--- a/src/ai_karen_engine/plugin_router.py
+++ b/src/ai_karen_engine/plugin_router.py
@@ -210,7 +210,7 @@ class PluginRouter:
         if not rec:
             raise RuntimeError(f"Plugin '{intent}' not found or failed validation.")
         allowed = rec.manifest.get("required_roles") or []
-        if allowed and roles is not None and not set(roles).intersection(allowed):
+        if allowed and (not roles or not set(roles).intersection(allowed)):
             raise AccessDenied(intent)
 
         prompt_template = jinja_env.from_string(rec.manifest.get("prompt", "{{prompt}}"))

--- a/tests/test_plugin_router.py
+++ b/tests/test_plugin_router.py
@@ -67,6 +67,14 @@ def test_dispatch_denied():
         asyncio.run(router.dispatch("desktop_action", {}, roles=["user"]))
 
 
+def test_dispatch_missing_roles_denied():
+    for dep in ["pyautogui", "urwid", "jinja2", "integrations", "integrations.llm_registry"]:
+        ensure_optional_dependency(dep)
+    router = PluginRouter()
+    with pytest.raises(AccessDenied):
+        asyncio.run(router.dispatch("desktop_action", {}))
+
+
 def test_list_intents():
     for dep in ["pyautogui", "urwid", "jinja2", "integrations", "integrations.llm_registry"]:
         ensure_optional_dependency(dep)


### PR DESCRIPTION
## Summary
- enforce required_roles when no roles provided
- test plugin router RBAC

## Testing
- `ruff check src/ai_karen_engine/plugin_router.py tests/test_plugin_router.py`
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687956ebcc008324abdb2e8cf2006dbf