### PR TITLE
Expose health & metrics endpoints

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,11 @@
 FROM python:3.11-slim
 WORKDIR /app
 COPY requirements.txt .
+RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
 RUN pip install --no-cache-dir -r requirements.txt
 COPY . .
 RUN pip install -e .
+EXPOSE 8000
+HEALTHCHECK --interval=30s --timeout=5s --start-period=5s \
+    CMD curl -f http://localhost:8000/health || exit 1
 CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -245,6 +245,11 @@ Kari's FastAPI backend exposes a small set of endpoints for headless deployments
 See [docs/api_usage.md](docs/api_usage.md) for the full list and example `curl`
 commands.
 
+Common service endpoints:
+
+- `GET /health` – quick liveness check used by the Docker healthcheck
+- `GET /metrics/prometheus` – Prometheus scrape endpoint
+
 ---
 
 ## 5 · Development Cheatsheet

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,13 @@ services:
     build: .
     ports:
       - "8000:8000"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://api:8000/ready"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+    # liveness probe example:
+    #   test: ["CMD", "curl", "-f", "http://api:8000/health"]
 
   postgres:
     image: postgres:15-alpine


### PR DESCRIPTION
## Summary
- add EXPOSE and HEALTHCHECK in Dockerfile
- document /health and /metrics/prometheus endpoints
- include example readiness and liveness probes in docker-compose

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68796595604c832484f479b7695ded90