### PR TITLE
Fix plugin discovery for meta packages

### DIFF
--- a/src/ai_karen_engine/core/plugin_registry.py
+++ b/src/ai_karen_engine/core/plugin_registry.py
@@ -62,6 +62,9 @@ def _discover_plugins(base_pkg: str, type_label: str) -> dict[str, dict[str, Mod
     for _, name, ispkg in pkgutil.iter_modules(package.__path__):
         if not ispkg:
             continue
+        # Skip metadata or private packages
+        if name.startswith("_"):
+            continue
         try:
             mod = importlib.import_module(f"{base_pkg}.{name}.handler")
             plugins[name] = {"handler": mod, "type": type_label}


### PR DESCRIPTION
## Summary
- skip packages starting with '_' during plugin discovery

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_6880c92b21a083249408a85eafda3b11