### PR TITLE
Ensure plugin manifests include required fields

### DIFF
--- a/plugin_marketplace/ai/fine-tune-lnm/plugin_manifest.json
+++ b/plugin_marketplace/ai/fine-tune-lnm/plugin_manifest.json
@@ -10,6 +10,9 @@
   "module": "ai_karen_engine.plugins.fine_tune_lnm.handler",
   "name": "fine-tune-lnm",
   "version": "0.1.0",
-  "description": "fine-tune-lnm plugin",
-  "author": "Kari Team"
+  "description": "Fine-tunes LNM models for custom tasks.",
+  "author": "Kari Team",
+  "license": "MPL-2.0",
+  "entry_point": "run",
+  "plugin_type": "ai"
 }

--- a/plugin_marketplace/ai/hf-llm/plugin_manifest.json
+++ b/plugin_marketplace/ai/hf-llm/plugin_manifest.json
@@ -9,6 +9,9 @@
   "module": "ai_karen_engine.plugins.hf_llm.handler",
   "name": "hf-llm",
   "version": "0.1.0",
-  "description": "hf-llm plugin",
-  "author": "Kari Team"
+  "description": "Generates text using HuggingFace models.",
+  "author": "Kari Team",
+  "license": "MPL-2.0",
+  "entry_point": "run",
+  "plugin_type": "ai"
 }

--- a/plugin_marketplace/ai/llm-services/deepseek/plugin_manifest.json
+++ b/plugin_marketplace/ai/llm-services/deepseek/plugin_manifest.json
@@ -9,6 +9,9 @@
   "module": "ai_karen_engine.plugins.llm_services.deepseek.handler",
   "name": "deepseek",
   "version": "0.1.0",
-  "description": "deepseek plugin",
-  "author": "Kari Team"
+  "description": "Uses the DeepSeek API for chat completion.",
+  "author": "Kari Team",
+  "license": "MPL-2.0",
+  "entry_point": "run",
+  "plugin_type": "ai"
 }

--- a/plugin_marketplace/ai/llm-services/gemini/plugin_manifest.json
+++ b/plugin_marketplace/ai/llm-services/gemini/plugin_manifest.json
@@ -9,6 +9,9 @@
   "module": "ai_karen_engine.plugins.llm_services.gemini.handler",
   "name": "gemini",
   "version": "0.1.0",
-  "description": "gemini plugin",
-  "author": "Kari Team"
+  "description": "Uses the Google Gemini API for chat.",
+  "author": "Kari Team",
+  "license": "MPL-2.0",
+  "entry_point": "run",
+  "plugin_type": "ai"
 }

--- a/plugin_marketplace/ai/llm-services/llama/plugin_manifest.json
+++ b/plugin_marketplace/ai/llm-services/llama/plugin_manifest.json
@@ -9,7 +9,6 @@
   "name": "LlamaCppLocal",
   "provider_id": "llama_cpp",
   "type": "llm_provider",
-  "entrypoint": "llama.handler:router",
   "description": "Pure in-process LLM using llama-cpp-python. No REST, no server. Hot-reload, async, and streaming.",
   "runtimes": [
     "python3.10+",
@@ -30,5 +29,8 @@
   },
   "module": "ai_karen_engine.plugins.llm_services.llama.handler",
   "version": "0.1.0",
-  "author": "Kari Team"
+  "author": "Kari Team",
+  "license": "MPL-2.0",
+  "entry_point": "llama.handler:router",
+  "plugin_type": "ai"
 }

--- a/plugin_marketplace/ai/llm-services/openai/plugin_manifest.json
+++ b/plugin_marketplace/ai/llm-services/openai/plugin_manifest.json
@@ -9,6 +9,9 @@
   "module": "ai_karen_engine.plugins.llm_services.openai.handler",
   "name": "openai",
   "version": "0.1.0",
-  "description": "openai plugin",
-  "author": "Kari Team"
+  "description": "Generates text using OpenAI GPT models.",
+  "author": "Kari Team",
+  "license": "MPL-2.0",
+  "entry_point": "run",
+  "plugin_type": "ai"
 }

--- a/plugin_marketplace/automation/autonomous-task-handler/plugin_manifest.json
+++ b/plugin_marketplace/automation/autonomous-task-handler/plugin_manifest.json
@@ -11,6 +11,9 @@
   "module": "ai_karen_engine.plugins.autonomous_task_handler.handler",
   "name": "autonomous-task-handler",
   "version": "0.1.0",
-  "description": "autonomous-task-handler plugin",
-  "author": "Kari Team"
+  "description": "Manages long-running autonomous tasks.",
+  "author": "Kari Team",
+  "license": "MPL-2.0",
+  "entry_point": "run",
+  "plugin_type": "automation"
 }

--- a/plugin_marketplace/automation/git-merge-safe/plugin_manifest.json
+++ b/plugin_marketplace/automation/git-merge-safe/plugin_manifest.json
@@ -9,6 +9,9 @@
   "module": "ai_karen_engine.plugins.git_merge_safe.handler",
   "name": "git-merge-safe",
   "version": "0.1.0",
-  "description": "git-merge-safe plugin",
-  "author": "Kari Team"
+  "description": "Safely merges branches with conflict checks.",
+  "author": "Kari Team",
+  "license": "MPL-2.0",
+  "entry_point": "run",
+  "plugin_type": "automation"
 }

--- a/plugin_marketplace/core/time-query/plugin_manifest.json
+++ b/plugin_marketplace/core/time-query/plugin_manifest.json
@@ -9,6 +9,9 @@
   "module": "ai_karen_engine.plugins.time_query.handler",
   "name": "time-query",
   "version": "0.1.0",
-  "description": "time-query plugin",
-  "author": "Kari Team"
+  "description": "Responds with the current time.",
+  "author": "Kari Team",
+  "license": "MPL-2.0",
+  "entry_point": "run",
+  "plugin_type": "core"
 }

--- a/plugin_marketplace/core/tui-fallback/plugin_manifest.json
+++ b/plugin_marketplace/core/tui-fallback/plugin_manifest.json
@@ -9,6 +9,9 @@
   "module": "ai_karen_engine.plugins.tui_fallback.handler",
   "name": "tui-fallback",
   "version": "0.1.0",
-  "description": "tui-fallback plugin",
-  "author": "Kari Team"
+  "description": "Provides a fallback terminal UI.",
+  "author": "Kari Team",
+  "license": "MPL-2.0",
+  "entry_point": "run",
+  "plugin_type": "core"
 }

--- a/plugin_marketplace/examples/hello-world/plugin_manifest.json
+++ b/plugin_marketplace/examples/hello-world/plugin_manifest.json
@@ -9,6 +9,9 @@
   "module": "ai_karen_engine.plugins.hello_world.handler",
   "name": "hello-world",
   "version": "0.1.0",
-  "description": "hello-world plugin",
-  "author": "Kari Team"
+  "description": "Example plugin that prints a greeting.",
+  "author": "Kari Team",
+  "license": "MPL-2.0",
+  "entry_point": "run",
+  "plugin_type": "example"
 }

--- a/plugin_marketplace/examples/sandbox-fail/plugin_manifest.json
+++ b/plugin_marketplace/examples/sandbox-fail/plugin_manifest.json
@@ -9,7 +9,10 @@
   "intent": "sandbox_fail",
   "trusted_ui": false,
   "sandbox": true,
-  "description": "sandbox-fail plugin",
+  "description": "Example plugin demonstrating sandbox failure.",
   "author": "Kari Team",
-  "module": "ai_karen_engine.plugins.sandbox_fail.handler"
+  "license": "MPL-2.0",
+  "module": "ai_karen_engine.plugins.sandbox_fail.handler",
+  "entry_point": "run",
+  "plugin_type": "example"
 }

--- a/plugin_marketplace/integrations/desktop-agent/plugin_manifest.json
+++ b/plugin_marketplace/integrations/desktop-agent/plugin_manifest.json
@@ -9,6 +9,9 @@
   "module": "ai_karen_engine.plugins.desktop_agent.handler",
   "name": "desktop-agent",
   "version": "0.1.0",
-  "description": "desktop-agent plugin",
-  "author": "Kari Team"
+  "description": "Provides desktop automation capabilities.",
+  "author": "Kari Team",
+  "license": "MPL-2.0",
+  "entry_point": "run",
+  "plugin_type": "integration"
 }

--- a/plugin_marketplace/integrations/k8s-scale/plugin_manifest.json
+++ b/plugin_marketplace/integrations/k8s-scale/plugin_manifest.json
@@ -9,6 +9,9 @@
   "module": "ai_karen_engine.plugins.k8s_scale.handler",
   "name": "k8s-scale",
   "version": "0.1.0",
-  "description": "k8s-scale plugin",
-  "author": "Kari Team"
+  "description": "Scales Kubernetes deployments via API.",
+  "author": "Kari Team",
+  "license": "MPL-2.0",
+  "entry_point": "run",
+  "plugin_type": "integration"
 }

--- a/plugin_marketplace/integrations/llm-manager/plugin_manifest.json
+++ b/plugin_marketplace/integrations/llm-manager/plugin_manifest.json
@@ -9,6 +9,9 @@
   "module": "ai_karen_engine.plugins.llm_manager.handler",
   "name": "llm-manager",
   "version": "0.1.0",
-  "description": "llm-manager plugin",
-  "author": "Kari Team"
+  "description": "Manages available LLM services.",
+  "author": "Kari Team",
+  "license": "MPL-2.0",
+  "entry_point": "run",
+  "plugin_type": "integration"
 }

--- a/src/ai_karen_engine/plugins/hello_world/plugin_manifest.json
+++ b/src/ai_karen_engine/plugins/hello_world/plugin_manifest.json
@@ -9,6 +9,9 @@
   "module": "ai_karen_engine.plugins.hello_world.handler",
   "name": "hello-world",
   "version": "0.1.0",
-  "description": "hello_world plugin",
-  "author": "Kari Team"
+  "description": "Simple greeting plugin for testing.",
+  "author": "Kari Team",
+  "license": "MPL-2.0",
+  "entry_point": "run",
+  "plugin_type": "core"
 }

--- a/src/ai_karen_engine/plugins/llm_manager/plugin_manifest.json
+++ b/src/ai_karen_engine/plugins/llm_manager/plugin_manifest.json
@@ -9,6 +9,9 @@
   "module": "ai_karen_engine.plugins.llm_manager.handler",
   "name": "llm-manager",
   "version": "0.1.0",
-  "description": "llm_manager plugin",
-  "author": "Kari Team"
+  "description": "Manages LLM configurations and deployments.",
+  "author": "Kari Team",
+  "license": "MPL-2.0",
+  "entry_point": "run",
+  "plugin_type": "core"
 }

--- a/src/ai_karen_engine/plugins/llm_services/deepseek/plugin_manifest.json
+++ b/src/ai_karen_engine/plugins/llm_services/deepseek/plugin_manifest.json
@@ -9,6 +9,9 @@
   "module": "ai_karen_engine.plugins.llm_services.deepseek.handler",
   "name": "deepseek",
   "version": "0.1.0",
-  "description": "deepseek plugin",
-  "author": "Kari Team"
+  "description": "Uses the DeepSeek API for chat completion.",
+  "author": "Kari Team",
+  "license": "MPL-2.0",
+  "entry_point": "run",
+  "plugin_type": "core"
 }

--- a/src/ai_karen_engine/plugins/llm_services/gemini/plugin_manifest.json
+++ b/src/ai_karen_engine/plugins/llm_services/gemini/plugin_manifest.json
@@ -9,6 +9,9 @@
   "module": "ai_karen_engine.plugins.llm_services.gemini.handler",
   "name": "gemini",
   "version": "0.1.0",
-  "description": "gemini plugin",
-  "author": "Kari Team"
+  "description": "Uses the Google Gemini API for chat.",
+  "author": "Kari Team",
+  "license": "MPL-2.0",
+  "entry_point": "run",
+  "plugin_type": "core"
 }

--- a/src/ai_karen_engine/plugins/llm_services/llama/plugin_manifest.json
+++ b/src/ai_karen_engine/plugins/llm_services/llama/plugin_manifest.json
@@ -9,7 +9,6 @@
   "name": "LlamaCppLocal",
   "provider_id": "llama_cpp",
   "type": "llm_provider",
-  "entrypoint": "llama.handler:router",
   "description": "Pure in-process LLM using llama-cpp-python. No REST, no server. Hot-reload, async, and streaming.",
   "runtimes": [
     "python3.10+",
@@ -30,5 +29,8 @@
   },
   "module": "ai_karen_engine.plugins.llm_services.llama.handler",
   "version": "0.1.0",
-  "author": "Kari Team"
+  "author": "Kari Team",
+  "license": "MPL-2.0",
+  "entry_point": "llama.handler:router",
+  "plugin_type": "core"
 }

--- a/src/ai_karen_engine/plugins/llm_services/openai/plugin_manifest.json
+++ b/src/ai_karen_engine/plugins/llm_services/openai/plugin_manifest.json
@@ -9,6 +9,9 @@
   "module": "ai_karen_engine.plugins.llm_services.openai.handler",
   "name": "openai",
   "version": "0.1.0",
-  "description": "openai plugin",
-  "author": "Kari Team"
+  "description": "Generates text using OpenAI GPT models.",
+  "author": "Kari Team",
+  "license": "MPL-2.0",
+  "entry_point": "run",
+  "plugin_type": "core"
 }

--- a/src/ai_karen_engine/plugins/sandbox_fail/plugin_manifest.json
+++ b/src/ai_karen_engine/plugins/sandbox_fail/plugin_manifest.json
@@ -9,7 +9,10 @@
   "sandbox": true,
   "name": "sandbox-fail",
   "version": "0.1.0",
-  "description": "sandbox_fail plugin",
+  "description": "Internal test plugin that fails in sandbox.",
   "author": "Kari Team",
-  "module": "ai_karen_engine.plugins.sandbox_fail.handler"
+  "license": "MPL-2.0",
+  "module": "ai_karen_engine.plugins.sandbox_fail.handler",
+  "entry_point": "run",
+  "plugin_type": "core"
 }

--- a/src/ai_karen_engine/plugins/time_query/plugin_manifest.json
+++ b/src/ai_karen_engine/plugins/time_query/plugin_manifest.json
@@ -9,6 +9,9 @@
   "module": "ai_karen_engine.plugins.time_query.handler",
   "name": "time-query",
   "version": "0.1.0",
-  "description": "time_query plugin",
-  "author": "Kari Team"
+  "description": "Responds with the current time.",
+  "author": "Kari Team",
+  "license": "MPL-2.0",
+  "entry_point": "run",
+  "plugin_type": "core"
 }

--- a/src/ai_karen_engine/plugins/tui_fallback/plugin_manifest.json
+++ b/src/ai_karen_engine/plugins/tui_fallback/plugin_manifest.json
@@ -9,6 +9,9 @@
   "module": "ai_karen_engine.plugins.tui_fallback.handler",
   "name": "tui-fallback",
   "version": "0.1.0",
-  "description": "tui_fallback plugin",
-  "author": "Kari Team"
+  "description": "Provides a fallback terminal UI.",
+  "author": "Kari Team",
+  "license": "MPL-2.0",
+  "entry_point": "run",
+  "plugin_type": "core"
 }


### PR DESCRIPTION
## Summary
- add `license` info and more descriptive text to plugin manifests
- verify manifests validate using `PluginManifest`

## Testing
- `python - <<'PY' ...` *(validation shows `errors []`)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_6880bf6a6b008324b2967d46290868ba