### PR TITLE
Add conversation processing intent to profiles

### DIFF
--- a/config/llm_profiles.yml
+++ b/config/llm_profiles.yml
@@ -1,13 +1,15 @@
 profiles:
-  default:
-    providers:
-      chat: ollama
-      code: deepseek
-      generic: ollama
-    fallback: openai
-  enterprise:
-    providers:
-      chat: openai
-      code: groq
-      generic: openai
-    fallback: openai
+    default:
+      providers:
+        chat: ollama
+        conversation_processing: ollama
+        code: deepseek
+        generic: ollama
+      fallback: openai
+    enterprise:
+      providers:
+        chat: openai
+        conversation_processing: openai
+        code: groq
+        generic: openai
+      fallback: openai


### PR DESCRIPTION
## Summary
- map the `conversation_processing` flow to providers in `llm_profiles.yml`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6883e04f07ec8324a633789c3b8d1f97