### PR TITLE
Add handler for llm_services plugin

### DIFF
--- a/src/ai_karen_engine/plugins/llm_services/handler.py
+++ b/src/ai_karen_engine/plugins/llm_services/handler.py
@@ -1,0 +1,8 @@
+"""Base handler for llm_services plugin.
+
+This plugin acts as a stub for loading LLM service sub-plugins.
+"""
+
+async def run(params: dict) -> str:
+    """Return a simple acknowledgement that the service plugin is loaded."""
+    return "ok"


### PR DESCRIPTION
## Summary
- stub out `handler.py` for `llm_services`
- ensure plugin discovery no longer logs an error for `llm_services`

## Testing
- `python - <<'EOF' ... EOF`

------
https://chatgpt.com/codex/tasks/task_e_6880d75819308324a4bc2c1e082e8edd