### PR TITLE
Remove sys.path hacks from demo scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,16 @@ pytest -v
 curl http://localhost:8000/api/health/summary
 ```
 
+### Running Demo Scripts
+
+Run the example demos with the project source on your `PYTHONPATH`:
+
+```bash
+PYTHONPATH=src python demo_plugin_system.py
+PYTHONPATH=src python demo_tool_system.py
+PYTHONPATH=src python demo_analytics_dashboard.py
+```
+
 ---
 
 ## Development Setup

--- a/demo_analytics_dashboard.py
+++ b/demo_analytics_dashboard.py
@@ -12,9 +12,7 @@ import time
 import random
 from datetime import datetime, timedelta
 
-# Import directly to avoid dependency issues
-import sys
-sys.path.append('src')
+# Run with: PYTHONPATH=src python demo_analytics_dashboard.py
 
 from ai_karen_engine.services.analytics_service import (
     AnalyticsService,

--- a/demo_plugin_system.py
+++ b/demo_plugin_system.py
@@ -10,8 +10,7 @@ import asyncio
 import json
 from pathlib import Path
 
-import sys
-sys.path.append('src')
+# Run with: PYTHONPATH=src python demo_plugin_system.py
 
 from ai_karen_engine.services.plugin_service import (
     PluginService, ExecutionMode

--- a/demo_tool_system.py
+++ b/demo_tool_system.py
@@ -9,12 +9,9 @@ tool registration, discovery, validation, and execution.
 import asyncio
 import json
 import logging
-import sys
-import os
 from datetime import datetime
 
-# Add src to path
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'src'))
+# Run with: PYTHONPATH=src python demo_tool_system.py
 
 # Configure logging
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')


### PR DESCRIPTION
## Summary
- drop `sys.path` manipulation from demo scripts
- document running demos with `PYTHONPATH=src`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_6880dfbe499c832481eb3cf6dd6cc7db