### PR TITLE
Expose starter prompt API without tenant header

### DIFF
--- a/main.py
+++ b/main.py
@@ -162,7 +162,15 @@ def _load_plugins() -> None:
 
 # ─── Middleware: Metrics & Multi-Tenant ───────────────────────────────────────
 
-PUBLIC_PATHS = {"/", "/ping", "/health", "/ready", "/metrics", "/metrics/prometheus"}
+PUBLIC_PATHS = {
+    "/",
+    "/ping",
+    "/health",
+    "/ready",
+    "/metrics",
+    "/metrics/prometheus",
+    "/api/ai/generate-starter",
+}
 
 @app.middleware("http")
 async def record_metrics(request: Request, call_next):


### PR DESCRIPTION
## Summary
- make `/api/ai/generate-starter` publicly accessible

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_6880d74573d48324822ee62bbfb6e004