### PR TITLE
Add black lint and docker push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI
 on:
   push:
     branches: [ main ]
+    tags: [ 'v*' ]
   pull_request:
 
 jobs:
@@ -17,10 +18,31 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          pip install ruff mypy pytest coverage
+          pip install ruff black mypy pytest coverage
       - name: Ruff
         run: ruff .
+      - name: Black
+        run: black --check .
       - name: Type check
         run: mypy --strict .
       - name: Test
         run: pytest --cov=./ --cov-report=xml --cov-report=term --cov-fail-under=85 -q
+
+  docker:
+    if: startsWith(github.ref, 'refs/tags/')
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Log in to registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/${{ github.repository }}:${{ github.ref_name }}


### PR DESCRIPTION
## Summary
- add a black step to CI
- push Docker image to GHCR when tags are pushed
- run pipeline on `v*` tags

## Testing
- `ruff check .` *(fails: many errors)*
- `black --check .` *(fails: many files would be reformatted)*
- `pytest --cov=./ --cov-report=xml --cov-report=term --cov-fail-under=85 -q` *(fails: unrecognized arguments)*
- `pytest -q` *(fails: import errors)*

------
https://chatgpt.com/codex/tasks/task_e_687c1616fa608324bc40a68285d81e7d