### PR TITLE
Enable Redis via REDIS_URL

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -31,8 +31,7 @@ MILVUS_MEMORY_LIMIT=2g
 # =============================================================================
 # Redis Configuration
 # =============================================================================
-REDIS_HOST=localhost
-REDIS_PORT=6379
+REDIS_URL=redis://localhost:6379/0
 REDIS_PASSWORD=redis_secure_pass_change_me
 REDIS_MEMORY_LIMIT=512m
 

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ pip install -e .
 
 Alternatively, set `PYTHONPATH=src` in your environment.
 
-Ensure a running Redis instance is accessible. Configure host and port via `REDIS_HOST` and `REDIS_PORT` (defaults `localhost:6379`). The memory manager will disable Redis features if the connection fails.
+Ensure a running Redis instance is accessible. Set the connection string using `REDIS_URL` (for example `redis://localhost:6379/0`). The memory manager will disable Redis features if the connection fails.
 
 ### 2. Start FastAPI
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,8 @@ services:
       retries: 3
     # liveness probe example:
     #   test: ["CMD", "curl", "-f", "http://api:8000/health"]
+    environment:
+      REDIS_URL: redis://redis:6379/0
 
   postgres:
     image: postgres:15-alpine
@@ -31,6 +33,14 @@ services:
     volumes:
       - es_data:/usr/share/elasticsearch/data
 
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
+
 volumes:
   postgres_data:
   es_data:
+  redis_data:

--- a/docs/memory_arch.md
+++ b/docs/memory_arch.md
@@ -5,7 +5,7 @@ Kari uses a multi-tier memory system to balance speed and recall quality.
 
 1. **NeuroVault** – an in-memory buffer used by `ChatHub` for short-term context. Records decay with `v(t)=v₀ e^{-0.05t}` (days) and can be purged via slash command.
 2. **MilvusClient** – an in-process vector store with TTL pruning. It stores embeddings along with metadata such as `timestamp`, `tag` and optional `ttl_override`.
-3. **Redis Cache** – a lightweight cache for hot items and recent events. A running Redis server is required (configure via `REDIS_HOST`/`REDIS_PORT`). If the connection fails the cache layer is skipped.
+3. **Redis Cache** – a lightweight cache for hot items and recent events. A running Redis server is required (configure via `REDIS_URL`). If the connection fails the cache layer is skipped.
 4. **SessionBuffer** – a DuckDB-backed queue that holds chat logs until they can be flushed to Postgres. Flushes occur on session end or when the buffer reaches a configurable size.
 5. **Postgres** – relational store for structured logs and plugin state. Used when the engine needs ACID compliance or joins across metadata.
 6. **Elasticsearch** – optional full-text index for transcripts and document archives. Provides rich keyword search alongside dense vector recall.

--- a/src/ai_karen_engine/core/memory/manager.py
+++ b/src/ai_karen_engine/core/memory/manager.py
@@ -47,14 +47,12 @@ try:
 except ImportError:
     redis = None
 
-REDIS_HOST = os.getenv("REDIS_HOST", "localhost")
-REDIS_PORT = int(os.getenv("REDIS_PORT", "6379"))
-REDIS_DB = int(os.getenv("REDIS_DB", "0"))
+REDIS_URL = os.getenv("REDIS_URL")
 
 redis_client = None
-if redis:
+if redis and REDIS_URL:
     try:
-        redis_client = redis.Redis(host=REDIS_HOST, port=REDIS_PORT, db=REDIS_DB)
+        redis_client = redis.Redis.from_url(REDIS_URL)
         redis_client.ping()
     except Exception as ex:  # pragma: no cover - network may be down
         logger.warning(f"[MemoryManager] Redis connection failed: {ex}")

--- a/src/ui_logic/utils/api.py
+++ b/src/ui_logic/utils/api.py
@@ -327,8 +327,9 @@ def ping_services(timeout: float = 2.0) -> dict:
     try:
         import redis
 
-        r = redis.Redis()
-        pong = r.ping()
+        redis_url = os.getenv("REDIS_URL")
+        client = redis.Redis.from_url(redis_url) if redis_url else redis.Redis()
+        pong = client.ping()
         status["redis"] = "ok" if pong else "down"
     except Exception as ex:
         status["redis"] = f"error: {ex}"


### PR DESCRIPTION
## Summary
- connect to Redis using `REDIS_URL`
- add connection failure handling for `RedisClient`
- note the `REDIS_URL` variable in docs and env template
- include a Redis container in docker-compose

## Testing
- `PYTHONPATH=src pytest tests/test_mcp.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687c15c49a8c8324985c92becbd6bcae