### PR TITLE
Fix LLM intent routing and registry import

### DIFF
--- a/src/ai_karen_engine/integrations/llm_registry.py
+++ b/src/ai_karen_engine/integrations/llm_registry.py
@@ -4,21 +4,16 @@ LLM Provider Registry
 Manages registration, discovery, and health monitoring of LLM providers.
 """
 
-import logging
 import json
+import logging
 import time
+from dataclasses import asdict, dataclass
 from pathlib import Path
-from typing import Dict, List, Any, Optional, Type
-from dataclasses import dataclass, asdict
+from typing import Any, Dict, List, Optional, Type
 
 from .llm_utils import LLMProviderBase
-from .providers import (
-    OllamaProvider,
-    OpenAIProvider, 
-    GeminiProvider,
-    DeepseekProvider,
-    HuggingFaceProvider
-)
+from .providers import (DeepseekProvider, GeminiProvider, HuggingFaceProvider,
+                        OllamaProvider, OpenAIProvider)
 
 logger = logging.getLogger("kari.llm_registry")
 
@@ -26,6 +21,7 @@ logger = logging.getLogger("kari.llm_registry")
 @dataclass
 class ProviderRegistration:
     """Provider registration information."""
+
     name: str
     provider_class: str
     description: str
@@ -40,24 +36,24 @@ class ProviderRegistration:
 
 class LLMRegistry:
     """Registry for managing LLM providers."""
-    
+
     def __init__(self, registry_path: Optional[Path] = None):
         """
         Initialize LLM registry.
-        
+
         Args:
             registry_path: Path to registry JSON file (defaults to models/llm_registry.json)
         """
         self.registry_path = registry_path or Path("models/llm_registry.json")
         self._providers: Dict[str, LLMProviderBase] = {}
         self._registrations: Dict[str, ProviderRegistration] = {}
-        
+
         # Register built-in providers
         self._register_builtin_providers()
-        
+
         # Load existing registry
         self._load_registry()
-    
+
     def _register_builtin_providers(self):
         """Register all built-in LLM providers."""
         builtin_providers = [
@@ -68,16 +64,16 @@ class LLMRegistry:
                 "supports_streaming": True,
                 "supports_embeddings": True,
                 "requires_api_key": False,
-                "default_model": "llama3.2:latest"
+                "default_model": "llama3.2:latest",
             },
             {
                 "name": "openai",
-                "provider_class": "OpenAIProvider", 
+                "provider_class": "OpenAIProvider",
                 "description": "OpenAI GPT models via API",
                 "supports_streaming": True,
                 "supports_embeddings": True,
                 "requires_api_key": True,
-                "default_model": "gpt-3.5-turbo"
+                "default_model": "gpt-3.5-turbo",
             },
             {
                 "name": "gemini",
@@ -86,7 +82,7 @@ class LLMRegistry:
                 "supports_streaming": True,
                 "supports_embeddings": True,
                 "requires_api_key": True,
-                "default_model": "gemini-1.5-flash"
+                "default_model": "gemini-1.5-flash",
             },
             {
                 "name": "deepseek",
@@ -95,7 +91,7 @@ class LLMRegistry:
                 "supports_streaming": True,
                 "supports_embeddings": False,
                 "requires_api_key": True,
-                "default_model": "deepseek-chat"
+                "default_model": "deepseek-chat",
             },
             {
                 "name": "huggingface",
@@ -104,21 +100,21 @@ class LLMRegistry:
                 "supports_streaming": False,
                 "supports_embeddings": True,
                 "requires_api_key": True,
-                "default_model": "microsoft/DialoGPT-large"
-            }
+                "default_model": "microsoft/DialoGPT-large",
+            },
         ]
-        
+
         for provider_info in builtin_providers:
             registration = ProviderRegistration(**provider_info)
             self._registrations[provider_info["name"]] = registration
-    
+
     def _load_registry(self):
         """Load registry from JSON file."""
         if self.registry_path.exists():
             try:
-                with open(self.registry_path, 'r') as f:
+                with open(self.registry_path, "r") as f:
                     data = json.load(f)
-                
+
                 # Load custom registrations (if any)
                 for item in data:
                     if isinstance(item, dict) and "name" in item:
@@ -127,45 +123,51 @@ class LLMRegistry:
                         if name in self._registrations:
                             # Update existing registration with saved data
                             registration = self._registrations[name]
-                            registration.health_status = item.get("health_status", "unknown")
-                            registration.last_health_check = item.get("last_health_check")
+                            registration.health_status = item.get(
+                                "health_status", "unknown"
+                            )
+                            registration.last_health_check = item.get(
+                                "last_health_check"
+                            )
                             registration.error_message = item.get("error_message")
                         else:
                             # Create new registration from saved data
                             self._registrations[name] = ProviderRegistration(**item)
-                            
+
                 logger.info(f"Loaded registry from {self.registry_path}")
-                
+
             except Exception as ex:
-                logger.warning(f"Could not load registry from {self.registry_path}: {ex}")
-    
+                logger.warning(
+                    f"Could not load registry from {self.registry_path}: {ex}"
+                )
+
     def _save_registry(self):
         """Save registry to JSON file."""
         try:
             # Ensure directory exists
             self.registry_path.parent.mkdir(parents=True, exist_ok=True)
-            
+
             # Convert registrations to list of dicts
             data = [asdict(reg) for reg in self._registrations.values()]
-            
-            with open(self.registry_path, 'w') as f:
+
+            with open(self.registry_path, "w") as f:
                 json.dump(data, f, indent=2)
-                
+
             logger.debug(f"Saved registry to {self.registry_path}")
-            
+
         except Exception as ex:
             logger.error(f"Could not save registry to {self.registry_path}: {ex}")
-    
+
     def register_provider(
         self,
         name: str,
         provider_class: Type[LLMProviderBase],
         description: str = "",
-        **kwargs
+        **kwargs,
     ):
         """
         Register a custom LLM provider.
-        
+
         Args:
             name: Provider name
             provider_class: Provider class
@@ -176,55 +178,55 @@ class LLMRegistry:
             name=name,
             provider_class=provider_class.__name__,
             description=description,
-            **kwargs
+            **kwargs,
         )
-        
+
         self._registrations[name] = registration
         logger.info(f"Registered provider: {name}")
-        
+
         # Save updated registry
         self._save_registry()
-    
+
     def get_provider(self, name: str, **init_kwargs) -> Optional[LLMProviderBase]:
         """
         Get provider instance by name.
-        
+
         Args:
             name: Provider name
             **init_kwargs: Provider initialization arguments
-            
+
         Returns:
             Provider instance or None if not found
         """
         if name not in self._registrations:
             logger.error(f"Provider '{name}' not registered")
             return None
-        
+
         # Return cached instance if available
         if name in self._providers:
             return self._providers[name]
-        
+
         # Create new instance
         try:
             registration = self._registrations[name]
             provider_class = self._get_provider_class(registration.provider_class)
-            
+
             if provider_class:
                 # Use default model if not specified
                 if "model" not in init_kwargs and registration.default_model:
                     init_kwargs["model"] = registration.default_model
-                
+
                 provider = provider_class(**init_kwargs)
                 self._providers[name] = provider
-                
+
                 logger.info(f"Created provider instance: {name}")
                 return provider
-            
+
         except Exception as ex:
             logger.error(f"Failed to create provider '{name}': {ex}")
-            
+
         return None
-    
+
     def _get_provider_class(self, class_name: str) -> Optional[Type[LLMProviderBase]]:
         """Get provider class by name."""
         class_map = {
@@ -232,23 +234,23 @@ class LLMRegistry:
             "OpenAIProvider": OpenAIProvider,
             "GeminiProvider": GeminiProvider,
             "DeepseekProvider": DeepseekProvider,
-            "HuggingFaceProvider": HuggingFaceProvider
+            "HuggingFaceProvider": HuggingFaceProvider,
         }
-        
+
         return class_map.get(class_name)
-    
+
     def list_providers(self) -> List[str]:
         """Get list of registered provider names."""
         return list(self._registrations.keys())
-    
+
     def get_provider_info(self, name: str) -> Optional[Dict[str, Any]]:
         """Get provider registration information."""
         if name not in self._registrations:
             return None
-        
+
         registration = self._registrations[name]
         info = asdict(registration)
-        
+
         # Add runtime info if provider is instantiated
         if name in self._providers:
             try:
@@ -256,103 +258,113 @@ class LLMRegistry:
                 info.update(provider_info)
             except Exception as ex:
                 logger.warning(f"Could not get provider info for {name}: {ex}")
-        
+
         return info
-    
+
     def health_check(self, name: str) -> Dict[str, Any]:
         """Perform health check on a provider."""
         if name not in self._registrations:
-            return {"status": "not_registered", "error": f"Provider '{name}' not registered"}
-        
+            return {
+                "status": "not_registered",
+                "error": f"Provider '{name}' not registered",
+            }
+
         try:
             provider = self.get_provider(name)
             if not provider:
-                return {"status": "failed_to_create", "error": "Could not create provider instance"}
-            
+                return {
+                    "status": "failed_to_create",
+                    "error": "Could not create provider instance",
+                }
+
             # Perform health check if provider supports it
-            if hasattr(provider, 'health_check'):
+            if hasattr(provider, "health_check"):
                 result = provider.health_check()
             else:
                 # Basic health check - try to get provider info
                 provider.get_provider_info()
                 result = {"status": "healthy", "message": "Basic health check passed"}
-            
+
             # Update registration
             registration = self._registrations[name]
             registration.health_status = result.get("status", "unknown")
             registration.last_health_check = time.time()
             registration.error_message = result.get("error")
-            
+
             # Save updated registry
             self._save_registry()
-            
+
             return result
-            
+
         except Exception as ex:
             # Update registration with error
             registration = self._registrations[name]
             registration.health_status = "unhealthy"
             registration.last_health_check = time.time()
             registration.error_message = str(ex)
-            
+
             # Save updated registry
             self._save_registry()
-            
+
             return {"status": "unhealthy", "error": str(ex)}
-    
+
     def health_check_all(self) -> Dict[str, Dict[str, Any]]:
         """Perform health check on all registered providers."""
         results = {}
-        
+
         for name in self._registrations.keys():
             results[name] = self.health_check(name)
-        
+
         return results
-    
+
     def get_available_providers(self) -> List[str]:
         """Get list of providers that are currently healthy or unknown status."""
         available = []
-        
+
         for name, registration in self._registrations.items():
             if registration.health_status in ["healthy", "unknown"]:
                 available.append(name)
-        
+
         return available
-    
-    def auto_select_provider(self, requirements: Optional[Dict[str, Any]] = None) -> Optional[str]:
+
+    def auto_select_provider(
+        self, requirements: Optional[Dict[str, Any]] = None
+    ) -> Optional[str]:
         """
         Automatically select the best available provider based on requirements.
-        
+
         Args:
             requirements: Dict with keys like 'streaming', 'embeddings', 'api_key_available'
-            
+
         Returns:
             Provider name or None if no suitable provider found
         """
         requirements = requirements or {}
-        
+
         # Get available providers
         available = self.get_available_providers()
-        
+
         # Filter by requirements
         suitable = []
         for name in available:
             registration = self._registrations[name]
-            
+
             # Check streaming requirement
             if requirements.get("streaming") and not registration.supports_streaming:
                 continue
-            
+
             # Check embeddings requirement
             if requirements.get("embeddings") and not registration.supports_embeddings:
                 continue
-            
+
             # Check API key requirement
-            if registration.requires_api_key and not requirements.get("api_key_available", True):
+            if registration.requires_api_key and not requirements.get(
+                "api_key_available", True
+            ):
                 continue
-            
+
             suitable.append(name)
-        
+
         # Return first suitable provider (could be enhanced with priority logic)
         return suitable[0] if suitable else None
 
@@ -391,3 +403,17 @@ def health_check_all() -> Dict[str, Dict[str, Any]]:
     """Health check all providers."""
     registry = get_registry()
     return registry.health_check_all()
+
+
+# Expose a module-level registry instance for plugin consumers
+registry = get_registry()
+
+__all__ = [
+    "LLMRegistry",
+    "get_registry",
+    "register_provider",
+    "get_provider",
+    "list_providers",
+    "health_check_all",
+    "registry",
+]

--- a/src/ai_karen_engine/services/ai_orchestrator/ai_orchestrator.py
+++ b/src/ai_karen_engine/services/ai_orchestrator/ai_orchestrator.py
@@ -5,33 +5,18 @@ It converts TypeScript AI flows to Python services while maintaining compatibili
 with the existing AI Karen architecture.
 """
 
-import asyncio
-import logging
-from typing import Dict, List, Optional, Any, Callable
-from datetime import datetime
+from typing import Any, Dict, List, Optional
 
 from ai_karen_engine.core.services.base import BaseService, ServiceConfig
-from ai_karen_engine.models.shared_types import (
-    FlowType,               # ← ensure FlowType is imported
-    FlowInput,
-    FlowOutput,
-    DecideActionInput,
-    DecideActionOutput,
-    ToolType,
-    ToolInput,
-    MemoryDepth,
-    PersonalityTone,
-    PersonalityVerbosity,
-    AiData,
-    MemoryContext,
-    PluginInfo
-)
 from ai_karen_engine.integrations.llm_router import LLMProfileRouter
 from ai_karen_engine.integrations.llm_utils import LLMUtils
+from ai_karen_engine.models.shared_types import (  # ← ensure FlowType is imported
+    AiData, DecideActionInput, FlowInput, FlowOutput, FlowType, PluginInfo,
+    ToolType)
 
-from .flow_manager import FlowManager
-from .decision_engine import DecisionEngine
 from .context_manager import ContextManager
+from .decision_engine import DecisionEngine
+from .flow_manager import FlowManager
 from .prompt_manager import PromptManager
 
 
@@ -39,7 +24,7 @@ class AIOrchestrator(BaseService):
     """
     Central AI Orchestrator Service that coordinates AI processing and workflows.
     """
-    
+
     def __init__(self, config: ServiceConfig):
         super().__init__(config)
         self.flow_manager = FlowManager()
@@ -49,7 +34,7 @@ class AIOrchestrator(BaseService):
         self.llm_utils = LLMUtils()
         self.llm_router = LLMProfileRouter()
         self._initialized = False
-    
+
     async def initialize(self) -> None:
         """Initialize the AI Orchestrator service."""
         try:
@@ -60,17 +45,17 @@ class AIOrchestrator(BaseService):
         except Exception as e:
             self.logger.error(f"Failed to initialize AI Orchestrator: {e}")
             raise
-    
+
     async def start(self) -> None:
         if not self._initialized:
             raise RuntimeError("Service not initialized")
         self.logger.info("AI Orchestrator Service started")
-    
+
     async def stop(self) -> None:
         self.logger.info("Stopping AI Orchestrator Service")
         self.context_manager.clear_context_cache()
         self.logger.info("AI Orchestrator Service stopped")
-    
+
     async def health_check(self) -> bool:
         return self._initialized and len(self.flow_manager.get_available_flows()) > 0
 
@@ -79,22 +64,24 @@ class AIOrchestrator(BaseService):
         self.flow_manager.register_flow(
             FlowType.DECIDE_ACTION,
             self._handle_decide_action_flow,
-            {"description": "Decision-making flow for determining next actions"}
+            {"description": "Decision-making flow for determining next actions"},
         )
         self.flow_manager.register_flow(
             FlowType.CONVERSATION_PROCESSING,
             self._handle_conversation_processing_flow,
-            {"description": "Comprehensive conversation processing with memory integration"}
+            {
+                "description": "Comprehensive conversation processing with memory integration"
+            },
         )
         self.logger.info("Default flows registered")
-    
+
     async def _handle_decide_action_flow(self, input_data: FlowInput) -> FlowOutput:
         """Handle decide action flow processing."""
         decide_input = DecideActionInput(
             prompt=input_data.prompt,
             short_term_memory=input_data.short_term_memory,
             long_term_memory=input_data.long_term_memory,
-            personal_facts=input_data.personal_facts
+            personal_facts=input_data.personal_facts,
         )
         result = await self.decision_engine.decide_action(decide_input)
         return FlowOutput(
@@ -103,10 +90,12 @@ class AIOrchestrator(BaseService):
             tool_to_call=result.tool_to_call,
             tool_input=result.tool_input,
             suggested_new_facts=result.suggested_new_facts,
-            proactive_suggestion=result.proactive_suggestion
+            proactive_suggestion=result.proactive_suggestion,
         )
-    
-    async def _handle_conversation_processing_flow(self, input_data: FlowInput) -> FlowOutput:
+
+    async def _handle_conversation_processing_flow(
+        self, input_data: FlowInput
+    ) -> FlowOutput:
         """Handle conversation processing flow with memory, plugins, and proactive suggestions."""
         try:
             context = await self.context_manager.build_context(
@@ -115,21 +104,27 @@ class AIOrchestrator(BaseService):
                 prompt=input_data.prompt,
                 conversation_history=input_data.conversation_history,
                 user_settings=input_data.user_settings,
-                memories=input_data.context_from_memory
+                memories=input_data.context_from_memory,
             )
-            
+
             response = await self._process_conversation_with_memory(input_data, context)
-            
-            requires_plugin, plugin_to_execute, plugin_parameters = await self._assess_plugin_needs(
-                input_data.prompt, context, input_data.available_plugins or []
+
+            requires_plugin, plugin_to_execute, plugin_parameters = (
+                await self._assess_plugin_needs(
+                    input_data.prompt, context, input_data.available_plugins or []
+                )
             )
-            
+
             memory_to_store = await self._identify_memory_to_store(input_data, context)
-            
-            proactive_suggestion = await self._generate_conversation_proactive_suggestion(input_data, context)
-            
+
+            proactive_suggestion = (
+                await self._generate_conversation_proactive_suggestion(
+                    input_data, context
+                )
+            )
+
             ai_data = await self._generate_conversation_ai_data(input_data, context)
-            
+
             return FlowOutput(
                 response=response,
                 requires_plugin=requires_plugin,
@@ -137,17 +132,21 @@ class AIOrchestrator(BaseService):
                 plugin_parameters=plugin_parameters,
                 memory_to_store=memory_to_store,
                 proactive_suggestion=proactive_suggestion,
-                ai_data=ai_data
+                ai_data=ai_data,
             )
         except Exception as e:
             self.logger.error(f"Conversation processing flow failed: {e}")
             return FlowOutput(
                 response="I'm experiencing some technical difficulties. Let me try a simpler response.",
                 requires_plugin=False,
-                ai_data=AiData(confidence=0.3, reasoning="Fallback due to processing error")
+                ai_data=AiData(
+                    confidence=0.3, reasoning="Fallback due to processing error"
+                ),
             )
 
-    async def _process_conversation_with_memory(self, input_data: FlowInput, context: Dict[str, Any]) -> str:
+    async def _process_conversation_with_memory(
+        self, input_data: FlowInput, context: Dict[str, Any]
+    ) -> str:
         """Process conversation using LLM with memory/context awareness."""
         try:
             template = self.prompt_manager.get_template("conversation_processing")
@@ -157,25 +156,37 @@ class AIOrchestrator(BaseService):
             user_prompt = template["user_template"].format(
                 prompt=input_data.prompt,
                 context_info=context.get("context_summary", ""),
-                plugin_info=", ".join(p.name for p in input_data.available_plugins or []),
-                memory_info="; ".join(mem.get("content", "") for mem in context.get("memories", [])[:3]),
-                user_preferences=", ".join(f"{k}={v}" for k, v in input_data.user_settings.items()),
+                plugin_info=", ".join(
+                    p.name for p in input_data.available_plugins or []
+                ),
+                memory_info="; ".join(
+                    mem.get("content", "") for mem in context.get("memories", [])[:3]
+                ),
+                user_preferences=", ".join(
+                    f"{k}={v}" for k, v in input_data.user_settings.items()
+                ),
             )
             full_prompt = f"{template['system_prompt']}\n\n{user_prompt}"
 
-            raw = self.llm_router.invoke(self.llm_utils, full_prompt, task_intent="chat")
+            raw = self.llm_router.invoke(
+                self.llm_utils,
+                full_prompt,
+                task_intent=FlowType.CONVERSATION_PROCESSING.value,
+            )
             if not isinstance(raw, str):
                 raise TypeError("LLM response must be text")
             response = raw.strip()
             if not response:
                 return await self._fallback_conversation_response(input_data, context)
-            
+
             return response[:4000] if len(response) > 4000 else response
         except Exception as ex:
             self.logger.error(f"LLM processing failed: {ex}")
             return await self._fallback_conversation_response(input_data, context)
 
-    async def _fallback_conversation_response(self, input_data: FlowInput, context: Dict[str, Any]) -> str:
+    async def _fallback_conversation_response(
+        self, input_data: FlowInput, context: Dict[str, Any]
+    ) -> str:
         """Fallback rule-based conversation processing used if LLM fails."""
         prompt_lower = input_data.prompt.lower()
         if "help" in prompt_lower:
@@ -191,40 +202,51 @@ class AIOrchestrator(BaseService):
         """Assess if the user's request requires plugin execution."""
         # Placeholder for more sophisticated plugin routing logic
         return False, None, None
-    
-    async def _identify_memory_to_store(self, input_data: FlowInput, context: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+
+    async def _identify_memory_to_store(
+        self, input_data: FlowInput, context: Dict[str, Any]
+    ) -> Optional[Dict[str, Any]]:
         """Identify important information to store in memory."""
         prompt_lower = input_data.prompt.lower()
-        if any(keyword in prompt_lower for keyword in ["remember", "my name is", "i like"]):
+        if any(
+            keyword in prompt_lower for keyword in ["remember", "my name is", "i like"]
+        ):
             return {
                 "content": input_data.prompt,
                 "tags": ["personal_info", "explicit_request"],
-                "metadata": {"importance": "high"}
+                "metadata": {"importance": "high"},
             }
         return None
-    
-    async def _generate_conversation_proactive_suggestion(self, input_data: FlowInput, context: Dict[str, Any]) -> Optional[str]:
+
+    async def _generate_conversation_proactive_suggestion(
+        self, input_data: FlowInput, context: Dict[str, Any]
+    ) -> Optional[str]:
         """Generate proactive suggestions based on the conversation."""
         if len(input_data.conversation_history) > 4:
             return "We've been chatting for a bit. Is there a specific task I can help you with?"
         return None
-    
-    async def _generate_conversation_ai_data(self, input_data: FlowInput, context: Dict[str, Any]) -> AiData:
+
+    async def _generate_conversation_ai_data(
+        self, input_data: FlowInput, context: Dict[str, Any]
+    ) -> AiData:
         """Generate AI metadata for the conversation processing."""
         return AiData(
             confidence=0.85,
             reasoning="Response generated by primary LLM with context.",
-            knowledge_graph_insights=context.get("context_summary")
+            knowledge_graph_insights=context.get("context_summary"),
         )
 
     # ─────────────────────────────────────────────────────────────────────────────
     # Public API methods exposed to the rest of the system:
-    async def process_flow(self, flow_type: FlowType, input_data: FlowInput) -> FlowOutput:
+    async def process_flow(
+        self, flow_type: FlowType, input_data: FlowInput
+    ) -> FlowOutput:
         return await self.flow_manager.execute_flow(flow_type, input_data)
 
     async def conversation_processing_flow(self, input_data: FlowInput) -> FlowOutput:
         """Execute the conversation processing flow."""
         return await self.process_flow(FlowType.CONVERSATION_PROCESSING, input_data)
+
     # ─────────────────────────────────────────────────────────────────────────────
 
     def get_metrics(self) -> Dict[str, Any]:


### PR DESCRIPTION
## Summary
- load `.envK` automatically and map POSTGRES_URL to DATABASE_URL
- expose a module-level `registry` in `llm_registry`
- use correct FlowType intent when invoking the LLM router

## Testing
- `black src/ai_karen_engine/services/ai_orchestrator/ai_orchestrator.py src/ai_karen_engine/integrations/llm_registry.py main.py`
- `isort src/ai_karen_engine/services/ai_orchestrator/ai_orchestrator.py src/ai_karen_engine/integrations/llm_registry.py main.py`
- `ruff check --fix src/ai_karen_engine/services/ai_orchestrator/ai_orchestrator.py`
- `ruff check --fix src/ai_karen_engine/integrations/llm_registry.py main.py`
- `mypy --follow-imports=skip --ignore-missing-imports src/ai_karen_engine/services/ai_orchestrator/ai_orchestrator.py src/ai_karen_engine/integrations/llm_registry.py main.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6883ccbb649c8324a88ae55961fcfaf5