### PR TITLE
Update web_ui production port

### DIFF
--- a/ui_launchers/web_ui/README.md
+++ b/ui_launchers/web_ui/README.md
@@ -301,6 +301,7 @@ npm run dev
 npm run build
 npm start
 ```
+- Runs on port 3000
 - Optimized bundle with tree shaking
 - Static generation where possible
 - Compressed assets

--- a/ui_launchers/web_ui/package.json
+++ b/ui_launchers/web_ui/package.json
@@ -7,7 +7,7 @@
     "genkit:dev": "genkit start -- tsx src/ai/dev.ts",
     "genkit:watch": "genkit start -- tsx --watch src/ai/dev.ts",
     "build": "next build",
-    "start": "next start",
+    "start": "next start -p 3000",
     "lint": "next lint",
     "typecheck": "tsc --noEmit"
   },


### PR DESCRIPTION
## Summary
- set the production `next start` port to 3000
- document the production port in the Web UI README

## Testing
- `pytest -k web_ui -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6883a5695cf88324a2e9081c2bdff209