### PR TITLE
Implement JWT auth middleware

### DIFF
--- a/src/ai_karen_engine/api_routes/auth.py
+++ b/src/ai_karen_engine/api_routes/auth.py
@@ -27,6 +27,11 @@ class LoginResponse(BaseModel):
     roles: list[str]
 
 
+class TokenResponse(BaseModel):
+    access_token: str
+    token_type: str = "bearer"
+
+
 class UserResponse(BaseModel):
     user_id: str
     roles: list[str]
@@ -39,6 +44,16 @@ async def login(req: LoginRequest, request: Request) -> LoginResponse:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials")
     token = create_session(req.username, user["roles"], request.headers.get("user-agent", ""), request.client.host)
     return LoginResponse(token=token, user_id=req.username, roles=user["roles"])
+
+
+@router.post("/token", response_model=TokenResponse)
+async def token(req: LoginRequest, request: Request) -> TokenResponse:
+    """Issue an OAuth2-compatible bearer token."""
+    user = _USERS.get(req.username)
+    if not user or user["password"] != req.password:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials")
+    token = create_session(req.username, user["roles"], request.headers.get("user-agent", ""), request.client.host)
+    return TokenResponse(access_token=token)
 
 
 @router.get("/me", response_model=UserResponse)

--- a/tests/test_auth_middleware.py
+++ b/tests/test_auth_middleware.py
@@ -1,0 +1,50 @@
+import asyncio
+from types import SimpleNamespace
+
+import ai_karen_engine.fastapi_stub as fastapi_stub
+import ai_karen_engine.pydantic_stub as pydantic_stub
+import sys
+
+sys.modules.setdefault("fastapi", fastapi_stub)
+sys.modules.setdefault("pydantic", pydantic_stub)
+
+from ai_karen_engine.fastapi import auth_middleware
+from ai_karen_engine.utils.auth import create_session
+from ai_karen_engine.fastapi_stub import Response
+
+
+async def _call_next(request):
+    return Response({"ok": True})
+
+
+def _build_request(path="/plugins", token: str | None = None):
+    headers = {"user-agent": "agent"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return SimpleNamespace(
+        url=SimpleNamespace(path=path),
+        headers=headers,
+        client=SimpleNamespace(host="1.1.1.1"),
+        state=SimpleNamespace(),
+    )
+
+
+def test_missing_token():
+    req = _build_request()
+    resp = asyncio.run(auth_middleware(req, _call_next))
+    assert resp.status_code == 401
+
+
+def test_invalid_token():
+    req = _build_request(token="bad")
+    resp = asyncio.run(auth_middleware(req, _call_next))
+    assert resp.status_code == 401
+
+
+def test_valid_token():
+    token = create_session("admin", ["admin"], "agent", "1.1.1.1")
+    req = _build_request(token=token)
+    resp = asyncio.run(auth_middleware(req, _call_next))
+    assert resp.status_code == 200
+    assert getattr(req.state, "user", None) == "admin"
+    assert "admin" in getattr(req.state, "roles", [])


### PR DESCRIPTION
## Summary
- implement OAuth2-style token validation middleware
- expose a `/api/auth/token` endpoint
- add minimal middleware and router support to FastAPI stub
- add unit test covering auth middleware behavior

## Testing
- `pytest tests/test_auth_middleware.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687962f5feb88324822abe69ce40bd38