### PR TITLE
Fix Next.js config option

### DIFF
--- a/ui_launchers/web_ui/next.config.ts
+++ b/ui_launchers/web_ui/next.config.ts
@@ -79,10 +79,10 @@ const nextConfig: NextConfig = {
   },
 
   // Experimental features
-  experimental: {
-    // Enable if using server components with external APIs
-    serverComponentsExternalPackages: [],
-  },
+  // Next.js 15 moved `experimental.serverComponentsExternalPackages`
+  // to a top-level `serverExternalPackages` option.
+  // Update config accordingly.
+  serverExternalPackages: [],
 
   // Output configuration
   output: process.env.NODE_ENV === 'production' ? 'standalone' : undefined,


### PR DESCRIPTION
## Summary
- update Next.js config to use `serverExternalPackages`

## Testing
- `pytest tests/test_memory_compatibility.py::test_transform_web_ui_memory_query -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6883da87b83083248ef221df607027b1