### PR TITLE
Add health checks and Prometheus annotations

### DIFF
--- a/src/charts/kari/README.md
+++ b/src/charts/kari/README.md
@@ -1,0 +1,16 @@
+# Kari Helm Chart
+
+This chart deploys the Kari API as a single pod with basic service exposure. The deployment includes health probes and metrics annotations for Prometheus.
+
+## Features
+
+- **Liveness and Readiness:** Kubernetes probes call `/livez` and `/readyz` on the container.
+- **Metrics Exposure:** `/metrics/prometheus` is exposed through the service so Prometheus can scrape metrics.
+
+## Usage
+
+```bash
+helm install kari ./charts/kari
+```
+
+Set `image.repository`, `image.tag`, or `service.port` in `values.yaml` to match your environment.

--- a/src/charts/kari/templates/deployment.yaml
+++ b/src/charts/kari/templates/deployment.yaml
@@ -16,4 +16,13 @@ spec:
         - name: kari
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           ports:
-            - containerPort: {{ .Values.service.port }}
+            - name: http
+              containerPort: {{ .Values.service.port }}
+          livenessProbe:
+            httpGet:
+              path: /livez
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: http

--- a/src/charts/kari/templates/service.yaml
+++ b/src/charts/kari/templates/service.yaml
@@ -2,6 +2,10 @@ apiVersion: v1
 kind: Service
 metadata:
   name: kari
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/path: "/metrics/prometheus"
+    prometheus.io/port: "{{ .Values.service.port }}"
 spec:
   selector:
     app: kari


### PR DESCRIPTION
## Summary
- add HTTP liveness and readiness probes to Kari helm chart
- expose `/metrics/prometheus` via service annotations
- document chart configuration and new endpoints

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879648860ac83248ff5d8b8bb95ddf4