### PR TITLE
Add eco mode for minimal model loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,7 @@ helm install ai-karen ./charts/kari/ \
 | `ENABLE_SELF_REFACTOR` | Enable self-refactoring | `false` |
 | `LOG_LEVEL` | Logging level | `INFO` |
 | `KARI_CORS_ORIGINS` | Comma-separated list of allowed CORS origins | `*` |
+| `KARI_ECO_MODE` | Skip heavy NLP model loading | `false` |
 
 ---
 

--- a/docs/development_guide.md
+++ b/docs/development_guide.md
@@ -50,6 +50,7 @@ Set these required environment variables before development:
 - `KARI_LLM_TIMEOUT` - LLM request timeout in seconds (default: 60)
 - `KARI_ENV` - Selects the runtime environment. Use `local` (the default) to
   run entirely on your machine without relying on external services.
+- `KARI_ECO_MODE` - Skip heavy NLP model loading for low-resource environments
 
 ### Local Development Setup
 

--- a/src/ai_karen_engine/core/default_models.py
+++ b/src/ai_karen_engine/core/default_models.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from pathlib import Path
 
 from ai_karen_engine.core.embedding_manager import EmbeddingManager
@@ -15,20 +16,31 @@ async def load_default_models() -> None:
     """Initialize default models if they haven't been loaded."""
     global embedding_manager, spacy_client, classifier
 
+    eco_mode = os.getenv("KARI_ECO_MODE", "false").lower() in {"1", "true", "yes"}
+
     if embedding_manager is None:
         embedding_manager = EmbeddingManager()
-        await embedding_manager.initialize()
-        logger.info("Default embedding model loaded: %s", embedding_manager.model_loaded)
+        if not eco_mode:
+            await embedding_manager.initialize()
+        logger.info(
+            "Default embedding model loaded: %s",
+            embedding_manager.model_loaded,
+        )
 
-    if spacy_client is None:
+    if not eco_mode and spacy_client is None:
         try:
             spacy_client = SpaCyClient()
-            logger.info("SpaCy model loaded: %s", SpaCyClient.DEFAULT_MODEL if hasattr(SpaCyClient, 'DEFAULT_MODEL') else 'default')
+            logger.info(
+                "SpaCy model loaded: %s",
+                SpaCyClient.DEFAULT_MODEL
+                if hasattr(SpaCyClient, "DEFAULT_MODEL")
+                else "default",
+            )
         except Exception as exc:  # pragma: no cover - runtime only
             logger.error("Failed to load spaCy model: %s", exc)
             spacy_client = None
 
-    if classifier is None:
+    if not eco_mode and classifier is None:
         try:
             classifier = BasicClassifier(Path("data/default_classifier"))
             logger.info("Basic classifier ready")

--- a/tests/test_default_models.py
+++ b/tests/test_default_models.py
@@ -1,0 +1,24 @@
+import importlib
+import os
+import pytest
+
+from ai_karen_engine.core import default_models
+
+
+@pytest.mark.asyncio
+async def test_load_default_models_eco_mode(monkeypatch):
+    monkeypatch.setenv("KARI_ECO_MODE", "true")
+    importlib.reload(default_models)
+    await default_models.load_default_models()
+    assert default_models.embedding_manager.model_loaded == "hashlib"
+    assert default_models.spacy_client is None
+    assert default_models.classifier is None
+
+
+@pytest.mark.asyncio
+async def test_load_default_models_normal(monkeypatch):
+    monkeypatch.delenv("KARI_ECO_MODE", raising=False)
+    importlib.reload(default_models)
+    await default_models.load_default_models()
+    assert default_models.embedding_manager is not None
+


### PR DESCRIPTION
## Summary
- add `KARI_ECO_MODE` environment flag
- skip heavy NLP models when eco mode is enabled
- document new variable in README and development guide
- test default model loader with eco mode

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_688291baebf0832494c3b904685ab911