### PR TITLE
Integrate LLM router and fix pydantic import

### DIFF
--- a/src/ai_karen_engine/services/tool_service.py
+++ b/src/ai_karen_engine/services/tool_service.py
@@ -18,7 +18,6 @@ import uuid
 import inspect
 
 from pydantic import BaseModel, Field, validator, create_model
-from pydantic.fields import FieldInfo
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- add LLM router and utils in AI orchestrator
- route conversation processing through the LLM
- fall back to previous rules if LLM call fails
- drop unused `FieldInfo` import from tool service

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68837830fd5c83249edc3806c831f663