### PR TITLE
Add event bus updates from MeshPlanner

### DIFF
--- a/tests/test_mesh_planner_events.py
+++ b/tests/test_mesh_planner_events.py
@@ -1,0 +1,16 @@
+from ai_karen_engine.core.mesh_planner import MeshPlanner
+from ai_karen_engine.event_bus import get_event_bus
+
+
+def test_mesh_planner_publishes_events():
+    bus = get_event_bus()
+    bus.consume()  # clear any existing events
+    planner = MeshPlanner()
+    planner.create_node("A")
+    planner.create_edge("A", "B")
+    planner.multi_hop_query("A", "B")
+    events = bus.consume(["admin"])
+    types = [e.event_type for e in events]
+    assert "node_created" in types
+    assert "edge_created" in types
+    assert "multi_hop_query" in types


### PR DESCRIPTION
## Summary
- publish event bus messages when MeshPlanner nodes, edges and multi-hop queries are executed
- expose events to Presence UI page which already consumes event bus
- test MeshPlanner publish/consume cycle

## Testing
- `pytest -q` *(fails: AttributeError in test collection)*
- `pytest tests/test_mesh_planner_events.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687c15cc75f883248a58e652e64af96d