### PR TITLE
Implement multi-tenant isolation for storage

### DIFF
--- a/main.py
+++ b/main.py
@@ -11,6 +11,7 @@ from ai_karen_engine.core.plugin_registry import _METRICS as PLUGIN_METRICS
 from ai_karen_engine.clients.database.elastic_client import _METRICS as DOC_METRICS
 from ai_karen_engine.core.soft_reasoning_engine import SoftReasoningEngine
 from ai_karen_engine.core.memory.manager import init_memory
+from ai_karen_engine.utils.auth import validate_session
 
 if (Path(__file__).resolve().parent / "fastapi").is_dir():
     sys.stderr.write(
@@ -133,6 +134,28 @@ if hasattr(app, "middleware"):
         return response
 else:
     async def record_metrics(request: Request, call_next):
+        return await call_next(request)
+
+TENANT_HEADER = "X-Tenant-ID"
+PUBLIC_PATHS = {"/ping", "/health", "/ready", "/metrics", "/metrics/prometheus", "/"}
+
+if hasattr(app, "middleware"):
+    @app.middleware("http")
+    async def require_tenant(request: Request, call_next):
+        if request.url.path not in PUBLIC_PATHS:
+            tenant = request.headers.get(TENANT_HEADER)
+            if not tenant:
+                auth = request.headers.get("authorization")
+                if auth and auth.lower().startswith("bearer "):
+                    token = auth.split(None, 1)[1]
+                    ctx = validate_session(token, request.headers.get("user-agent", ""), request.client.host)
+                    tenant = ctx.get("tenant_id") if ctx else None
+            if not tenant:
+                return JSONResponse(status_code=400, content={"detail": "tenant_id required"})
+            request.state.tenant_id = tenant
+        return await call_next(request)
+else:
+    async def require_tenant(request: Request, call_next):
         return await call_next(request)
 
 class ChatRequest(BaseModel):

--- a/src/ai_karen_engine/api_routes/auth.py
+++ b/src/ai_karen_engine/api_routes/auth.py
@@ -37,7 +37,14 @@ async def login(req: LoginRequest, request: Request) -> LoginResponse:
     user = _USERS.get(req.username)
     if not user or user["password"] != req.password:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials")
-    token = create_session(req.username, user["roles"], request.headers.get("user-agent", ""), request.client.host)
+    tenant_id = request.headers.get("X-Tenant-ID", "default")
+    token = create_session(
+        req.username,
+        user["roles"],
+        request.headers.get("user-agent", ""),
+        request.client.host,
+        tenant_id,
+    )
     return LoginResponse(token=token, user_id=req.username, roles=user["roles"])
 
 

--- a/src/ai_karen_engine/clients/database/postgres_client.py
+++ b/src/ai_karen_engine/clients/database/postgres_client.py
@@ -120,13 +120,11 @@ class PostgresClient:
             "timestamp": row[5],
         }
 
-    def get_session_records(self, session_id: str, tenant_id: Optional[str] = None) -> List[Dict[str, Any]]:
+    def get_session_records(self, session_id: str, tenant_id: str) -> List[Dict[str, Any]]:
         sql = "SELECT vector_id, tenant_id, user_id, session_id, query, result, timestamp FROM memory WHERE session_id = "
         sql += "?" if self.use_sqlite else "%s"
-        params = [session_id]
-        if tenant_id is not None:
-            sql += " AND tenant_id = " + ("?" if self.use_sqlite else "%s")
-            params.append(tenant_id)
+        sql += " AND tenant_id = " + ("?" if self.use_sqlite else "%s")
+        params = [session_id, tenant_id]
         rows = self._execute(sql, params, fetch=True)
         return [
             {
@@ -142,17 +140,15 @@ class PostgresClient:
         ]
 
     def recall_memory(
-        self, user_id: str, query: Optional[str] = None, limit: int = 5, tenant_id: Optional[str] = None
+        self, user_id: str, query: Optional[str] = None, limit: int = 5, tenant_id: str = ""
     ) -> List[Dict[str, Any]]:
         sql = (
             "SELECT vector_id, tenant_id, user_id, session_id, query, result, timestamp FROM memory "
             "WHERE user_id = "
         )
         sql += "?" if self.use_sqlite else "%s"
-        params = [user_id]
-        if tenant_id is not None:
-            sql += " AND tenant_id = " + ("?" if self.use_sqlite else "%s")
-            params.append(tenant_id)
+        sql += " AND tenant_id = " + ("?" if self.use_sqlite else "%s")
+        params = [user_id, tenant_id]
         sql += " ORDER BY timestamp DESC LIMIT "
         sql += "?" if self.use_sqlite else "%s"
         params.append(limit)

--- a/src/ai_karen_engine/clients/database/redis_client.py
+++ b/src/ai_karen_engine/clients/database/redis_client.py
@@ -11,33 +11,33 @@ class RedisClient:
         self.r = redis.StrictRedis(host=host, port=port, db=db, decode_responses=True)
         self.prefix = prefix
 
-    def _k(self, user_id, kind):
-        return f"{self.prefix}:{user_id}:{kind}"
+    def _k(self, tenant_id, user_id, kind):
+        return f"{self.prefix}:{tenant_id}:{user_id}:{kind}"
 
-    def flush_short_term(self, user_id):
+    def flush_short_term(self, tenant_id, user_id):
         """Flush all short-term cache for user."""
-        keys = self.r.keys(self._k(user_id, "short_term*"))
+        keys = self.r.keys(self._k(tenant_id, user_id, "short_term*"))
         for k in keys:
             self.r.delete(k)
 
-    def flush_long_term(self, user_id):
+    def flush_long_term(self, tenant_id, user_id):
         """Flush all long-term cache for user."""
-        keys = self.r.keys(self._k(user_id, "long_term*"))
+        keys = self.r.keys(self._k(tenant_id, user_id, "long_term*"))
         for k in keys:
             self.r.delete(k)
 
-    def set_short_term(self, user_id, data):
-        self.r.set(self._k(user_id, "short_term"), json.dumps(data))
+    def set_short_term(self, tenant_id, user_id, data):
+        self.r.set(self._k(tenant_id, user_id, "short_term"), json.dumps(data))
 
-    def get_short_term(self, user_id):
-        val = self.r.get(self._k(user_id, "short_term"))
+    def get_short_term(self, tenant_id, user_id):
+        val = self.r.get(self._k(tenant_id, user_id, "short_term"))
         return json.loads(val) if val else None
 
-    def set_session(self, user_id, sess_data):
-        self.r.set(self._k(user_id, "session"), json.dumps(sess_data))
+    def set_session(self, tenant_id, user_id, sess_data):
+        self.r.set(self._k(tenant_id, user_id, "session"), json.dumps(sess_data))
 
-    def get_session(self, user_id):
-        val = self.r.get(self._k(user_id, "session"))
+    def get_session(self, tenant_id, user_id):
+        val = self.r.get(self._k(tenant_id, user_id, "session"))
         return json.loads(val) if val else None
 
     # Health

--- a/src/ai_karen_engine/core/memory/manager.py
+++ b/src/ai_karen_engine/core/memory/manager.py
@@ -231,7 +231,7 @@ def recall_context(
             es_user = os.getenv("ELASTIC_USER")
             es_password = os.getenv("ELASTIC_PASSWORD")
             es = ElasticClient(es_host, es_port, es_index, es_user, es_password)
-            records = es.search(user_id, query, limit=limit)
+            records = es.search(user_id, query, limit=limit, tenant_id=tenant_id or "")
             if records:
                 logger.info(
                     f"[MemoryManager] Elastic recall: {len(records)} results for user {user_id}"

--- a/src/ai_karen_engine/utils/auth.py
+++ b/src/ai_karen_engine/utils/auth.py
@@ -17,7 +17,9 @@ def _device_fingerprint(user_agent: str, ip: str) -> str:
     return hashlib.sha256(data).hexdigest()
 
 
-def create_session(user_id: str, roles: List[str], user_agent: str, ip: str) -> str:
+def create_session(
+    user_id: str, roles: List[str], user_agent: str, ip: str, tenant_id: str
+) -> str:
     now = int(time.time())
     payload = {
         "sub": user_id,
@@ -25,6 +27,7 @@ def create_session(user_id: str, roles: List[str], user_agent: str, ip: str) -> 
         "exp": now + SESSION_DURATION,
         "iat": now,
         "device": _device_fingerprint(user_agent, ip),
+        "tenant_id": tenant_id,
     }
     return jwt.encode(payload, AUTH_SIGNING_KEY, algorithm=JWT_ALGORITHM)
 

--- a/src/ui_logic/components/memory/memory_manager.py
+++ b/src/ui_logic/components/memory/memory_manager.py
@@ -92,13 +92,13 @@ def reset_profile(user_id: str):
     duckdb.delete_profile_history(user_id)
     if milvus is not None:
         milvus.delete_persona_embedding(user_id)
-    redis.flush_short_term(user_id)
-    redis.flush_long_term(user_id)
+    redis.flush_short_term("default", user_id)
+    redis.flush_long_term("default", user_id)
 
 def flush_short_term(user_id: str):
     """Flush only Redis-based short-term memory for this user."""
     require_user(user_id)
-    redis.flush_short_term(user_id)
+    redis.flush_short_term("default", user_id)
 
 def flush_long_term(user_id: str):
     """Flush Milvus/DuckDB-backed long-term memory for this user."""

--- a/src/ui_logic/hooks/auth.py
+++ b/src/ui_logic/hooks/auth.py
@@ -69,7 +69,9 @@ def _verify_token(token: str) -> Optional[dict]:
         return None
 
 
-def create_session(user_id: str, roles: List[str], user_agent: str, ip: str) -> str:
+def create_session(
+    user_id: str, roles: List[str], user_agent: str, ip: str, tenant_id: str
+) -> str:
     """Create a session JWT token (device-bound, time-limited)."""
     now = int(time.time())
     payload = {
@@ -78,6 +80,7 @@ def create_session(user_id: str, roles: List[str], user_agent: str, ip: str) -> 
         "exp": now + SESSION_DURATION,
         "iat": now,
         "device": _device_fingerprint(user_agent, ip),
+        "tenant_id": tenant_id,
     }
     return _sign_token(payload)
 

--- a/tests/stubs/ai_karen_engine/clients/database/postgres_client.py
+++ b/tests/stubs/ai_karen_engine/clients/database/postgres_client.py
@@ -33,17 +33,11 @@ class PostgresClient:
             "timestamp": row[5],
         }
 
-    def get_session_records(self, session_id, tenant_id=None):
-        if tenant_id is None:
-            rows = self.conn.execute(
-                "SELECT vector_id,tenant_id,user_id,session_id,query,result,timestamp FROM memory WHERE session_id=?",
-                (session_id,),
-            ).fetchall()
-        else:
-            rows = self.conn.execute(
-                "SELECT vector_id,tenant_id,user_id,session_id,query,result,timestamp FROM memory WHERE session_id=? AND tenant_id=?",
-                (session_id, tenant_id),
-            ).fetchall()
+    def get_session_records(self, session_id, tenant_id):
+        rows = self.conn.execute(
+            "SELECT vector_id,tenant_id,user_id,session_id,query,result,timestamp FROM memory WHERE session_id=? AND tenant_id=?",
+            (session_id, tenant_id),
+        ).fetchall()
         return [
             {
                 "vector_id": r[0],
@@ -57,17 +51,11 @@ class PostgresClient:
             for r in rows
         ]
 
-    def recall_memory(self, user_id, query=None, limit=5, tenant_id=None):
-        if tenant_id is None:
-            rows = self.conn.execute(
-                "SELECT vector_id,tenant_id,user_id,session_id,query,result,timestamp FROM memory WHERE user_id=? ORDER BY timestamp DESC LIMIT ?",
-                (user_id, limit),
-            ).fetchall()
-        else:
-            rows = self.conn.execute(
-                "SELECT vector_id,tenant_id,user_id,session_id,query,result,timestamp FROM memory WHERE user_id=? AND tenant_id=? ORDER BY timestamp DESC LIMIT ?",
-                (user_id, tenant_id, limit),
-            ).fetchall()
+    def recall_memory(self, user_id, query=None, limit=5, tenant_id=""):
+        rows = self.conn.execute(
+            "SELECT vector_id,tenant_id,user_id,session_id,query,result,timestamp FROM memory WHERE user_id=? AND tenant_id=? ORDER BY timestamp DESC LIMIT ?",
+            (user_id, tenant_id, limit),
+        ).fetchall()
         return [
             {
                 "vector_id": r[0],

--- a/tests/test_elastic_client.py
+++ b/tests/test_elastic_client.py
@@ -5,6 +5,7 @@ def test_index_and_search_in_memory():
     client = ElasticClient(use_memory=True)
     client.ensure_index()
     entry = {
+        "tenant_id": "A",
         "user_id": "u1",
         "session_id": "s1",
         "query": "hello world",
@@ -12,7 +13,7 @@ def test_index_and_search_in_memory():
         "timestamp": 1,
     }
     client.index_entry(entry)
-    hits = client.search("u1", "hello")
+    hits = client.search("u1", "hello", tenant_id="A")
     assert hits and hits[0]["result"] == "r1"
 
 
@@ -21,6 +22,7 @@ def test_search_no_results():
     client.ensure_index()
     client.index_entry(
         {
+            "tenant_id": "B",
             "user_id": "u2",
             "session_id": "s2",
             "query": "foo",
@@ -28,4 +30,14 @@ def test_search_no_results():
             "timestamp": 1,
         }
     )
-    assert client.search("u2", "baz") == []
+    assert client.search("u2", "baz", tenant_id="B") == []
+
+
+def test_cross_tenant_isolation():
+    client = ElasticClient(use_memory=True)
+    client.ensure_index()
+    client.index_entry({"tenant_id": "A", "user_id": "u1", "session_id": "s1", "query": "hello", "result": "rA", "timestamp": 1})
+    client.index_entry({"tenant_id": "B", "user_id": "u1", "session_id": "s1", "query": "hello", "result": "rB", "timestamp": 1})
+    hits = client.search("u1", "hello", tenant_id="A")
+    assert len(hits) == 1
+    assert hits[0]["result"] == "rA"

--- a/tests/test_memory_manager.py
+++ b/tests/test_memory_manager.py
@@ -101,7 +101,7 @@ class RecordingPostgres:
             raise RuntimeError("db down")
         self.upserts.append((vector_id, tenant_id, user_id, session_id, query, result, timestamp))
 
-    def recall_memory(self, user_id, query, limit, tenant_id=None):
+    def recall_memory(self, user_id, query, limit, tenant_id=""):
         self.recalls.append((user_id, query, limit, tenant_id))
         return [{"source": "postgres"}]
 

--- a/tests/test_milvus_client.py
+++ b/tests/test_milvus_client.py
@@ -1,6 +1,15 @@
 import time
 import pytest
-from ai_karen_engine.core.milvus_client import MilvusClient
+from ai_karen_engine.core.milvus_client import (
+    MilvusClient,
+    store_vector,
+    recall_vectors,
+    _vector_stores,
+)
+
+
+def setup_function(func):
+    _vector_stores.clear()
 
 
 def test_upsert_and_search():
@@ -52,3 +61,11 @@ def test_delete_nonexistent_id_no_error():
     kept = client.upsert([1.0, 0.0], {"text": "keep"})
     client.delete([9999])
     assert kept in client._data
+
+
+def test_tenant_isolation_store_funcs():
+    id_a = store_vector("u", "hello", "ra", tenant_id="A")
+    id_b = store_vector("u", "hello", "rb", tenant_id="B")
+    res_a = recall_vectors("u", "hello", tenant_id="A")
+    ids = {r["id"] for r in res_a}
+    assert id_a in ids and id_b not in ids


### PR DESCRIPTION
## Summary
- enforce tenant header in API middleware
- include tenant info in Postgres and Elastic operations
- isolate Milvus vectors per tenant
- prefix Redis keys with tenant
- update authentication helpers for tenant claim
- adjust memory manager and related tests for tenant filtering

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687962fba78083248fc4e0ab17710b85