### PR TITLE
Refactor chat UI helpers

### DIFF
--- a/tests/ui/test_chat_ui_helpers.py
+++ b/tests/ui/test_chat_ui_helpers.py
@@ -1,0 +1,46 @@
+from datetime import datetime
+
+import pytest
+
+# Skip tests if ``streamlit.testing`` is unavailable
+pytest.importorskip("streamlit.testing.v1", reason="streamlit not installed")
+from streamlit.testing.v1 import AppTest
+import streamlit as st
+
+from ui_launchers.streamlit_ui.helpers import (
+    render_message,
+    render_typing_indicator,
+    render_export_modal,
+)
+
+
+def test_render_message_runs():
+    def app():
+        render_message({"role": "assistant", "content": "hi", "timestamp": datetime.now(), "attachments": []})
+
+    at = AppTest.from_function(app)
+    at.run()
+    assert at.exception is None
+
+
+def test_render_typing_indicator_runs():
+    def app():
+        render_typing_indicator(True)
+
+    at = AppTest.from_function(app)
+    at.run()
+    assert at.exception is None
+
+
+def test_render_export_modal_runs():
+    st.session_state.chat_messages = [
+        {"role": "assistant", "content": "hi", "timestamp": datetime.now(), "attachments": []}
+    ]
+    st.session_state.show_export_modal = True
+
+    def app():
+        render_export_modal()
+
+    at = AppTest.from_function(app)
+    at.run()
+    assert at.exception is None

--- a/ui_launchers/streamlit_ui/helpers/__init__.py
+++ b/ui_launchers/streamlit_ui/helpers/__init__.py
@@ -1,4 +1,12 @@
 from .session import get_user_context, store_token
 from .auth import login
+from .chat_ui import render_message, render_typing_indicator, render_export_modal
 
-__all__ = ["get_user_context", "store_token", "login"]
+__all__ = [
+    "get_user_context",
+    "store_token",
+    "login",
+    "render_message",
+    "render_typing_indicator",
+    "render_export_modal",
+]

--- a/ui_launchers/streamlit_ui/helpers/chat_ui.py
+++ b/ui_launchers/streamlit_ui/helpers/chat_ui.py
@@ -1,0 +1,84 @@
+"""Helper functions for rendering chat UI components."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+
+import streamlit as st
+
+TEMPLATE_DIR = Path(__file__).parent / "templates"
+
+
+def _load_template(name: str) -> str:
+    return (TEMPLATE_DIR / name).read_text()
+
+
+def render_message(message: dict) -> None:
+    """Render a single chat ``message`` using the HTML templates."""
+    timestamp = message.get("timestamp", datetime.now()).strftime("%H:%M")
+    template = "message_user.html" if message.get("role") == "user" else "message_assistant.html"
+    st.markdown(
+        _load_template(template).format(content=message["content"], timestamp=timestamp),
+        unsafe_allow_html=True,
+    )
+    if message.get("attachments"):
+        for attachment in message["attachments"]:
+            st.markdown(f"📎 {attachment['name']} ({attachment['size']})")
+
+
+def render_typing_indicator(show: bool) -> None:
+    """Render the typing indicator when ``show`` is ``True``."""
+    if show:
+        st.markdown(_load_template("typing_indicator.html"), unsafe_allow_html=True)
+
+
+def render_export_modal() -> None:
+    """Render the export modal and handle export actions."""
+    with st.expander("📤 Export Conversation", expanded=True):
+        st.markdown(_load_template("export_modal.md"))
+        col1, col2, col3 = st.columns(3)
+
+        if col1.button("📄 Export as Text"):
+            export_text = "AI Karen Conversation Export\n" + "=" * 40 + "\n\n"
+            for msg in st.session_state.chat_messages:
+                role = "You" if msg["role"] == "user" else "AI Karen"
+                ts = msg.get("timestamp", datetime.now()).strftime("%Y-%m-%d %H:%M:%S")
+                export_text += f"[{ts}] {role}: {msg['content']}\n\n"
+            col1.download_button(
+                label="💾 Download Text File",
+                data=export_text,
+                file_name=f"ai_karen_chat_{datetime.now().strftime('%Y%m%d_%H%M%S')}.txt",
+                mime="text/plain",
+            )
+
+        if col2.button("📊 Export as JSON"):
+            export_data = {
+                "export_timestamp": datetime.now().isoformat(),
+                "conversation_length": len(st.session_state.chat_messages),
+                "messages": [
+                    {
+                        "role": m["role"],
+                        "content": m["content"],
+                        "timestamp": m.get("timestamp", datetime.now()).isoformat(),
+                        "attachments": m.get("attachments", []),
+                    }
+                    for m in st.session_state.chat_messages
+                ],
+            }
+            col2.download_button(
+                label="💾 Download JSON File",
+                data=json.dumps(export_data, indent=2),
+                file_name=f"ai_karen_chat_{datetime.now().strftime('%Y%m%d_%H%M%S')}.json",
+                mime="application/json",
+            )
+
+        if col3.button("📋 Copy to Clipboard"):
+            st.info(
+                "📋 Copy functionality would be implemented with JavaScript in a full deployment"
+            )
+
+        if st.button("❌ Close Export"):
+            st.session_state.show_export_modal = False
+            st.rerun()

--- a/ui_launchers/streamlit_ui/helpers/templates/export_modal.md
+++ b/ui_launchers/streamlit_ui/helpers/templates/export_modal.md
@@ -1,0 +1,1 @@
+**Export Options:**

--- a/ui_launchers/streamlit_ui/helpers/templates/message_assistant.html
+++ b/ui_launchers/streamlit_ui/helpers/templates/message_assistant.html
@@ -1,0 +1,18 @@
+<div style="display: flex; justify-content: flex-start; margin: 1rem 0;">
+    <div style="
+        background: #f1f5f9;
+        color: #1e293b;
+        padding: 1rem;
+        border-radius: 18px 18px 18px 4px;
+        max-width: 70%;
+        box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+        border-left: 3px solid #10b981;
+    ">
+        <div style="font-size: 0.9rem; margin-bottom: 0.5rem;">
+            {content}
+        </div>
+        <div style="font-size: 0.7rem; opacity: 0.6; text-align: left;">
+            🤖 AI Karen • {timestamp}
+        </div>
+    </div>
+</div>

--- a/ui_launchers/streamlit_ui/helpers/templates/message_user.html
+++ b/ui_launchers/streamlit_ui/helpers/templates/message_user.html
@@ -1,0 +1,17 @@
+<div style="display: flex; justify-content: flex-end; margin: 1rem 0;">
+    <div style="
+        background: #2563eb;
+        color: white;
+        padding: 1rem;
+        border-radius: 18px 18px 4px 18px;
+        max-width: 70%;
+        box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    ">
+        <div style="font-size: 0.9rem; margin-bottom: 0.5rem;">
+            {content}
+        </div>
+        <div style="font-size: 0.7rem; opacity: 0.8; text-align: right;">
+            👤 You • {timestamp}
+        </div>
+    </div>
+</div>

--- a/ui_launchers/streamlit_ui/helpers/templates/typing_indicator.html
+++ b/ui_launchers/streamlit_ui/helpers/templates/typing_indicator.html
@@ -1,0 +1,19 @@
+<div style="display: flex; justify-content: flex-start; margin: 1rem 0;">
+    <div style="
+        background: #f1f5f9;
+        color: #64748b;
+        padding: 1rem;
+        border-radius: 18px;
+        font-style: italic;
+        animation: pulse 1.5s infinite;
+    ">
+        🤖 AI Karen is typing...
+    </div>
+</div>
+<style>
+@keyframes pulse {
+    0% { opacity: 0.6; }
+    50% { opacity: 1; }
+    100% { opacity: 0.6; }
+}
+</style>

--- a/ui_launchers/streamlit_ui/pages/chat.py
+++ b/ui_launchers/streamlit_ui/pages/chat.py
@@ -7,6 +7,11 @@ import json
 import numpy as np
 from datetime import datetime
 from services.chat_service import chat_service
+from ui_launchers.streamlit_ui.helpers.chat_ui import (
+    render_message,
+    render_typing_indicator,
+    render_export_modal,
+)
 
 
 def render_enhanced_chat_interface(user_ctx=None):
@@ -57,81 +62,11 @@ def render_enhanced_chat_interface(user_ctx=None):
     
     with chat_container:
         # Display chat messages with rich formatting
-        for i, message in enumerate(st.session_state.chat_messages):
-            timestamp = message.get('timestamp', datetime.now()).strftime('%H:%M')
-            
-            if message["role"] == "user":
-                # User message (right-aligned)
-                st.markdown(f"""
-                <div style="display: flex; justify-content: flex-end; margin: 1rem 0;">
-                    <div style="
-                        background: #2563eb;
-                        color: white;
-                        padding: 1rem;
-                        border-radius: 18px 18px 4px 18px;
-                        max-width: 70%;
-                        box-shadow: 0 2px 4px rgba(0,0,0,0.1);
-                    ">
-                        <div style="font-size: 0.9rem; margin-bottom: 0.5rem;">
-                            {message["content"]}
-                        </div>
-                        <div style="font-size: 0.7rem; opacity: 0.8; text-align: right;">
-                            👤 You • {timestamp}
-                        </div>
-                    </div>
-                </div>
-                """, unsafe_allow_html=True)
-            else:
-                # Assistant message (left-aligned)
-                st.markdown(f"""
-                <div style="display: flex; justify-content: flex-start; margin: 1rem 0;">
-                    <div style="
-                        background: #f1f5f9;
-                        color: #1e293b;
-                        padding: 1rem;
-                        border-radius: 18px 18px 18px 4px;
-                        max-width: 70%;
-                        box-shadow: 0 2px 4px rgba(0,0,0,0.1);
-                        border-left: 3px solid #10b981;
-                    ">
-                        <div style="font-size: 0.9rem; margin-bottom: 0.5rem;">
-                            {message["content"]}
-                        </div>
-                        <div style="font-size: 0.7rem; opacity: 0.6; text-align: left;">
-                            🤖 AI Karen • {timestamp}
-                        </div>
-                    </div>
-                </div>
-                """, unsafe_allow_html=True)
-            
-            # Show attachments if any
-            if message.get('attachments'):
-                for attachment in message['attachments']:
-                    st.markdown(f"📎 {attachment['name']} ({attachment['size']})")
+        for message in st.session_state.chat_messages:
+            render_message(message)
     
     # Typing indicator
-    if show_typing and st.session_state.get('ai_typing', False):
-        st.markdown("""
-        <div style="display: flex; justify-content: flex-start; margin: 1rem 0;">
-            <div style="
-                background: #f1f5f9;
-                color: #64748b;
-                padding: 1rem;
-                border-radius: 18px;
-                font-style: italic;
-                animation: pulse 1.5s infinite;
-            ">
-                🤖 AI Karen is typing...
-            </div>
-        </div>
-        <style>
-        @keyframes pulse {
-            0% { opacity: 0.6; }
-            50% { opacity: 1; }
-            100% { opacity: 0.6; }
-        }
-        </style>
-        """, unsafe_allow_html=True)
+    render_typing_indicator(show_typing and st.session_state.get('ai_typing', False))
     
     # Message input area
     st.markdown("---")
@@ -266,55 +201,4 @@ def render_enhanced_chat_interface(user_ctx=None):
     
     # Export modal
     if st.session_state.get('show_export_modal', False):
-        with st.expander("📤 Export Conversation", expanded=True):
-            st.markdown("**Export Options:**")
-            
-            export_col1, export_col2, export_col3 = st.columns(3)
-            
-            with export_col1:
-                if st.button("📄 Export as Text"):
-                    # Generate text export
-                    export_text = "AI Karen Conversation Export\n" + "="*40 + "\n\n"
-                    for msg in st.session_state.chat_messages:
-                        role = "You" if msg["role"] == "user" else "AI Karen"
-                        timestamp = msg.get('timestamp', datetime.now()).strftime('%Y-%m-%d %H:%M:%S')
-                        export_text += f"[{timestamp}] {role}: {msg['content']}\n\n"
-                    
-                    st.download_button(
-                        label="💾 Download Text File",
-                        data=export_text,
-                        file_name=f"ai_karen_chat_{datetime.now().strftime('%Y%m%d_%H%M%S')}.txt",
-                        mime="text/plain"
-                    )
-            
-            with export_col2:
-                if st.button("📊 Export as JSON"):
-                    # Generate JSON export
-                    export_data = {
-                        "export_timestamp": datetime.now().isoformat(),
-                        "conversation_length": len(st.session_state.chat_messages),
-                        "messages": [
-                            {
-                                "role": msg["role"],
-                                "content": msg["content"],
-                                "timestamp": msg.get('timestamp', datetime.now()).isoformat(),
-                                "attachments": msg.get('attachments', [])
-                            }
-                            for msg in st.session_state.chat_messages
-                        ]
-                    }
-                    
-                    st.download_button(
-                        label="💾 Download JSON File",
-                        data=json.dumps(export_data, indent=2),
-                        file_name=f"ai_karen_chat_{datetime.now().strftime('%Y%m%d_%H%M%S')}.json",
-                        mime="application/json"
-                    )
-            
-            with export_col3:
-                if st.button("📋 Copy to Clipboard"):
-                    st.info("📋 Copy functionality would be implemented with JavaScript in a full deployment")
-            
-            if st.button("❌ Close Export"):
-                st.session_state.show_export_modal = False
-                st.rerun()
+        render_export_modal()


### PR DESCRIPTION
## Summary
- centralize chat UI helpers in `chat_ui` module
- store HTML snippets in helper templates
- update `chat.py` to use new helpers
- expose helper functions from `helpers.__init__`
- add `streamlit.testing` unit tests for the helpers

## Testing
- `pytest tests/ui/test_chat_ui_helpers.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687c20696514832492570f54b3d5d515