### PR TITLE
Fix plugin manifest intent fields

### DIFF
--- a/plugin_marketplace/core/tui-fallback/plugin_manifest.json
+++ b/plugin_marketplace/core/tui-fallback/plugin_manifest.json
@@ -4,9 +4,7 @@
   "required_roles": [
     "admin"
   ],
-  "intent": [
-    "tui_diagnostics"
-  ],
+  "intent": "tui_diagnostics",
   "trusted_ui": false,
   "module": "ai_karen_engine.plugins.tui_fallback.handler",
   "name": "tui-fallback",

--- a/plugin_marketplace/integrations/desktop-agent/plugin_manifest.json
+++ b/plugin_marketplace/integrations/desktop-agent/plugin_manifest.json
@@ -4,9 +4,7 @@
   "required_roles": [
     "admin"
   ],
-  "intent": [
-    "desktop_action"
-  ],
+  "intent": "desktop_action",
   "trusted_ui": false,
   "module": "ai_karen_engine.plugins.desktop_agent.handler",
   "name": "desktop-agent",

--- a/src/ai_karen_engine/plugins/tui_fallback/plugin_manifest.json
+++ b/src/ai_karen_engine/plugins/tui_fallback/plugin_manifest.json
@@ -4,9 +4,7 @@
   "required_roles": [
     "admin"
   ],
-  "intent": [
-    "tui_diagnostics"
-  ],
+  "intent": "tui_diagnostics",
   "trusted_ui": false,
   "module": "ai_karen_engine.plugins.tui_fallback.handler",
   "name": "tui-fallback",


### PR DESCRIPTION
## Summary
- fix plugin manifest JSON fields to use string `intent` values

## Testing
- `pytest tests/services/test_plugin_service.py::TestPluginRegistry.test_discover_plugins -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_6880b834a72c8324b72a4314955229a5