### PR TITLE
Ensure memory table and default models

### DIFF
--- a/src/ai_karen_engine/api_routes/admin.py
+++ b/src/ai_karen_engine/api_routes/admin.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import logging
+import uuid
+from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import JSONResponse
+
+from ai_karen_engine.services.memory_service import WebUIMemoryService
+from ai_karen_engine.core.dependencies import get_memory_service
+from ai_karen_engine.utils.bootstrap import bootstrap_memory_system
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/admin", tags=["admin"])
+
+@router.post("/bootstrap_memory")
+async def bootstrap_memory(
+    request: Request,
+    memory_service: WebUIMemoryService = Depends(get_memory_service),
+):
+    """Force initialization of memory tables and default models."""
+    trace_id = getattr(request.state, "trace_id", str(uuid.uuid4()))
+    try:
+        success = await bootstrap_memory_system(memory_service, tenant_id="default")
+        return JSONResponse({"success": success})
+    except Exception as exc:
+        logger.error(f"[{trace_id}] bootstrap failed: {exc}")
+        raise HTTPException(status_code=500, detail="bootstrap failed") from exc

--- a/src/ai_karen_engine/clients/nlp/spacy_client.py
+++ b/src/ai_karen_engine/clients/nlp/spacy_client.py
@@ -14,7 +14,7 @@ except Exception:  # pragma: no cover - optional dep
     spacy = None
 
 
-DEFAULT_MODEL = "en_core_web_trf"
+DEFAULT_MODEL = "en_core_web_sm"
 
 
 class SpaCyClient:

--- a/src/ai_karen_engine/core/__init__.py
+++ b/src/ai_karen_engine/core/__init__.py
@@ -65,3 +65,17 @@ __all__ = [
     "setup_middleware",
     "setup_routing"
 ]
+
+from .default_models import (
+    load_default_models,
+    get_embedding_manager,
+    get_spacy_client,
+    get_classifier,
+)
+
+__all__ += [
+    "load_default_models",
+    "get_embedding_manager",
+    "get_spacy_client",
+    "get_classifier",
+]

--- a/src/ai_karen_engine/core/default_models.py
+++ b/src/ai_karen_engine/core/default_models.py
@@ -1,0 +1,51 @@
+import logging
+from pathlib import Path
+
+from ai_karen_engine.core.embedding_manager import EmbeddingManager
+from ai_karen_engine.clients.nlp.spacy_client import SpaCyClient
+from ai_karen_engine.clients.nlp.basic_classifier import BasicClassifier
+
+embedding_manager: EmbeddingManager | None = None
+spacy_client: SpaCyClient | None = None
+classifier: BasicClassifier | None = None
+
+logger = logging.getLogger(__name__)
+
+async def load_default_models() -> None:
+    """Initialize default models if they haven't been loaded."""
+    global embedding_manager, spacy_client, classifier
+
+    if embedding_manager is None:
+        embedding_manager = EmbeddingManager()
+        await embedding_manager.initialize()
+        logger.info("Default embedding model loaded: %s", embedding_manager.model_loaded)
+
+    if spacy_client is None:
+        try:
+            spacy_client = SpaCyClient()
+            logger.info("SpaCy model loaded: %s", SpaCyClient.DEFAULT_MODEL if hasattr(SpaCyClient, 'DEFAULT_MODEL') else 'default')
+        except Exception as exc:  # pragma: no cover - runtime only
+            logger.error("Failed to load spaCy model: %s", exc)
+            spacy_client = None
+
+    if classifier is None:
+        try:
+            classifier = BasicClassifier(Path("data/default_classifier"))
+            logger.info("Basic classifier ready")
+        except Exception as exc:  # pragma: no cover - runtime only
+            logger.error("Failed to load basic classifier: %s", exc)
+            classifier = None
+
+
+def get_embedding_manager() -> EmbeddingManager:
+    if embedding_manager is None:
+        raise RuntimeError("Default models not loaded")
+    return embedding_manager
+
+
+def get_spacy_client() -> SpaCyClient | None:
+    return spacy_client
+
+
+def get_classifier() -> BasicClassifier | None:
+    return classifier

--- a/src/ai_karen_engine/core/embedding_manager.py
+++ b/src/ai_karen_engine/core/embedding_manager.py
@@ -2,9 +2,22 @@
 
 from __future__ import annotations
 
+"""Flexible embedding manager with optional HuggingFace backend."""
+
 import hashlib
+import logging
+import os
 import time
-from typing import List
+from typing import List, Optional
+
+try:  # Optional heavy dependency
+    import torch
+    from transformers import AutoModel, AutoTokenizer
+except Exception:  # pragma: no cover - optional dep
+    torch = None
+    AutoModel = AutoTokenizer = None
+
+logger = logging.getLogger(__name__)
 
 
 _METRICS = {}
@@ -15,13 +28,17 @@ def record_metric(name: str, value: float) -> None:
 
 
 class EmbeddingManager:
-    """Return deterministic embeddings using hashlib."""
+    """Return embeddings using HuggingFace if available, otherwise hashlib."""
 
-    def __init__(self, dim: int = 8) -> None:
+    def __init__(self, model_name: Optional[str] = None, dim: int = 8) -> None:
         self.dim = dim
+        self.model_name = model_name or os.getenv("KARI_EMBED_MODEL", "distilbert-base-uncased")
+        self.model = None
+        self.tokenizer = None
+        self.model_loaded = "hashlib"
 
     def embed(self, text: str) -> List[float]:
-        """Embed text into a fixed-size vector."""
+        """Embed text into a fixed-size vector using deterministic hashing."""
         start = time.time()
         h = hashlib.sha256(text.encode("utf-8")).digest()
         vector = [b / 255 for b in h[: self.dim]]
@@ -29,11 +46,35 @@ class EmbeddingManager:
         return vector
 
     async def initialize(self) -> None:
-        """Async placeholder for initialization logic."""
-        # In this simple implementation there is nothing to initialize, but
-        # the async method keeps the contract consistent with other services.
-        return None
+        """Load HuggingFace model if available."""
+        if AutoModel is None or AutoTokenizer is None:
+            logger.warning("[EmbeddingManager] transformers not installed; using hashlib embeddings")
+            return
+
+        try:
+            self.tokenizer = AutoTokenizer.from_pretrained(self.model_name)
+            self.model = AutoModel.from_pretrained(self.model_name)
+            if torch:
+                self.model = self.model.to("cpu")
+            self.model.eval()
+            self.model_loaded = self.model_name
+            logger.info("[EmbeddingManager] Loaded model %s", self.model_name)
+        except Exception as exc:  # pragma: no cover - runtime only
+            logger.error("[EmbeddingManager] Failed to load %s: %s", self.model_name, exc)
+            self.model = None
+            self.tokenizer = None
+            self.model_loaded = "hashlib"
     
     async def get_embedding(self, text: str) -> List[float]:
-        """Async wrapper for embed method to maintain contract compatibility."""
+        """Return an embedding for the given text."""
+        if self.model and self.tokenizer:
+            try:
+                inputs = self.tokenizer(text, return_tensors="pt", truncation=True)
+                with torch.no_grad():
+                    outputs = self.model(**inputs)
+                vector = outputs.last_hidden_state.mean(dim=1).squeeze().tolist()
+                record_metric("embedding_time_seconds", 0)  # Already timed by HF
+                return vector
+            except Exception as exc:  # pragma: no cover - runtime only
+                logger.error("[EmbeddingManager] HF embedding failed: %s", exc)
         return self.embed(text)

--- a/src/ai_karen_engine/core/service_registry.py
+++ b/src/ai_karen_engine/core/service_registry.py
@@ -146,12 +146,13 @@ class ServiceRegistry:
                 from ai_karen_engine.database.memory_manager import MemoryManager
                 from ai_karen_engine.database.client import MultiTenantPostgresClient
                 from ai_karen_engine.core.milvus_client import MilvusClient
-                from ai_karen_engine.core.embedding_manager import EmbeddingManager
+                from ai_karen_engine.core import default_models
                 
                 # Initialize required components
                 db_client = MultiTenantPostgresClient()
                 milvus_client = MilvusClient()
-                embedding_manager = EmbeddingManager()
+                await default_models.load_default_models()
+                embedding_manager = default_models.get_embedding_manager()
                 
                 # Create memory manager instance
                 memory_manager = MemoryManager(

--- a/src/ai_karen_engine/fastapi.py
+++ b/src/ai_karen_engine/fastapi.py
@@ -121,6 +121,27 @@ async def _init_extensions() -> None:
         logger.error(f"Failed to load extensions: {e}")
         # Don't fail startup if extensions fail to load
 
+
+@app.on_event("startup")
+async def _bootstrap_memory_defaults() -> None:
+    """Ensure memory tables exist and default models are loaded."""
+    try:
+        from .core.service_registry import get_service_registry
+        from ai_karen_engine.core import default_models
+
+        registry = get_service_registry()
+        memory_service = await registry.get_service("memory_service")
+        base_manager = memory_service.base_manager
+        db_client = base_manager.db_client
+        db_client.ensure_memory_table("default")
+
+        # Load default models
+        await default_models.load_default_models()
+        logger.info("Default models initialized")
+    except Exception as exc:
+        logger.error(f"Failed to bootstrap memory defaults: {exc}")
+        raise RuntimeError("Memory bootstrap failed") from exc
+
 # -- Prometheus Metrics (optional) --
 try:
     from prometheus_client import make_asgi_app

--- a/src/ai_karen_engine/utils/bootstrap.py
+++ b/src/ai_karen_engine/utils/bootstrap.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import logging
+import uuid
+
+from ai_karen_engine.services.memory_service import WebUIMemoryService, WebUIMemoryQuery, UISource
+from ai_karen_engine.core.default_models import load_default_models
+
+logger = logging.getLogger(__name__)
+
+async def bootstrap_memory_system(memory_service: WebUIMemoryService, tenant_id: str = "default") -> bool:
+    """Ensure memory schema and models are initialized and perform roundtrip test."""
+    base_manager = memory_service.base_manager
+    db_client = base_manager.db_client
+
+    if not db_client.ensure_memory_table(tenant_id):
+        logger.error("[bootstrap] failed to ensure memory table for %s", tenant_id)
+        return False
+
+    await load_default_models()
+
+    test_id = await memory_service.store_web_ui_memory(
+        tenant_id=tenant_id,
+        content="bootstrap test",
+        user_id=str(uuid.uuid4()),
+        ui_source=UISource.API,
+    )
+    results = await memory_service.query_memories(
+        tenant_id=tenant_id, query=WebUIMemoryQuery(text="bootstrap test")
+    )
+    found = any(m.id == test_id for m in results)
+    logger.info("[bootstrap] roundtrip success=%s", found)
+    return found


### PR DESCRIPTION
## Summary
- load default models through new `default_models` module
- bootstrap memory table and model loading via startup event
- expose `/api/admin/bootstrap_memory` to force initialization
- share embedding manager from default models when starting services

## Testing
- `ruff check .` *(fails: numerous F401/F841 errors in streamlit_ui)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `pip install sqlalchemy` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6882289dbe1883249db05955ed4c074e