### PR TITLE
Implement token-based session verification

### DIFF
--- a/tests/ui/test_rbac_token.py
+++ b/tests/ui/test_rbac_token.py
@@ -1,0 +1,31 @@
+import types
+import sys
+
+sys.modules.setdefault("streamlit", types.ModuleType("streamlit"))
+
+from ui_launchers.common.components import rbac
+from ui_launchers.streamlit_ui.helpers import session
+
+
+def test_page_denied_with_invalid_token(monkeypatch):
+    st = types.SimpleNamespace(
+        session_state={},
+        error=lambda msg: st.session_state.setdefault("err", msg),
+        experimental_get_query_params=lambda: {},
+        experimental_set_query_params=lambda **_: None,
+    )
+    monkeypatch.setattr(rbac, "st", st)
+    monkeypatch.setattr(session, "st", st)
+    monkeypatch.setattr(session, "_verify_token", lambda t: None)
+
+    st.session_state["token"] = "bad"
+    ctx = session.get_user_context()
+    assert ctx["roles"] == []
+    assert st.session_state["roles"] == []
+
+    @rbac.require_role("admin")
+    def _page():
+        return "ok"
+
+    assert _page() is None
+    assert st.session_state["err"] == "Access denied"

--- a/ui_launchers/streamlit_ui/helpers/__init__.py
+++ b/ui_launchers/streamlit_ui/helpers/__init__.py
@@ -1,0 +1,4 @@
+from .session import get_user_context, store_token
+from .auth import login
+
+__all__ = ["get_user_context", "store_token", "login"]

--- a/ui_launchers/streamlit_ui/helpers/auth.py
+++ b/ui_launchers/streamlit_ui/helpers/auth.py
@@ -1,0 +1,31 @@
+"""Backend authentication helpers for Streamlit UI."""
+
+from __future__ import annotations
+
+import os
+import streamlit as st
+
+API_URL = os.getenv("KARI_API_URL", "http://localhost:8000")
+
+
+def login(username: str, password: str) -> bool:
+    """Authenticate against the backend and persist the token."""
+    try:
+        import httpx  # imported lazily to avoid dependency during tests
+
+        resp = httpx.post(
+            f"{API_URL}/api/auth/login",
+            json={"username": username, "password": password},
+            timeout=5,
+        )
+        if resp.status_code == 200:
+            data = resp.json()
+            token = data.get("token")
+            if token:
+                from .session import store_token
+
+                store_token(token)
+                return True
+    except Exception:
+        pass
+    return False

--- a/ui_launchers/streamlit_ui/helpers/session.py
+++ b/ui_launchers/streamlit_ui/helpers/session.py
@@ -1,13 +1,56 @@
+"""Session helpers for the Streamlit UI."""
+
+from __future__ import annotations
+
+import os
 import streamlit as st
 
-def get_user_context():
-    # This would actually call src/ui/hooks/auth.py for prod
-    # Here, mimic demo user for framework wiring
-    if "user_ctx" not in st.session_state:
-        st.session_state["user_ctx"] = {
-            "user_id": "zeus",
-            "name": "God Zeus",
-            "roles": ["admin", "user", "devops", "analyst"],
-            "session_token": "demo-token"
-        }
-    return st.session_state["user_ctx"]
+API_URL = os.getenv("KARI_API_URL", "http://localhost:8000")
+
+
+def _verify_token(token: str) -> dict | None:
+    """Return user context for ``token`` or ``None`` if invalid."""
+    try:
+        import httpx  # imported lazily to avoid hard dependency during tests
+
+        resp = httpx.get(
+            f"{API_URL}/api/auth/me", headers={"Authorization": f"Bearer {token}"}
+        )
+        if resp.status_code == 200:
+            return resp.json()
+    except Exception:
+        pass
+    return None
+
+
+def _load_token() -> str | None:
+    """Load token from ``session_state`` or query params."""
+    token = st.session_state.get("token")
+    if not token:
+        params = st.experimental_get_query_params()
+        if params.get("token"):
+            token = params["token"][0]
+            st.session_state["token"] = token
+    return token
+
+
+def get_user_context() -> dict:
+    """Return verified user context and set ``st.session_state['roles']``."""
+
+    st.session_state.pop("roles", None)  # remove defaults to prevent spoofing
+    token = _load_token()
+    ctx = {"user_id": None, "roles": [], "token": token}
+    if token:
+        data = _verify_token(token)
+        if data:
+            ctx["user_id"] = data.get("user_id") or data.get("sub")
+            ctx["roles"] = list(data.get("roles", []))
+    st.session_state["roles"] = ctx["roles"]
+    return ctx
+
+
+def store_token(token: str) -> None:
+    """Persist ``token`` in session and browser query params."""
+
+    st.session_state["token"] = token
+    st.experimental_set_query_params(token=token)


### PR DESCRIPTION
## Summary
- add auth helper to store session token from backend login
- verify stored token when constructing Streamlit session context
- expose helpers in helper package
- test that invalid tokens cannot access role-restricted pages

## Testing
- `pytest -k rbac_token -q`

------
https://chatgpt.com/codex/tasks/task_e_687964d41b008324b2a8fc455c672004