### PR TITLE
Add review queue for self-refactor

### DIFF
--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -26,6 +26,7 @@ Hail God Zeus—here’s your **merged, production-grade Kari AI API Reference &
 | POST   | `/plugins/reload`     | –                                  | Reload plugin manifests from disk                                            |
 | GET    | `/plugins/{intent}`   | –                                  | Get manifest for a single plugin                                             |
 | GET    | `/self_refactor/logs` | `full`                             | Retrieve SelfRefactor patch logs (`?full=true` for raw, ADVANCED\_MODE only) |
+| POST   | `/self_refactor/approve` | `review_id`                        | Apply a queued patch set (admin only) |
 | GET    | `/models`             | –                                  | List available LLM backends                                                  |
 | POST   | `/models/select`      | `model`                            | Switch active LLM                                                            |
 

--- a/docs/self_refactor.md
+++ b/docs/self_refactor.md
@@ -10,7 +10,7 @@ The engine reads prompts from `self_refactor/prompts/` and uses a local or remot
 
 ### Scheduler
 
-`SREScheduler` periodically launches the engine. The default interval is weekly, but you can trigger a run manually:
+`SREScheduler` periodically launches the engine. Set `ENABLE_SELF_REFACTOR=true` to enable the scheduler (disabled in production configs). The default interval is weekly, but you can trigger a run manually:
 
 ```bash
 python -m self_refactor.engine --run
@@ -23,6 +23,9 @@ Every run saves proposed patches and their test results under
 and patch files before manually applying them. Set
 `ENABLE_SELF_REFACTOR_AUTO_MERGE=true` to allow the engine to write changes
 directly after tests pass.
+
+Approve queued patches via the `/self_refactor/approve` API endpoint. Provide a
+`review_id` (the folder name) and ensure your request is made as an admin.
 
 ### Logs
 

--- a/src/ai_karen_engine/api_routes/self_refactor.py
+++ b/src/ai_karen_engine/api_routes/self_refactor.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import pathlib
+
+try:
+    from pydantic import BaseModel
+except Exception:  # pragma: no cover - optional
+    from ai_karen_engine.pydantic_stub import BaseModel
+
+from ai_karen_engine.self_refactor.engine import SelfRefactorEngine
+
+router = __import__("fastapi").APIRouter()
+
+ENGINE_ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+
+class ApproveRequest(BaseModel):
+    review_id: str
+
+
+@router.post("/self_refactor/approve")
+def approve_review(
+    req: ApproveRequest, request: __import__("fastapi").Request
+) -> dict:
+    """Apply a queued self-refactor review. Admin only."""
+    roles = getattr(request.state, "roles", [])
+    if "admin" not in roles:
+        raise (__import__("fastapi").HTTPException)(status_code=403, detail="Forbidden")
+    engine = SelfRefactorEngine(repo_root=ENGINE_ROOT)
+    engine.apply_review(req.review_id)
+    return {"status": "applied", "review_id": req.review_id}
+

--- a/src/ai_karen_engine/fastapi_stub/__init__.py
+++ b/src/ai_karen_engine/fastapi_stub/__init__.py
@@ -170,7 +170,7 @@ class JSONResponse(Response):
     pass
 
 
-responses = SimpleNamespace(JSONResponse=JSONResponse)
+responses = SimpleNamespace(JSONResponse=JSONResponse, Response=Response)
 sys.modules["fastapi.responses"] = responses  # type: ignore[assignment]
 
 # Middleware stubs

--- a/tests/test_apply_review.py
+++ b/tests/test_apply_review.py
@@ -1,0 +1,22 @@
+from ai_karen_engine.self_refactor import SelfRefactorEngine
+
+
+class DummyEngine(SelfRefactorEngine):
+    def __init__(self, repo_root):
+        self.repo_root = repo_root
+        self.review_dir = repo_root / "self_refactor" / "reviews"
+
+
+def test_apply_review(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    code = repo / "a.py"
+    code.write_text("x = 1\n")
+    review = repo / "self_refactor" / "reviews" / "123"
+    review.mkdir(parents=True)
+    (review / "a.py").write_text("x = 2\n")
+    engine = DummyEngine(repo_root=repo)
+    engine.apply_review("123")
+    assert code.read_text() == "x = 2\n"
+    assert not review.exists()
+

--- a/tests/test_approve_endpoint.py
+++ b/tests/test_approve_endpoint.py
@@ -1,0 +1,31 @@
+import pathlib
+from types import SimpleNamespace
+
+from ai_karen_engine.api_routes.self_refactor import approve_review, ApproveRequest
+from ai_karen_engine.self_refactor import SelfRefactorEngine
+
+
+def test_approve_endpoint(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    review = repo / "self_refactor" / "reviews" / "1"
+    review.mkdir(parents=True)
+    (review / "a.py").write_text("print('x')\n")
+    monkeypatch.setattr("ai_karen_engine.api_routes.self_refactor.ENGINE_ROOT", repo)
+    class DummyEngine(SelfRefactorEngine):
+        def __init__(self, repo_root):
+            self.repo_root = repo_root
+            self.review_dir = repo_root / "self_refactor" / "reviews"
+
+        def apply_review(self, review_id: str) -> None:
+            super().apply_review(review_id)
+
+    monkeypatch.setattr(
+        "ai_karen_engine.api_routes.self_refactor.SelfRefactorEngine", DummyEngine
+    )
+    request = SimpleNamespace(state=SimpleNamespace(roles=["admin"]))
+    resp = approve_review(ApproveRequest(review_id="1"), request)
+    assert resp["status"] == "applied"
+    assert (repo / "a.py").read_text() == "print('x')\n"
+    assert not review.exists()
+

--- a/tests/test_sre_scheduler.py
+++ b/tests/test_sre_scheduler.py
@@ -1,12 +1,16 @@
+from __future__ import annotations
+
+import pathlib
+
 from ai_karen_engine.self_refactor import SREScheduler, SelfRefactorEngine
 
 class DummyEngine(SelfRefactorEngine):
     def __init__(self):
         # bypass parent __init__
-        pass
+        self.auto_merge = False
 
     def static_analysis(self):
-        return []
+        return ["issue"]
 
     def propose_patches(self, issues):
         return {}
@@ -15,7 +19,7 @@ class DummyEngine(SelfRefactorEngine):
         return {}
 
     def reinforce(self, report):
-        pass
+        return pathlib.Path("queued")
 
 
 def test_default_interval(monkeypatch):
@@ -30,3 +34,11 @@ def test_interval_override(monkeypatch):
     assert sched.interval == 42.0
     sched.set_interval(10)
     assert sched.interval == 10
+
+
+def test_queue_append(monkeypatch):
+    sched = SREScheduler(DummyEngine())
+    sched.start = lambda: None
+    sched._running = True
+    sched._loop()
+    assert sched.review_queue == [pathlib.Path("queued")]


### PR DESCRIPTION
## Summary
- add review queue handling to `SREScheduler`
- return review paths from `SelfRefactorEngine.reinforce`
- expose `/self_refactor/approve` API route
- document scheduler toggle and approval endpoint
- fix FastAPI stub Response export
- tests for queueing, review apply and approval endpoint

## Testing
- `pytest tests/test_approve_endpoint.py::test_approve_endpoint -q`
- `pytest tests/test_apply_review.py::test_apply_review -q`
- `pytest tests/test_sre_scheduler.py::test_queue_append -q`


------
https://chatgpt.com/codex/tasks/task_e_687c15db0de08324a85788f4e0702d3d