### PR TITLE
Add manual approval workflow for SelfRefactor

### DIFF
--- a/docs/self_refactor.md
+++ b/docs/self_refactor.md
@@ -1,12 +1,12 @@
 # SelfRefactor Engine
 
-Kari can improve its own code using the built-in SelfRefactor engine. This component generates patches, runs tests, and merges the changes automatically when they pass.
+Kari can improve its own code using the built-in SelfRefactor engine. This component generates patches, runs tests, and stores the results for review. Patches are only merged automatically when the `SRE_AUTO_APPLY` flag is enabled.
 
 The OSIRIS Knowledge Engine feeds the SelfRefactor pipeline. As new information is ingested through multi-hop queries, the engine refreshes its knowledge base and schedules refactor runs, forming a continuous self-updating loop.
 
 ## 1. Overview
 
-The engine reads prompts from `self_refactor/prompts/` and uses a local or remote LLM to suggest code improvements. Patches are applied in a sandboxed git worktree and executed with `pytest` before merging.
+The engine reads prompts from `self_refactor/prompts/` and uses a local or remote LLM to suggest code improvements. Patches are applied in a sandboxed git worktree and executed with `pytest`. The resulting patch files and test reports are saved under `self_refactor_review/` for manual approval.
 
 ### Scheduler
 
@@ -25,6 +25,10 @@ curl http://localhost:8000/self_refactor/logs
 ```
 
 Set `ADVANCED_MODE=true` and add `?full=true` for raw stdout/stderr details.
+
+### Approval Flow
+
+After each run the engine creates a timestamped folder under `self_refactor_review/` containing the generated patches and a `report.json` file with the test results. Review the changes and manually apply them or set the `SRE_AUTO_APPLY=true` environment variable to allow automatic writes to the repository.
 
 ## Security Notes
 

--- a/tests/test_self_refactor_loop.py
+++ b/tests/test_self_refactor_loop.py
@@ -20,10 +20,32 @@ def test_test_patches_and_reinforce(tmp_path):
         "from maths import add\n\n\ndef test_add():\n    assert add(1, 1) == 2\n"
     )
 
-    engine = SelfRefactorEngine(repo_root=repo, llm=DummyLLM(), nanda=DummyNANDA())
+    engine = SelfRefactorEngine(repo_root=repo, llm=DummyLLM(), nanda=DummyNANDA(), auto_apply=True)
     patches = {code: "def add(a, b):\n    return a + b\n"}
     report = engine.test_patches(patches)
     assert report.reward == 1
 
     engine.reinforce(report)
     assert code.read_text() == patches[code]
+
+
+def test_reinforce_requires_approval(tmp_path):
+    repo = tmp_path / "repo2"
+    repo.mkdir()
+    (repo / "tests").mkdir()
+    code = repo / "maths.py"
+    code.write_text("def add(a, b):\n    return a - b\n")
+    (repo / "tests" / "test_maths.py").write_text(
+        "from maths import add\n\n\ndef test_add():\n    assert add(1, 1) == 2\n"
+    )
+
+    engine = SelfRefactorEngine(repo_root=repo, llm=DummyLLM(), nanda=DummyNANDA())
+    patches = {code: "def add(a, b):\n    return a + b\n"}
+    report = engine.test_patches(patches)
+    assert report.reward == 1
+
+    engine.reinforce(report)
+    # patch should not be applied without auto_apply flag
+    assert code.read_text() != patches[code]
+    review_root = repo / "self_refactor_review"
+    assert any(review_root.iterdir())


### PR DESCRIPTION
## Summary
- require approval before applying patches generated by the SelfRefactor engine
- keep proposed patches and test reports in `self_refactor_review/`
- document the approval flow for the SelfRefactor engine
- update unit tests for the new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687964de2cdc8324a6c80e6544b2f3c6