### PR TITLE
Fix tenant header docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,19 @@ helm install ai-karen ./charts/kari/ \
 The memory query endpoint (`/api/memory/query`) returns at most **100 results** by default.
 You can override this cap by providing the `result_limit` parameter in your request.
 
+### Tenant Header
+
+Most API endpoints are tenant-aware. Include an `X-Tenant-ID` header with your
+tenant name in requests that are not listed under the public paths. For local
+testing you can use `default`:
+
+```bash
+curl -H "X-Tenant-ID: default" \
+     -H "Authorization: Bearer <token>" \
+     -H "Content-Type: application/json" \
+     -d '{"text": "hello"}' http://localhost:8000/chat
+```
+
 ### Authentication
 
 ```bash

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -70,6 +70,17 @@ curl -X POST -H "Content-Type: application/json" \
   http://localhost:8000/api/memory/query
 ```
 
+### Tenant Header
+
+Most non-public endpoints require a tenant identifier. Include the header
+`X-Tenant-ID` with your tenant name when calling the API:
+
+```bash
+curl -H "X-Tenant-ID: default" \
+     -H "Content-Type: application/json" \
+     -d '{"text": "hello"}' http://localhost:8000/chat
+```
+
 ### 5. List and Reload Plugins
 
 ```bash


### PR DESCRIPTION
## Description
- document required `X-Tenant-ID` header for non-public endpoints

## Testing
- `pre-commit` *(fails: command not found)*
- `PYTHONPATH=src pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_6880ea7c0c308324bb8edcd929a76e1f