### PR TITLE
Align credential defaults

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,10 @@
-POSTGRES_DB=postgres
-POSTGRES_USER=postgres
-POSTGRES_PASSWORD=postgres
+POSTGRES_DB=ai_karen
+POSTGRES_USER=karen_user
+POSTGRES_PASSWORD=karen_secure_pass_change_me
 POSTGRES_HOST=postgres
 POSTGRES_PORT=5432
 
-ELASTIC_HOST=elasticsearch
-ELASTIC_PORT=9200
-ELASTIC_INDEX=kari_memory
+ELASTICSEARCH_HOST=elasticsearch
+ELASTICSEARCH_PORT=9200
+ELASTICSEARCH_USER=elastic
+ELASTICSEARCH_PASSWORD=elastic_secure_pass_change_me

--- a/README.md
+++ b/README.md
@@ -195,10 +195,10 @@ pip install -r requirements.txt
 pre-commit install
 
 # Set environment variables
-export POSTGRES_USER=postgres
-export POSTGRES_PASSWORD=postgres
-export POSTGRES_DB=postgres
-export POSTGRES_HOST=localhost
+export POSTGRES_USER=karen_user
+export POSTGRES_PASSWORD=karen_secure_pass_change_me
+export POSTGRES_DB=ai_karen
+export POSTGRES_HOST=postgres  # use 'postgres' when running via Docker
 export POSTGRES_PORT=5432
 export REDIS_URL=redis://localhost:6379/0
 export ELASTICSEARCH_URL=http://localhost:9200
@@ -289,10 +289,10 @@ helm install ai-karen ./charts/kari/ \
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `POSTGRES_USER` | PostgreSQL user | `postgres` |
-| `POSTGRES_PASSWORD` | PostgreSQL password | `postgres` |
-| `POSTGRES_DB` | PostgreSQL database | `postgres` |
-| `POSTGRES_HOST` | PostgreSQL host | `localhost` |
+| `POSTGRES_USER` | PostgreSQL user | `karen_user` |
+| `POSTGRES_PASSWORD` | PostgreSQL password | `karen_secure_pass_change_me` |
+| `POSTGRES_DB` | PostgreSQL database | `ai_karen` |
+| `POSTGRES_HOST` | PostgreSQL host | `postgres` |
 | `POSTGRES_PORT` | PostgreSQL port | `5432` |
 | `REDIS_URL` | Redis connection string | `redis://localhost:6379/0` |
 | `ELASTICSEARCH_URL` | Elasticsearch URL | `http://localhost:9200` |

--- a/docker/database/.env
+++ b/docker/database/.env
@@ -7,7 +7,7 @@
 POSTGRES_DB=ai_karen
 POSTGRES_USER=karen_user
 POSTGRES_PASSWORD=karen_secure_pass_change_me
-POSTGRES_HOST=localhost
+POSTGRES_HOST=postgres
 POSTGRES_PORT=5432
 
 # =============================================================================
@@ -33,7 +33,7 @@ MILVUS_MEMORY_LIMIT=2g
 # =============================================================================
 REDIS_HOST=localhost
 REDIS_PORT=6379
-REDIS_PASSWORD=redis_secure_pass
+REDIS_PASSWORD=redis_secure_pass_change_me
 REDIS_MEMORY_LIMIT=512m
 
 # =============================================================================

--- a/docker/database/README.md
+++ b/docker/database/README.md
@@ -164,15 +164,15 @@ The `.env` file controls all aspects of the database stack configuration:
 # PostgreSQL
 POSTGRES_DB=ai_karen
 POSTGRES_USER=karen_user
-POSTGRES_PASSWORD=secure_password_here
+POSTGRES_PASSWORD=karen_secure_pass_change_me
 POSTGRES_MAX_CONNECTIONS=200
 
 # Redis
-REDIS_PASSWORD=redis_secure_password
+REDIS_PASSWORD=redis_secure_pass_change_me
 REDIS_MEMORY_LIMIT=2g
 
 # Elasticsearch
-ELASTICSEARCH_PASSWORD=elastic_secure_password
+ELASTICSEARCH_PASSWORD=elastic_secure_pass_change_me
 ELASTICSEARCH_HEAP_SIZE=2g
 
 # Milvus & MinIO

--- a/docker/database/docker-compose.yml
+++ b/docker/database/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     environment:
       POSTGRES_DB: ${POSTGRES_DB:-ai_karen}
       POSTGRES_USER: ${POSTGRES_USER:-karen_user}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-karen_secure_pass}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-karen_secure_pass_change_me}
     ports:
       - "${POSTGRES_PORT:-5432}:5432"
     volumes:
@@ -112,7 +112,7 @@ services:
   redis:
     image: redis:7-alpine
     container_name: ai-karen-redis
-    command: redis-server --requirepass ${REDIS_PASSWORD:-redis_secure_pass} --maxmemory ${REDIS_MEMORY_LIMIT:-512m} --maxmemory-policy allkeys-lru
+    command: redis-server --requirepass ${REDIS_PASSWORD:-redis_secure_pass_change_me} --maxmemory ${REDIS_MEMORY_LIMIT:-512m} --maxmemory-policy allkeys-lru
     ports:
       - "${REDIS_PORT:-6379}:6379"
     volumes:
@@ -157,7 +157,7 @@ services:
       - MILVUS_PORT=19530
       - REDIS_HOST=redis
       - REDIS_PORT=6379
-      - REDIS_PASSWORD=${REDIS_PASSWORD:-redis_secure_pass}
+      - REDIS_PASSWORD=${REDIS_PASSWORD:-redis_secure_pass_change_me}
       - DUCKDB_PATH=/data/duckdb/kari_duckdb.db
     depends_on:
       postgres:


### PR DESCRIPTION
## Summary
- update `.env.example` to use karen credentials
- sync docker database `.env` and `docker-compose.yml`
- clarify dev environment variables in README
- align credential examples in database README

## Testing
- `pre-commit` *(fails: command not found)*
- `pytest -k "nothing"` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*


------
https://chatgpt.com/codex/tasks/task_e_6883c7d1b4e4832484117f04b4d8e34f