### PR TITLE
Add missing SQL migrations

### DIFF
--- a/data/migrations/postgres/005_create_conversations_table.sql
+++ b/data/migrations/postgres/005_create_conversations_table.sql
@@ -1,0 +1,30 @@
+-- Migration: Create conversations table
+-- Date: 2025-07-24
+-- Creates tenant-specific conversations table
+
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+CREATE TABLE IF NOT EXISTS conversations (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    user_id UUID NOT NULL,
+    title VARCHAR(255),
+    messages JSONB DEFAULT '[]',
+    conversation_metadata JSONB DEFAULT '{}',
+    is_active BOOLEAN DEFAULT TRUE,
+    created_at TIMESTAMP DEFAULT NOW(),
+    updated_at TIMESTAMP DEFAULT NOW(),
+    session_id VARCHAR(255),
+    ui_context JSONB DEFAULT '{}',
+    ai_insights JSONB DEFAULT '{}',
+    user_settings JSONB DEFAULT '{}',
+    summary TEXT,
+    tags TEXT[] DEFAULT '{}',
+    last_ai_response_id VARCHAR(255)
+);
+
+CREATE INDEX IF NOT EXISTS idx_conversation_user ON conversations(user_id);
+CREATE INDEX IF NOT EXISTS idx_conversation_created ON conversations(created_at);
+CREATE INDEX IF NOT EXISTS idx_conversation_active ON conversations(is_active);
+CREATE INDEX IF NOT EXISTS idx_conversation_session ON conversations(session_id);
+CREATE INDEX IF NOT EXISTS idx_conversation_tags ON conversations USING GIN(tags);
+CREATE INDEX IF NOT EXISTS idx_conversation_user_session ON conversations(user_id, session_id);

--- a/data/migrations/postgres/006_create_plugin_executions_table.sql
+++ b/data/migrations/postgres/006_create_plugin_executions_table.sql
@@ -1,0 +1,23 @@
+-- Migration: Create plugin_executions table
+-- Date: 2025-07-24
+-- Stores plugin execution records per tenant
+
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+CREATE TABLE IF NOT EXISTS plugin_executions (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    user_id UUID NOT NULL,
+    plugin_name VARCHAR(255) NOT NULL,
+    execution_data JSONB DEFAULT '{}',
+    result JSONB,
+    status VARCHAR(50) DEFAULT 'pending',
+    error_message TEXT,
+    execution_time_ms INTEGER,
+    created_at TIMESTAMP DEFAULT NOW(),
+    completed_at TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_plugin_user ON plugin_executions(user_id);
+CREATE INDEX IF NOT EXISTS idx_plugin_name ON plugin_executions(plugin_name);
+CREATE INDEX IF NOT EXISTS idx_plugin_status ON plugin_executions(status);
+CREATE INDEX IF NOT EXISTS idx_plugin_created ON plugin_executions(created_at);

--- a/data/migrations/postgres/007_create_audit_logs_table.sql
+++ b/data/migrations/postgres/007_create_audit_logs_table.sql
@@ -1,0 +1,24 @@
+-- Migration: Create audit_logs table
+-- Date: 2025-07-24
+-- Stores audit logging information per tenant
+
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+CREATE TABLE IF NOT EXISTS audit_logs (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    user_id UUID,
+    action VARCHAR(255) NOT NULL,
+    resource_type VARCHAR(100),
+    resource_id VARCHAR(255),
+    details JSONB DEFAULT '{}',
+    ip_address VARCHAR(45),
+    user_agent TEXT,
+    correlation_id VARCHAR(255),
+    created_at TIMESTAMP DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_audit_user ON audit_logs(user_id);
+CREATE INDEX IF NOT EXISTS idx_audit_action ON audit_logs(action);
+CREATE INDEX IF NOT EXISTS idx_audit_resource ON audit_logs(resource_type, resource_id);
+CREATE INDEX IF NOT EXISTS idx_audit_created ON audit_logs(created_at);
+CREATE INDEX IF NOT EXISTS idx_audit_correlation ON audit_logs(correlation_id);

--- a/docker/database/migrations/postgres/005_create_conversations_table.sql
+++ b/docker/database/migrations/postgres/005_create_conversations_table.sql
@@ -1,0 +1,30 @@
+-- Migration: Create conversations table
+-- Date: 2025-07-24
+-- Creates tenant-specific conversations table
+
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+CREATE TABLE IF NOT EXISTS conversations (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    user_id UUID NOT NULL,
+    title VARCHAR(255),
+    messages JSONB DEFAULT '[]',
+    conversation_metadata JSONB DEFAULT '{}',
+    is_active BOOLEAN DEFAULT TRUE,
+    created_at TIMESTAMP DEFAULT NOW(),
+    updated_at TIMESTAMP DEFAULT NOW(),
+    session_id VARCHAR(255),
+    ui_context JSONB DEFAULT '{}',
+    ai_insights JSONB DEFAULT '{}',
+    user_settings JSONB DEFAULT '{}',
+    summary TEXT,
+    tags TEXT[] DEFAULT '{}',
+    last_ai_response_id VARCHAR(255)
+);
+
+CREATE INDEX IF NOT EXISTS idx_conversation_user ON conversations(user_id);
+CREATE INDEX IF NOT EXISTS idx_conversation_created ON conversations(created_at);
+CREATE INDEX IF NOT EXISTS idx_conversation_active ON conversations(is_active);
+CREATE INDEX IF NOT EXISTS idx_conversation_session ON conversations(session_id);
+CREATE INDEX IF NOT EXISTS idx_conversation_tags ON conversations USING GIN(tags);
+CREATE INDEX IF NOT EXISTS idx_conversation_user_session ON conversations(user_id, session_id);

--- a/docker/database/migrations/postgres/006_create_plugin_executions_table.sql
+++ b/docker/database/migrations/postgres/006_create_plugin_executions_table.sql
@@ -1,0 +1,23 @@
+-- Migration: Create plugin_executions table
+-- Date: 2025-07-24
+-- Stores plugin execution records per tenant
+
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+CREATE TABLE IF NOT EXISTS plugin_executions (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    user_id UUID NOT NULL,
+    plugin_name VARCHAR(255) NOT NULL,
+    execution_data JSONB DEFAULT '{}',
+    result JSONB,
+    status VARCHAR(50) DEFAULT 'pending',
+    error_message TEXT,
+    execution_time_ms INTEGER,
+    created_at TIMESTAMP DEFAULT NOW(),
+    completed_at TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_plugin_user ON plugin_executions(user_id);
+CREATE INDEX IF NOT EXISTS idx_plugin_name ON plugin_executions(plugin_name);
+CREATE INDEX IF NOT EXISTS idx_plugin_status ON plugin_executions(status);
+CREATE INDEX IF NOT EXISTS idx_plugin_created ON plugin_executions(created_at);

--- a/docker/database/migrations/postgres/007_create_audit_logs_table.sql
+++ b/docker/database/migrations/postgres/007_create_audit_logs_table.sql
@@ -1,0 +1,24 @@
+-- Migration: Create audit_logs table
+-- Date: 2025-07-24
+-- Stores audit logging information per tenant
+
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+CREATE TABLE IF NOT EXISTS audit_logs (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    user_id UUID,
+    action VARCHAR(255) NOT NULL,
+    resource_type VARCHAR(100),
+    resource_id VARCHAR(255),
+    details JSONB DEFAULT '{}',
+    ip_address VARCHAR(45),
+    user_agent TEXT,
+    correlation_id VARCHAR(255),
+    created_at TIMESTAMP DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_audit_user ON audit_logs(user_id);
+CREATE INDEX IF NOT EXISTS idx_audit_action ON audit_logs(action);
+CREATE INDEX IF NOT EXISTS idx_audit_resource ON audit_logs(resource_type, resource_id);
+CREATE INDEX IF NOT EXISTS idx_audit_created ON audit_logs(created_at);
+CREATE INDEX IF NOT EXISTS idx_audit_correlation ON audit_logs(correlation_id);


### PR DESCRIPTION
## Summary
- add `conversations` table migrations
- add `plugin_executions` table migrations
- add `audit_logs` table migrations

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6882b4799640832487f390e2b11643f7