### PR TITLE
Fix plugin discovery defaults

### DIFF
--- a/src/ai_karen_engine/compatibility.py
+++ b/src/ai_karen_engine/compatibility.py
@@ -5,21 +5,22 @@ This module provides temporary compatibility imports to ensure
 existing code continues to work during the migration period.
 """
 
-import warnings
-from typing import Any, Dict, Optional
 import sys
+import warnings
 from pathlib import Path
+from typing import Any, Dict, Optional
 
 
 def deprecated_import(old_path: str, new_path: str, removal_version: str = "0.5.0"):
     """
     Decorator to mark imports as deprecated.
-    
+
     Args:
         old_path: The old import path being deprecated
         new_path: The new import path to use instead
         removal_version: Version when the compatibility will be removed
     """
+
     def decorator(func_or_class):
         def wrapper(*args, **kwargs):
             warnings.warn(
@@ -27,28 +28,28 @@ def deprecated_import(old_path: str, new_path: str, removal_version: str = "0.5.
                 f"Use '{new_path}' instead. "
                 f"This compatibility layer will be removed in version {removal_version}.",
                 DeprecationWarning,
-                stacklevel=3
+                stacklevel=3,
             )
             return func_or_class(*args, **kwargs)
-        
+
         # Preserve original attributes
-        wrapper.__name__ = getattr(func_or_class, '__name__', 'unknown')
-        wrapper.__doc__ = getattr(func_or_class, '__doc__', None)
-        wrapper.__module__ = getattr(func_or_class, '__module__', None)
-        
+        wrapper.__name__ = getattr(func_or_class, "__name__", "unknown")
+        wrapper.__doc__ = getattr(func_or_class, "__doc__", None)
+        wrapper.__module__ = getattr(func_or_class, "__module__", None)
+
         return wrapper
+
     return decorator
 
 
 class CompatibilityImportManager:
     """Manages compatibility imports during migration."""
-    
+
     def __init__(self):
         self.import_mappings = {
             # Plugin system mappings
             "ai_karen_engine.plugin_manager": "ai_karen_engine.plugins.manager",
             "ai_karen_engine.plugin_router": "ai_karen_engine.plugins.router",
-            
             # Individual plugin mappings (examples)
             "ai_karen_engine.plugins.hello_world": "plugins.examples.hello_world",
             "ai_karen_engine.plugins.time_query": "plugins.core.time_query",
@@ -63,27 +64,33 @@ class CompatibilityImportManager:
             "ai_karen_engine.plugins.sandbox_fail": "plugins.examples.sandbox_fail",
             "ai_karen_engine.plugins.tui_fallback": "plugins.core.tui_fallback",
         }
-        
+
         self.usage_tracking: Dict[str, int] = {}
-    
+
     def track_usage(self, old_path: str) -> None:
         """Track usage of deprecated import paths."""
         self.usage_tracking[old_path] = self.usage_tracking.get(old_path, 0) + 1
-    
+
     def get_usage_report(self) -> Dict[str, Any]:
         """Get report of deprecated import usage."""
         return {
             "total_deprecated_imports": len(self.usage_tracking),
             "usage_by_path": self.usage_tracking,
-            "most_used": max(self.usage_tracking.items(), key=lambda x: x[1]) if self.usage_tracking else None
+            "most_used": (
+                max(self.usage_tracking.items(), key=lambda x: x[1])
+                if self.usage_tracking
+                else None
+            ),
         }
-    
-    def create_compatibility_module(self, old_module_path: str, new_module_path: str) -> None:
+
+    def create_compatibility_module(
+        self, old_module_path: str, new_module_path: str
+    ) -> None:
         """Create a compatibility module that redirects to the new location."""
         try:
             # Import the new module
-            new_module = __import__(new_module_path, fromlist=[''])
-            
+            new_module = __import__(new_module_path, fromlist=[""])
+
             # Create compatibility wrapper
             class CompatibilityModule:
                 def __getattr__(self, name):
@@ -92,13 +99,13 @@ class CompatibilityImportManager:
                         f"Import from '{old_module_path}' is deprecated. "
                         f"Use '{new_module_path}' instead.",
                         DeprecationWarning,
-                        stacklevel=2
+                        stacklevel=2,
                     )
                     return getattr(new_module, name)
-            
+
             # Install compatibility module
             sys.modules[old_module_path] = CompatibilityModule()
-            
+
         except ImportError:
             # New module doesn't exist yet, skip compatibility
             pass
@@ -111,18 +118,24 @@ _compatibility_manager = CompatibilityImportManager()
 # Plugin System Compatibility Imports
 try:
     from ai_karen_engine.plugins.manager import PluginManager as _PluginManager
-    from ai_karen_engine.plugins.manager import get_plugin_manager as _get_plugin_manager
-    
-    @deprecated_import("ai_karen_engine.plugin_manager", "ai_karen_engine.plugins.manager")
+    from ai_karen_engine.plugins.manager import \
+        get_plugin_manager as _get_plugin_manager
+
+    @deprecated_import(
+        "ai_karen_engine.plugin_manager", "ai_karen_engine.plugins.manager"
+    )
     class PluginManager(_PluginManager):
         """Compatibility wrapper for PluginManager."""
+
         pass
-    
-    @deprecated_import("ai_karen_engine.plugin_manager", "ai_karen_engine.plugins.manager")
+
+    @deprecated_import(
+        "ai_karen_engine.plugin_manager", "ai_karen_engine.plugins.manager"
+    )
     def get_plugin_manager(*args, **kwargs):
         """Compatibility wrapper for get_plugin_manager."""
         return _get_plugin_manager(*args, **kwargs)
-    
+
 except ImportError:
     # New plugin system not available yet
     PluginManager = None
@@ -130,31 +143,43 @@ except ImportError:
 
 
 try:
-    from ai_karen_engine.plugins.router import PluginRouter as _PluginRouter
-    from ai_karen_engine.plugins.router import PluginRecord as _PluginRecord
     from ai_karen_engine.plugins.router import AccessDenied as _AccessDenied
-    from ai_karen_engine.plugins.router import get_plugin_router as _get_plugin_router
-    
-    @deprecated_import("ai_karen_engine.plugin_router", "ai_karen_engine.plugins.router")
+    from ai_karen_engine.plugins.router import PluginRecord as _PluginRecord
+    from ai_karen_engine.plugins.router import PluginRouter as _PluginRouter
+    from ai_karen_engine.plugins.router import \
+        get_plugin_router as _get_plugin_router
+
+    @deprecated_import(
+        "ai_karen_engine.plugin_router", "ai_karen_engine.plugins.router"
+    )
     class PluginRouter(_PluginRouter):
         """Compatibility wrapper for PluginRouter."""
+
         pass
-    
-    @deprecated_import("ai_karen_engine.plugin_router", "ai_karen_engine.plugins.router")
+
+    @deprecated_import(
+        "ai_karen_engine.plugin_router", "ai_karen_engine.plugins.router"
+    )
     class PluginRecord(_PluginRecord):
         """Compatibility wrapper for PluginRecord."""
+
         pass
-    
-    @deprecated_import("ai_karen_engine.plugin_router", "ai_karen_engine.plugins.router")
+
+    @deprecated_import(
+        "ai_karen_engine.plugin_router", "ai_karen_engine.plugins.router"
+    )
     class AccessDenied(_AccessDenied):
         """Compatibility wrapper for AccessDenied."""
+
         pass
-    
-    @deprecated_import("ai_karen_engine.plugin_router", "ai_karen_engine.plugins.router")
+
+    @deprecated_import(
+        "ai_karen_engine.plugin_router", "ai_karen_engine.plugins.router"
+    )
     def get_plugin_router(*args, **kwargs):
         """Compatibility wrapper for get_plugin_router."""
         return _get_plugin_router(*args, **kwargs)
-    
+
 except ImportError:
     # New plugin system not available yet
     PluginRouter = None
@@ -166,22 +191,24 @@ except ImportError:
 # Individual Plugin Compatibility
 # Note: These will be created dynamically as plugins are moved
 
+
 def create_plugin_compatibility_imports():
     """Create compatibility imports for individual plugins."""
     plugin_mappings = {
         "ai_karen_engine.plugins.hello_world": "plugins.examples.hello_world",
         "ai_karen_engine.plugins.time_query": "plugins.core.time_query",
+        "ai_karen_engine.plugins.llm_manager": "plugins.integrations.llm_manager",
         # Add more as needed during migration
     }
-    
+
     for old_path, new_path in plugin_mappings.items():
         try:
             # Try to import from new location
-            new_module = __import__(new_path, fromlist=[''])
-            
+            new_module = __import__(new_path, fromlist=[""])
+
             # Create compatibility module
             _compatibility_manager.create_compatibility_module(old_path, new_path)
-            
+
         except ImportError:
             # New location doesn't exist yet, skip
             continue
@@ -199,7 +226,7 @@ def warn_about_deprecated_import(old_path: str, new_path: str) -> None:
     warnings.warn(
         f"Import from '{old_path}' is deprecated. Use '{new_path}' instead.",
         DeprecationWarning,
-        stacklevel=3
+        stacklevel=3,
     )
 
 
@@ -208,6 +235,7 @@ def is_migration_complete() -> bool:
     try:
         # Test key new imports
         from ai_karen_engine.plugins import manager, router
+
         return True
     except ImportError:
         return False
@@ -221,7 +249,7 @@ if __name__ != "__main__":
 # Export compatibility components
 __all__ = [
     "PluginManager",
-    "PluginRouter", 
+    "PluginRouter",
     "PluginRecord",
     "AccessDenied",
     "get_plugin_manager",

--- a/src/ai_karen_engine/fastapi_stub/__init__.py
+++ b/src/ai_karen_engine/fastapi_stub/__init__.py
@@ -22,6 +22,7 @@ class _Route:
         self.pattern = re.compile(f"^{regex}$")
         self.func = func
 
+
 class FastAPI:
     def __init__(self, *_, **__):
         self.routes = []
@@ -36,6 +37,7 @@ class FastAPI:
         def decorator(func):
             self._middlewares.append(func)
             return func
+
         return decorator
 
     async def _handle_request(self, method, path, json=None):
@@ -99,19 +101,27 @@ class FastAPI:
         resp = Response(data)
         content = json.dumps(resp.json()).encode()
         headers = [(b"content-type", b"application/json")]
-        await send({"type": "http.response.start", "status": resp.status_code, "headers": headers})
+        await send(
+            {
+                "type": "http.response.start",
+                "status": resp.status_code,
+                "headers": headers,
+            }
+        )
         await send({"type": "http.response.body", "body": content})
 
     def get(self, path, **_kw):
         def decorator(func):
             self.routes.append(_Route("GET", path, func))
             return func
+
         return decorator
 
     def post(self, path, **_kw):
         def decorator(func):
             self.routes.append(_Route("POST", path, func))
             return func
+
         return decorator
 
     def on_event(self, event: str):
@@ -119,11 +129,13 @@ class FastAPI:
             if event == "startup":
                 self._startup.append(func)
             return func
+
         return decorator
 
     def exception_handler(self, exc):
         def decorator(func):
             return func
+
         return decorator
 
     def include_router(self, router, prefix: str = ""):
@@ -142,13 +154,16 @@ class APIRouter(FastAPI):
         def decorator(func):
             self.routes.append(_Route("GET", path, func))
             return func
+
         return decorator
 
     def post(self, path, **_kw):
         def decorator(func):
             self.routes.append(_Route("POST", path, func))
             return func
+
         return decorator
+
 
 class Response:
     def __init__(self, content=None, status_code=200, media_type=None, headers=None):
@@ -180,13 +195,18 @@ sys.modules.setdefault("fastapi.middleware.cors", cors_stub)
 sys.modules.setdefault("fastapi.middleware.gzip", gzip_stub)
 
 
+# FastAPI Depends stub for compatibility
+def Depends(dep):
+    return dep
+
+
 class status:
     HTTP_401_UNAUTHORIZED = 401
 
 
-
 class Request:
     pass
+
 
 class TestClient:
     def __init__(self, app):
@@ -203,7 +223,9 @@ class TestClient:
         resp = Response(
             getattr(data, "_data", data),
             status,
-            media_type=data.headers.get("content-type") if hasattr(data, "headers") else None,
+            media_type=(
+                data.headers.get("content-type") if hasattr(data, "headers") else None
+            ),
         )
         resp.headers.update(getattr(data, "headers", {}))
         return resp
@@ -214,7 +236,9 @@ class TestClient:
         resp = Response(
             getattr(data, "_data", data),
             status,
-            media_type=data.headers.get("content-type") if hasattr(data, "headers") else None,
+            media_type=(
+                data.headers.get("content-type") if hasattr(data, "headers") else None
+            ),
         )
         resp.headers.update(getattr(data, "headers", {}))
         return resp

--- a/src/ai_karen_engine/plugins/llm_manager/__init__.py
+++ b/src/ai_karen_engine/plugins/llm_manager/__init__.py
@@ -1,0 +1,5 @@
+"""LLM manager plugin (compat shim)."""
+
+from .handler import run
+
+__all__ = ["run"]

--- a/src/ai_karen_engine/plugins/llm_manager/handler.py
+++ b/src/ai_karen_engine/plugins/llm_manager/handler.py
@@ -1,0 +1,23 @@
+"""Manage available language models for Kari."""
+
+from ai_karen_engine.integrations import model_discovery
+from ai_karen_engine.integrations.llm_registry import registry
+
+
+async def run(params: dict) -> dict:
+    action = params.get("action", "list")
+    if action == "list":
+        return {"models": list(registry.list_models()), "active": registry.active}
+    if action == "refresh":
+        models = model_discovery.sync_registry(model_discovery.REGISTRY_PATH)
+        return {"status": "refreshed", "count": len(models)}
+    if action == "select":
+        model = params.get("model")
+        if not model:
+            return {"error": "model required"}
+        try:
+            registry.set_active(model)
+        except KeyError:
+            return {"error": f"unknown model {model}"}
+        return {"status": "selected", "active": registry.active}
+    return {"error": "unknown action"}

--- a/src/ai_karen_engine/plugins/router.py
+++ b/src/ai_karen_engine/plugins/router.py
@@ -5,15 +5,15 @@ Kari PluginRouter: Ruthless Prompt‐First Plugin Orchestration
 - Local‐only execution by default (no cloud unless manifest demands it)
 """
 
-import os
-import json
 import inspect
+import json
+import os
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 # --- Prometheus metrics (optional) -------------------------------------
 try:
-    from prometheus_client import Counter, REGISTRY
+    from prometheus_client import REGISTRY, Counter
 
     # avoid double‐registration on reload
     if "plugin_import_error_total" not in REGISTRY._names_to_collectors:
@@ -23,45 +23,64 @@ try:
             ["plugin", "module", "error"],
         )
     else:
-        PLUGIN_IMPORT_ERRORS = REGISTRY._names_to_collectors["plugin_import_error_total"]
+        PLUGIN_IMPORT_ERRORS = REGISTRY._names_to_collectors[
+            "plugin_import_error_total"
+        ]
 except ImportError:
+
     class _DummyMetric:
-        def labels(self, **kw): return self
-        def inc(self, n: int = 1): pass
+        def labels(self, **kw):
+            return self
+
+        def inc(self, n: int = 1):
+            pass
+
     PLUGIN_IMPORT_ERRORS = _DummyMetric()
 
 
 # --- Sandboxing helper --------------------------------------------------
-from ai_karen_engine.utils.sandbox import run_in_sandbox  # your existing sandbox runner
-
+from ai_karen_engine.utils.sandbox import \
+    run_in_sandbox  # your existing sandbox runner
 
 # --- Jinja2 environment (optional) -------------------------------------
 try:
     from jinja2 import Environment, FileSystemLoader, select_autoescape
+
     jinja_env = Environment(
-        loader=FileSystemLoader(str(Path(__file__).parent.parent.parent.parent / "plugins")),
-        autoescape=select_autoescape(['txt'])
+        loader=FileSystemLoader(
+            str(Path(__file__).parent.parent.parent.parent / "plugins")
+        ),
+        autoescape=select_autoescape(["txt"]),
     )
 except ImportError:
     # fallback to simple str.format
     class Environment:
-        def __init__(self, *args, **kw): pass
+        def __init__(self, *args, **kw):
+            pass
+
         def from_string(self, text):
             class T:
-                def __init__(self, t): self.t = t
-                def render(self, ctx): return self.t.format(**ctx)
+                def __init__(self, t):
+                    self.t = t
+
+                def render(self, ctx):
+                    return self.t.format(**ctx)
+
             return T(text)
+
     jinja_env = Environment()
 
 
 # --- Paths & schema -----------------------------------------------------
-# Plugin root now points to the root plugins directory (marketplace structure)
-PLUGIN_ROOT       = Path(__file__).parent.parent.parent.parent / "plugins"
-PLUGIN_META       = "__meta"
-PLUGIN_MANIFEST   = "plugin_manifest.json"
-PROMPT_FILE       = "prompt.txt"
-HANDLER_FILE      = "handler.py"
-SCHEMA_PATH       = Path(__file__).parents[1] / "config" / "plugin_schema.json"
+# Default plugin root is this package's directory. It can be overridden via
+# the ``KARI_PLUGIN_DIR`` environment variable so tests and deployments may
+# point at a different runtime plugin folder.
+PLUGIN_ROOT = Path(os.getenv("KARI_PLUGIN_DIR", str(Path(__file__).parent)))
+PLUGIN_META = "__meta"
+PLUGIN_MANIFEST = "plugin_manifest.json"
+PROMPT_FILE = "prompt.txt"
+HANDLER_FILE = "handler.py"
+SCHEMA_PATH = Path(__file__).parents[1] / "config" / "plugin_schema.json"
 
 
 def load_schema() -> Dict[str, Any]:
@@ -75,12 +94,12 @@ def validate_manifest(manifest: Dict[str, Any], schema: Dict[str, Any]) -> bool:
     # If jsonschema is installed, use it; else fallback to key check
     try:
         import jsonschema  # type: ignore
+
         jsonschema.validate(instance=manifest, schema=schema)
         return True
     except Exception:
         required = schema.get(
-            "required",
-            ["plugin_api_version", "intent", "required_roles", "trusted_ui"]
+            "required", ["plugin_api_version", "intent", "required_roles", "trusted_ui"]
         )
         return all(k in manifest for k in required)
 
@@ -99,12 +118,15 @@ def load_prompt(plugin_dir: Path) -> str:
     return pf.read_text(encoding="utf-8")
 
 
-def load_handler(plugin_dir: Path, module_path: Optional[str] = None) -> Tuple[Callable, str]:
+def load_handler(
+    plugin_dir: Path, module_path: Optional[str] = None
+) -> Tuple[Callable, str]:
     """
     Return (handler_callable, module_name).
     Handler must expose `async def run(params)` or `def run(params)`.
     """
-    import importlib, importlib.util
+    import importlib
+    import importlib.util
 
     if module_path:
         module = importlib.import_module(module_path)
@@ -112,18 +134,23 @@ def load_handler(plugin_dir: Path, module_path: Optional[str] = None) -> Tuple[C
         handler_py = plugin_dir / HANDLER_FILE
         if not handler_py.exists():
             raise FileNotFoundError(f"Missing handler.py: {handler_py}")
-        spec = importlib.util.spec_from_file_location(f"plugin_{plugin_dir.name}", str(handler_py))
+        spec = importlib.util.spec_from_file_location(
+            f"plugin_{plugin_dir.name}", str(handler_py)
+        )
         module = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(module)  # type: ignore
 
     if not hasattr(module, "run"):
-        raise AttributeError(f"Plugin '{plugin_dir.name}' handler must define `run(params)`")
+        raise AttributeError(
+            f"Plugin '{plugin_dir.name}' handler must define `run(params)`"
+        )
     return getattr(module, "run"), module.__name__
 
 
 # --- Plugin record & router --------------------------------------------
 class AccessDenied(Exception):
     """User lacks required roles for this plugin."""
+
     pass
 
 
@@ -134,19 +161,19 @@ class PluginRecord:
         handler: Callable,
         module_name: str,
         ui: Optional[Callable],
-        dir_path: Path
+        dir_path: Path,
     ):
-        self.manifest    = manifest
-        self.handler     = handler
+        self.manifest = manifest
+        self.handler = handler
         self.module_name = module_name
-        self.ui          = ui
-        self.dir_path    = dir_path
+        self.ui = ui
+        self.dir_path = dir_path
 
 
 class PluginRouter:
     def __init__(self, plugin_root: Path = PLUGIN_ROOT):
         self.plugin_root = plugin_root
-        self.schema      = load_schema()
+        self.schema = load_schema()
         self.intent_map: Dict[str, PluginRecord] = {}
         self.reload()
 
@@ -154,19 +181,21 @@ class PluginRouter:
         out: Dict[str, PluginRecord] = {}
         self._scan_directory_for_plugins(self.plugin_root, out)
         return out
-    
-    def _scan_directory_for_plugins(self, directory: Path, out: Dict[str, PluginRecord]) -> None:
+
+    def _scan_directory_for_plugins(
+        self, directory: Path, out: Dict[str, PluginRecord]
+    ) -> None:
         """
         Recursively scan directory for plugins, supporting categorized structure.
         """
         for p in directory.iterdir():
             if not p.is_dir():
                 continue
-                
+
             # Skip metadata directories
-            if p.name.startswith('__') or p.name.startswith('.'):
+            if p.name.startswith("__") or p.name.startswith("."):
                 continue
-            
+
             mf = p / PLUGIN_MANIFEST
             if mf.exists():
                 # Found a plugin directory with manifest
@@ -178,9 +207,14 @@ class PluginRouter:
                     handler, mod_name = load_handler(p, manifest.get("module"))
                     ui = None
                     ui_py = p / "ui.py"
-                    if ui_py.exists() and (os.getenv("ADVANCED_MODE") or manifest.get("trusted_ui")):
+                    if ui_py.exists() and (
+                        os.getenv("ADVANCED_MODE") or manifest.get("trusted_ui")
+                    ):
                         import importlib.util
-                        spec = importlib.util.spec_from_file_location(f"plugin_ui_{p.name}", str(ui_py))
+
+                        spec = importlib.util.spec_from_file_location(
+                            f"plugin_ui_{p.name}", str(ui_py)
+                        )
                         ui_mod = importlib.util.module_from_spec(spec)
                         spec.loader.exec_module(ui_mod)  # type: ignore
                         ui = getattr(ui_mod, "render", None)
@@ -195,8 +229,12 @@ class PluginRouter:
                     # increment import‐error metric (labels auto‐noop if disabled)
                     PLUGIN_IMPORT_ERRORS.labels(
                         plugin=p.name,
-                        module=manifest.get("module", HANDLER_FILE) if 'manifest' in locals() else HANDLER_FILE,
-                        error=type(e).__name__
+                        module=(
+                            manifest.get("module", HANDLER_FILE)
+                            if "manifest" in locals()
+                            else HANDLER_FILE
+                        ),
+                        error=type(e).__name__,
                     ).inc()
                     print(f"Plugin discovery failed in {p}: {e}")
             else:
@@ -213,7 +251,7 @@ class PluginRouter:
 
     def list_intents(self) -> List[str]:
         return list(self.intent_map)
-    
+
     def get_plugin(self, intent: str) -> Optional[PluginRecord]:
         """Get plugin record for a specific intent."""
         return self.intent_map.get(intent)
@@ -223,10 +261,7 @@ class PluginRouter:
         return rec.handler if rec else None
 
     async def dispatch(
-        self,
-        intent: str,
-        params: Dict[str, Any],
-        roles: Optional[List[str]] = None
+        self, intent: str, params: Dict[str, Any], roles: Optional[List[str]] = None
     ) -> Any:
         rec = self.get_plugin(intent)
         if not rec:
@@ -257,6 +292,7 @@ class PluginRouter:
 
 # --- Singleton accessor -------------------------------------------------
 _plugin_router: Optional[PluginRouter] = None
+
 
 def get_plugin_router() -> PluginRouter:
     global _plugin_router


### PR DESCRIPTION
## Summary
- correct default plugin directory using env var `KARI_PLUGIN_DIR`
- allow compatibility imports for `llm_manager` plugin
- stub out `Depends` in fastapi stub
- ship basic in-tree `llm_manager` plugin for tests

## Testing
- `black src/ai_karen_engine/plugins/llm_manager/handler.py src/ai_karen_engine/plugins/llm_manager/__init__.py`
- `isort src/ai_karen_engine/plugins/llm_manager/handler.py src/ai_karen_engine/plugins/llm_manager/__init__.py`
- `ruff check src/ai_karen_engine/plugins/llm_manager/handler.py src/ai_karen_engine/plugins/llm_manager/__init__.py`
- `pytest tests/test_llm_manager.py::test_refresh_models -q`
- `pytest -q` *(fails: 10 failed, 14 passed)*

------
https://chatgpt.com/codex/tasks/task_e_687c18e02be88324a51595ed9b0c9397