### PR TITLE
Add manual approval workflow to SelfRefactorEngine

### DIFF
--- a/docs/self_refactor.md
+++ b/docs/self_refactor.md
@@ -1,6 +1,6 @@
 # SelfRefactor Engine
 
-Kari can improve its own code using the built-in SelfRefactor engine. This component generates patches, runs tests, and merges the changes automatically when they pass.
+Kari can improve its own code using the built-in SelfRefactor engine. This component generates patches, runs tests, and stores the results for review. Patches are only merged automatically when the `ENABLE_SELF_REFACTOR_AUTO_MERGE` flag is enabled; otherwise they await manual approval.
 
 The OSIRIS Knowledge Engine feeds the SelfRefactor pipeline. As new information is ingested through multi-hop queries, the engine refreshes its knowledge base and schedules refactor runs, forming a continuous self-updating loop.
 
@@ -15,6 +15,14 @@ The engine reads prompts from `self_refactor/prompts/` and uses a local or remot
 ```bash
 python -m self_refactor.engine --run
 ```
+
+### Review Directory
+
+Every run saves proposed patches and their test results under
+`self_refactor/reviews/` using a timestamped folder. Review the `report.json`
+and patch files before manually applying them. Set
+`ENABLE_SELF_REFACTOR_AUTO_MERGE=true` to allow the engine to write changes
+directly after tests pass.
 
 ### Logs
 

--- a/tests/test_self_refactor_loop.py
+++ b/tests/test_self_refactor_loop.py
@@ -20,10 +20,33 @@ def test_test_patches_and_reinforce(tmp_path):
         "from maths import add\n\n\ndef test_add():\n    assert add(1, 1) == 2\n"
     )
 
-    engine = SelfRefactorEngine(repo_root=repo, llm=DummyLLM(), nanda=DummyNANDA())
+    engine = SelfRefactorEngine(repo_root=repo, llm=DummyLLM(), deepseek=DummyLLM(), nanda=DummyNANDA(), auto_merge=True)
     patches = {code: "def add(a, b):\n    return a + b\n"}
     report = engine.test_patches(patches)
     assert report.reward == 1
 
     engine.reinforce(report)
     assert code.read_text() == patches[code]
+
+
+def test_review_dir_saved(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "tests").mkdir()
+    code = repo / "maths.py"
+    code.write_text("def add(a, b):\n    return a - b\n")
+    (repo / "tests" / "test_maths.py").write_text(
+        "from maths import add\n\n\ndef test_add():\n    assert add(1, 1) == 2\n"
+    )
+
+    engine = SelfRefactorEngine(repo_root=repo, llm=DummyLLM(), deepseek=DummyLLM(), nanda=DummyNANDA(), auto_merge=False)
+    patches = {code: "def add(a, b):\n    return a + b\n"}
+    report = engine.test_patches(patches)
+    engine.reinforce(report)
+
+    review_root = repo / "self_refactor" / "reviews"
+    entries = list(review_root.iterdir())
+    assert entries, "review directory not created"
+    saved_patch = next((p for p in entries[0].iterdir() if p.name == "maths.py"), None)
+    assert saved_patch and saved_patch.read_text() == patches[code]
+    assert code.read_text() != patches[code]


### PR DESCRIPTION
## Summary
- require `ENABLE_SELF_REFACTOR_AUTO_MERGE` to automatically apply patches
- store patch review artifacts under `self_refactor/reviews/`
- document new approval process
- test review directory logic

## Testing
- `pytest tests/test_self_refactor_loop.py -q`
- `pytest -q` *(fails to exit cleanly; 13 tests passed before interruption)*

------
https://chatgpt.com/codex/tasks/task_e_687965da0810832496321baddba4f27a