### PR TITLE
Fix starter prompt API mismatch

### DIFF
--- a/src/ai_karen_engine/api_routes/ai_orchestrator_routes.py
+++ b/src/ai_karen_engine/api_routes/ai_orchestrator_routes.py
@@ -262,24 +262,39 @@ async def get_flow_metrics(
         raise HTTPException(status_code=500, detail=f"Failed to get metrics: {str(e)}")
 
 
+async def _generate_starter_prompts(_: Optional[str] = None) -> Dict[str, Any]:
+    """Internal helper to build starter prompt payload."""
+    starter_prompts = [
+        "What's the weather like today?",
+        "Tell me about the latest news",
+        "Help me organize my tasks",
+        "What can you help me with?",
+        "Show me my recent conversations",
+    ]
+
+    return {
+        "prompts": starter_prompts,
+        "timestamp": datetime.utcnow().isoformat(),
+    }
+
+
 @router.get("/generate-starter")
-async def generate_starter_prompts():
-    """Generate starter prompts for the web UI."""
+async def generate_starter_prompts_get():
+    """Generate starter prompts for the web UI (GET variant)."""
     try:
-        # Return some default starter prompts for now
-        starter_prompts = [
-            "What's the weather like today?",
-            "Tell me about the latest news",
-            "Help me organize my tasks",
-            "What can you help me with?",
-            "Show me my recent conversations"
-        ]
-        
-        return {
-            "prompts": starter_prompts,
-            "timestamp": datetime.utcnow().isoformat()
-        }
-        
+        return await _generate_starter_prompts()
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Failed to generate starter prompts: {str(e)}")
+
+
+@router.post("/generate-starter")
+async def generate_starter_prompts_post(body: Optional[Dict[str, Any]] = None):
+    """Generate starter prompts for the web UI (POST variant)."""
+    try:
+        assistant_type = None
+        if body:
+            assistant_type = body.get("assistant_type") or body.get("assistantType")
+        return await _generate_starter_prompts(assistant_type)
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to generate starter prompts: {str(e)}")
 

--- a/ui_launchers/web_ui/src/app/actions.ts
+++ b/ui_launchers/web_ui/src/app/actions.ts
@@ -87,15 +87,15 @@ export async function handleUserMessage(
 export async function getSuggestedStarter(assistantType: string): Promise<string> {
   try {
     const backend = getKarenBackend();
-    // API contract: GET request, returns { prompts: string[], timestamp: ... }
+    // API contract: POST request, returns { prompts: string[], timestamp: ... }
     const url = `${backend['config'].baseUrl}/api/ai/generate-starter`;
     const response = await fetch(url, {
-      method: 'GET',
+      method: 'POST',
       headers: {
         'Content-Type': 'application/json',
         ...(backend['config'].apiKey && { 'Authorization': `Bearer ${backend['config'].apiKey}` }),
       },
-      // GET requests never send a body!
+      body: JSON.stringify({ assistantType }),
     });
 
     if (response.ok) {
@@ -107,7 +107,9 @@ export async function getSuggestedStarter(assistantType: string): Promise<string
       }
       return "Tell me something interesting!";
     }
-    throw new Error(`Failed to get starter: ${response.statusText}`);
+
+    const errorText = await response.text();
+    throw new Error(`Failed to get starter: ${response.statusText} — ${errorText}`);
   } catch (error) {
     console.error('Error getting suggested starter:', error);
     return "I had trouble thinking of a starter prompt right now. How about you start with 'Tell me something interesting'?";


### PR DESCRIPTION
## Summary
- support POST `/api/ai/generate-starter` alongside GET
- handle both `assistant_type` and `assistantType` fields
- make web UI call POST and surface server error text

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_6880c92b21a083249408a85eafda3b11