### PR TITLE
Remove sys.path hacks from demos

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,16 @@ export MILVUS_URL=localhost:19530
 | Build web UI | `cd ui_launchers/web_ui && npm run build` |
 | Build desktop | `cd ui_launchers/desktop_ui && npm run tauri build` |
 
+### Demo Scripts
+
+When running the example demo scripts directly from the repository, set
+`PYTHONPATH=src` so the `ai_karen_engine` package can be imported without
+modifying `sys.path` inside the scripts:
+
+```bash
+PYTHONPATH=src python demo_plugin_system.py
+```
+
 ### Plugin Development
 
 Create a new plugin in `src/ai_karen_engine/plugins/`:

--- a/demo_analytics_dashboard.py
+++ b/demo_analytics_dashboard.py
@@ -12,10 +12,6 @@ import time
 import random
 from datetime import datetime, timedelta
 
-# Import directly to avoid dependency issues
-import sys
-sys.path.append('src')
-
 from ai_karen_engine.services.analytics_service import (
     AnalyticsService,
     MetricType,

--- a/demo_plugin_system.py
+++ b/demo_plugin_system.py
@@ -10,8 +10,6 @@ import asyncio
 import json
 from pathlib import Path
 
-import sys
-sys.path.append('src')
 
 from ai_karen_engine.services.plugin_service import (
     PluginService, ExecutionMode

--- a/demo_tool_system.py
+++ b/demo_tool_system.py
@@ -9,12 +9,9 @@ tool registration, discovery, validation, and execution.
 import asyncio
 import json
 import logging
-import sys
 import os
+import sys
 from datetime import datetime
-
-# Add src to path
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'src'))
 
 # Configure logging
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')


### PR DESCRIPTION
## Summary
- clean up `demo_analytics_dashboard.py`
- clean up `demo_plugin_system.py`
- clean up `demo_tool_system.py`
- document how to run demo scripts without modifying `sys.path`

## Testing
- `PYTHONPATH=src python demo_analytics_dashboard.py` *(fails: ModuleNotFoundError: No module named 'pydantic')*
- `PYTHONPATH=src python demo_plugin_system.py` *(fails: ModuleNotFoundError: No module named 'pydantic')*
- `PYTHONPATH=src python demo_tool_system.py` *(fails: ModuleNotFoundError: No module named 'pydantic')*
- `PYTHONPATH=src pytest tests/test_basic_setup.py -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_6880dfbe499c832481eb3cf6dd6cc7db