### PR TITLE
Add memory_entries table migration and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,8 +108,8 @@ docker compose up -d postgres redis elasticsearch milvus
 ### 3. Initialize Databases
 
 ```bash
-# Initialize PostgreSQL schema
-docker-compose exec postgres psql -U postgres -d postgres -f /docker-entrypoint-initdb.d/001_create_tables.sql
+# Apply PostgreSQL migrations (creates all tables including `memory_entries`)
+./docker/database/scripts/migrate.sh --service postgres
 
 # Create Elasticsearch index
 curl -X PUT "http://localhost:9200/ai_karen_index"

--- a/data/migrations/postgres/002a_create_memory_entries_table.sql
+++ b/data/migrations/postgres/002a_create_memory_entries_table.sql
@@ -1,0 +1,23 @@
+-- Create memory_entries table for tenant data
+CREATE TABLE IF NOT EXISTS memory_entries (
+    id UUID PRIMARY KEY,
+    vector_id VARCHAR(255) NOT NULL,
+    user_id UUID NOT NULL,
+    session_id VARCHAR(255),
+    content TEXT NOT NULL,
+    query TEXT,
+    result JSONB,
+    embedding_id VARCHAR(255),
+    memory_metadata JSONB DEFAULT '{}',
+    ttl TIMESTAMP,
+    timestamp BIGINT DEFAULT 0,
+    created_at TIMESTAMP DEFAULT NOW(),
+    updated_at TIMESTAMP DEFAULT NOW()
+);
+
+-- Base indexes
+CREATE INDEX idx_memory_vector ON memory_entries(vector_id);
+CREATE INDEX idx_memory_user ON memory_entries(user_id);
+CREATE INDEX idx_memory_session ON memory_entries(session_id);
+CREATE INDEX idx_memory_created ON memory_entries(created_at);
+CREATE INDEX idx_memory_ttl ON memory_entries(ttl);

--- a/tests/test_memory_entries_schema.py
+++ b/tests/test_memory_entries_schema.py
@@ -1,0 +1,13 @@
+import pytest
+from sqlalchemy import create_engine, inspect
+
+from src.ai_karen_engine.database.models import Base, TenantMemoryEntry
+
+
+class TestMemoryEntriesInitialization:
+    def test_create_memory_entries_table(self):
+        engine = create_engine("sqlite:///:memory:")
+        Base.metadata.create_all(engine, tables=[TenantMemoryEntry.__table__])
+        inspector = inspect(engine)
+        assert "memory_entries" in inspector.get_table_names()
+


### PR DESCRIPTION
## Summary
- create memory_entries table migration
- update quickstart docs to run migration script
- test memory_entries table creation in-memory

## Testing
- `pytest tests/test_memory_entries_schema.py -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_6881fada72008324b92a0ca6437d38b5