### PR TITLE
Add persona-aware fallback for missing LLM provider

### DIFF
--- a/tests/test_persona_fallback.py
+++ b/tests/test_persona_fallback.py
@@ -1,0 +1,27 @@
+import pytest
+from unittest.mock import Mock
+from ai_karen_engine.services.ai_orchestrator.ai_orchestrator import AIOrchestrator
+from ai_karen_engine.core.services.base import ServiceConfig
+from ai_karen_engine.models.shared_types import FlowInput
+
+
+@pytest.mark.asyncio
+async def test_fallback_includes_persona_and_tone_when_provider_missing():
+    orch = AIOrchestrator(ServiceConfig(name="test"))
+    await orch.initialize()
+    orch.llm_router.invoke = Mock(
+        side_effect=RuntimeError(
+            "No provider for intent 'conversation_processing' and no fallback"
+        )
+    )
+    flow_input = FlowInput(
+        prompt="Hi",
+        conversation_history=[],
+        user_settings={
+            "personality_tone": "formal",
+            "custom_persona_instructions": "Professor Bot",
+        },
+    )
+    out = await orch.conversation_processing_flow(flow_input)
+    assert "Professor Bot" in out.response
+    assert "formal" in out.response


### PR DESCRIPTION
## Summary
- improve error handling in `_process_conversation_with_memory` to detect missing LLM providers
- generate fallback replies using the user's persona instructions and tone
- test fallback behaviour when no LLM provider is available
- format updated files with `black`

## Testing
- `pre-commit` *(fails: command not found)*
- `pytest -q tests/test_persona_fallback.py` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*


------
https://chatgpt.com/codex/tasks/task_e_6883da87b83083248ef221df607027b1