### PR TITLE
Add persona-aware fallback for missing LLM provider

### DIFF
--- a/src/ai_karen_engine/services/ai_orchestrator/ai_orchestrator.py
+++ b/src/ai_karen_engine/services/ai_orchestrator/ai_orchestrator.py
@@ -182,19 +182,46 @@ class AIOrchestrator(BaseService):
             return response[:4000] if len(response) > 4000 else response
         except Exception as ex:
             self.logger.error(f"LLM processing failed: {ex}")
-            return await self._fallback_conversation_response(input_data, context)
+            provider_missing = isinstance(ex, RuntimeError) and "no provider for intent" in str(ex).lower()
+            return await self._fallback_conversation_response(
+                input_data, context, provider_missing=provider_missing
+            )
 
     async def _fallback_conversation_response(
-        self, input_data: FlowInput, context: Dict[str, Any]
+        self,
+        input_data: FlowInput,
+        context: Dict[str, Any],
+        provider_missing: bool = False,
     ) -> str:
         """Fallback rule-based conversation processing used if LLM fails."""
+        settings = context.get("user_settings", {})
+        tone = settings.get("personality_tone", "friendly")
+        persona = settings.get("custom_persona_instructions", "").strip()
+
+        prefix_parts = []
+        if persona:
+            prefix_parts.append(persona)
+        if tone:
+            prefix_parts.append(f"{tone} tone")
+        prefix = " ".join(prefix_parts)
+        if prefix:
+            prefix += ": "
+
+        base_msg = ""
+        if provider_missing:
+            base_msg = "My language model is unavailable so I'll reply directly. "
+
         prompt_lower = input_data.prompt.lower()
         if "help" in prompt_lower:
-            return "I'm here to assist. I can access plugins and remember our conversations to help you better."
+            reply = (
+                "I'm here to assist. I can access plugins and remember our conversations to help you better."
+            )
         elif "thank" in prompt_lower:
-            return "You're welcome! I'm glad I could help."
+            reply = "You're welcome! I'm glad I could help."
         else:
-            return f"I've registered your message: '{input_data.prompt}'. How can I further assist you?"
+            reply = f"I've registered your message: '{input_data.prompt}'. How can I further assist you?"
+
+        return f"{prefix}{base_msg}{reply}"
 
     async def _assess_plugin_needs(
         self, prompt: str, context: Dict[str, Any], available_plugins: List[PluginInfo]

--- a/tests/test_persona_fallback.py
+++ b/tests/test_persona_fallback.py
@@ -1,0 +1,19 @@
+import pytest
+from unittest.mock import Mock
+from ai_karen_engine.services.ai_orchestrator.ai_orchestrator import AIOrchestrator
+from ai_karen_engine.core.services.base import ServiceConfig
+from ai_karen_engine.models.shared_types import FlowInput
+
+@pytest.mark.asyncio
+async def test_fallback_includes_persona_and_tone_when_provider_missing():
+    orch = AIOrchestrator(ServiceConfig(name="test"))
+    await orch.initialize()
+    orch.llm_router.invoke = Mock(side_effect=RuntimeError("No provider for intent 'conversation_processing' and no fallback"))
+    flow_input = FlowInput(
+        prompt="Hi",
+        conversation_history=[],
+        user_settings={"personality_tone": "formal", "custom_persona_instructions": "Professor Bot"},
+    )
+    out = await orch.conversation_processing_flow(flow_input)
+    assert "Professor Bot" in out.response
+    assert "formal" in out.response


### PR DESCRIPTION
## Summary
- improve error handling in `_process_conversation_with_memory` to detect missing LLM providers
- generate fallback replies using the user's persona instructions and tone
- test fallback behaviour when no LLM provider is available

## Testing
- `pre-commit` *(fails: command not found)*
- `pytest -q tests/test_persona_fallback.py` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6883da87b83083248ef221df607027b1