### PR TITLE
Add plugin entrypoints

### DIFF
--- a/src/ai_karen_engine/plugins/__meta/handler.py
+++ b/src/ai_karen_engine/plugins/__meta/handler.py
@@ -1,0 +1,25 @@
+import json
+from pathlib import Path
+
+COMMAND_MANIFEST = Path(__file__).with_name("command_manifest.json")
+
+
+def _load_commands() -> list:
+    try:
+        return json.loads(COMMAND_MANIFEST.read_text(encoding="utf-8"))
+    except Exception:
+        return []
+
+
+async def run(params: dict) -> dict:
+    """Return available meta commands or details for a specific command."""
+    command = params.get("command")
+    commands = _load_commands()
+    if not command or command == "list":
+        return {"commands": commands}
+
+    for cmd in commands:
+        if cmd.get("keyword") == command:
+            return cmd
+
+    return {"error": "unknown command"}

--- a/src/ai_karen_engine/plugins/llm_services/handler.py
+++ b/src/ai_karen_engine/plugins/llm_services/handler.py
@@ -1,0 +1,3 @@
+async def run(params: dict) -> str:
+    """Base handler for llm services plugin group."""
+    return "ok"


### PR DESCRIPTION
## Summary
- implement `run` entrypoint for plugins `__meta` and `llm_services`
- ensure loaders can import these modules

## Testing
- `ruff check src/ai_karen_engine/plugins/__meta/handler.py src/ai_karen_engine/plugins/llm_services/handler.py`
- `mypy --ignore-missing-imports src/ai_karen_engine/plugins/__meta/handler.py src/ai_karen_engine/plugins/llm_services/handler.py` *(fails: Name `Environment` already defined)*
- `pytest tests/services/test_plugin_service.py::TestGlobalServiceFunctions::test_initialize_plugin_service -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_6880d77e244883248f8136110dd78e7b