### PR TITLE
Update chat summary text for production

### DIFF
--- a/ui_launchers/web_ui/src/components/chat/ChatInterface.tsx
+++ b/ui_launchers/web_ui/src/components/chat/ChatInterface.tsx
@@ -199,7 +199,7 @@ export default function ChatInterface() {
         if (parsedSettings.notifications.enabled && parsedSettings.notifications.alertOnSummaryReady) {
           toast({
             title: "Conversation Summary Ready!",
-            description: "A summary of your recent conversation has been generated. (Logged to server console for now).",
+            description: "A summary of your recent conversation has been generated.",
             duration: 7000,
           });
         }

--- a/ui_launchers/web_ui/src/components/settings/NotificationSettings.tsx
+++ b/ui_launchers/web_ui/src/components/settings/NotificationSettings.tsx
@@ -204,7 +204,7 @@ export default function NotificationSettings() {
                 </Label>
                 </div>
                 <p className="text-xs text-muted-foreground pl-7">
-                  Notify when a conversation summary is generated. (Summary logged to server console for now).
+                  Notify when a conversation summary is generated.
                 </p>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- clean up summary notification text in ChatInterface
- remove temporary note in NotificationSettings

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6883a5695cf88324a2e9081c2bdff209