### PR TITLE
Add CI workflow and document pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,26 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          pip install ruff mypy pytest coverage
+          pip install ruff mypy pytest coverage black
       - name: Ruff
         run: ruff .
+      - name: Black
+        run: black --check .
       - name: Type check
         run: mypy --strict .
       - name: Test
         run: pytest --cov=./ --cov-report=xml --cov-report=term --cov-fail-under=85 -q
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to GHCR
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/${{ github.repository }}:${{ github.sha }}

--- a/docs/development_guide.md
+++ b/docs/development_guide.md
@@ -94,3 +94,17 @@ To meet WCAG AA requirements, ensure all text maintains a contrast ratio of at l
 | Open help | `?` |
 
 These shortcuts should be implemented in custom components where possible.
+
+## Continuous Integration
+
+All pull requests trigger the workflow defined in `.github/workflows/ci.yml`.
+The job installs dependencies and then runs the following checks:
+
+1. `ruff` for linting
+2. `black --check` for formatting
+3. `mypy --strict` for type safety
+4. `pytest` with coverage
+
+If the tests pass, the workflow builds a Docker image from the repository's
+`Dockerfile` and pushes it to the GitHub Container Registry under the commit
+SHA tag.

--- a/src/ai_karen_engine/fastapi_stub/__init__.py
+++ b/src/ai_karen_engine/fastapi_stub/__init__.py
@@ -170,7 +170,7 @@ class JSONResponse(Response):
     pass
 
 
-responses = SimpleNamespace(JSONResponse=JSONResponse)
+responses = SimpleNamespace(JSONResponse=JSONResponse, Response=Response)
 sys.modules["fastapi.responses"] = responses  # type: ignore[assignment]
 
 # Middleware stubs


### PR DESCRIPTION
## Summary
- expand CI workflow with black formatting check
- build and push Docker image after tests
- document workflow in development guide
- fix fastapi stub to export `Response`

## Testing
- `pytest -q` *(fails: FileNotFoundError in PluginRouter)*

------
https://chatgpt.com/codex/tasks/task_e_687c146f2a5c8324af20967e238ee952