### PR TITLE
Reduce startup logs but keep debug defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ helm install ai-karen ./charts/kari/ \
 | `MILVUS_PORT` | Milvus port | `19530` |
 | `JWT_SECRET_KEY` | JWT signing key | `your-secret-key` |
 | `ENABLE_SELF_REFACTOR` | Enable self-refactoring | `false` |
-| `LOG_LEVEL` | Logging level | `INFO` |
+| `KAREN_LOG_LEVEL` | Logging level | `INFO` |
 | `KARI_CORS_ORIGINS` | Comma-separated list of allowed CORS origins | `*` |
 | `KARI_ECO_MODE` | Skip heavy NLP model loading | `false` |
 
@@ -393,11 +393,13 @@ The system exposes Prometheus metrics at `/metrics/prometheus`:
 
 ### Logging
 
-Structured logging with configurable levels:
+Structured logging with configurable levels. The server runs at `INFO` level by
+default and prints `Greetings, the logs are ready for review` once startup
+completes.
 
 ```bash
-# Set log level
-export LOG_LEVEL=DEBUG
+# Increase verbosity if needed
+export KAREN_LOG_LEVEL=DEBUG
 
 # View logs
 docker-compose logs -f api

--- a/docs/development_guide.md
+++ b/docs/development_guide.md
@@ -116,13 +116,16 @@ uvicorn main:app --reload --port 8000
 # Development mode with hot reload
 uvicorn main:app --reload --port 8000
 
-# With debug logging
-KARI_LOG_LEVEL=DEBUG uvicorn main:app --reload --port 8000
+# Increase log verbosity
+KAREN_LOG_LEVEL=DEBUG uvicorn main:app --reload --port 8000
 
 # API documentation available at:
 # http://localhost:8000/docs (Swagger UI)
 # http://localhost:8000/redoc (ReDoc)
 ```
+
+On startup the server logs `Greetings, the logs are ready for review` to confirm
+that logging is configured correctly.
 
 **Common Development Tasks:**
 ```bash
@@ -495,10 +498,10 @@ logging.getLogger('ai_karen_engine.plugins').setLevel(logging.DEBUG)
 **Debug Mode:**
 ```bash
 # Start API with debug logging
-KARI_LOG_LEVEL=DEBUG uvicorn main:app --reload --port 8000
+KAREN_LOG_LEVEL=DEBUG uvicorn main:app --reload --port 8000
 
 # Enable SQL query logging
-KARI_DB_ECHO=true uvicorn main:app --reload --port 8000
+KAREN_DB_ECHO=true uvicorn main:app --reload --port 8000
 ```
 
 **Using Python Debugger:**

--- a/main.py
+++ b/main.py
@@ -391,6 +391,7 @@ async def on_startup() -> None:
         health_monitor = get_health_monitor()
         health_monitor.start_monitoring()
         logger.info("Health monitoring started")
+        logger.info("Greetings, the logs are ready for review")
 
     except Exception as e:
         logger.error(f"Failed to initialize AI Karen integration: {e}")

--- a/src/ai_karen_engine/core/embedding_manager.py
+++ b/src/ai_karen_engine/core/embedding_manager.py
@@ -275,7 +275,9 @@ class EmbeddingManager:
             
             batch_time = time.time() - start
             record_metric("batch_embedding_time_seconds", batch_time)
-            logger.debug(f"[EmbeddingManager] Batch processed {len(valid_texts)} texts in {batch_time:.2f}s")
+            logger.debug(
+                f"[EmbeddingManager] Batch processed {len(valid_texts)} texts in {batch_time:.2f}s"
+            )
             
             return result
             

--- a/src/ai_karen_engine/database/schema_validator.py
+++ b/src/ai_karen_engine/database/schema_validator.py
@@ -104,8 +104,9 @@ class DatabaseSchemaValidator:
             existing_columns = {row[0] for row in result.fetchall()}
             
             missing_columns = [col for col in required_columns if col not in existing_columns]
-            
+
             logger.debug(f"Table {table_name} missing columns: {missing_columns}")
+
             return missing_columns
             
         except Exception as e:

--- a/src/ai_karen_engine/extensions/manager.py
+++ b/src/ai_karen_engine/extensions/manager.py
@@ -147,7 +147,9 @@ class ExtensionManager:
                 self.logger.warning(f"Manifest warnings for {extension_dir.name}: {'; '.join(warnings)}")
             
             manifests[manifest.name] = manifest
-            self.logger.debug(f"Discovered extension: {manifest.name} v{manifest.version} at {extension_dir}")
+            self.logger.debug(
+                f"Discovered extension: {manifest.name} v{manifest.version} at {extension_dir}"
+            )
             
         except Exception as e:
             self.logger.error(f"Failed to load manifest from {manifest_path}: {e}")

--- a/src/ai_karen_engine/extensions/registry.py
+++ b/src/ai_karen_engine/extensions/registry.py
@@ -119,7 +119,9 @@ class ExtensionRegistry:
         if name in self.extensions:
             self.extensions[name].status = status
             self.extensions[name].error_message = error_message
-            self.logger.debug(f"Updated extension {name} status to {status.value}")
+            self.logger.debug(
+                f"Updated extension {name} status to {status.value}"
+            )
             return True
         return False
     

--- a/src/ai_karen_engine/integrations/llm_registry.py
+++ b/src/ai_karen_engine/integrations/llm_registry.py
@@ -152,7 +152,6 @@ class LLMRegistry:
 
             with open(self.registry_path, "w") as f:
                 json.dump(data, f, indent=2)
-
             logger.debug(f"Saved registry to {self.registry_path}")
 
         except Exception as ex:


### PR DESCRIPTION
## Summary
- keep the new greeting message after startup
- restore previously lowered debug messages
- clarify log level env var as `KAREN_LOG_LEVEL`

## Testing
- `pytest tests/test_basic_orchestration.py::test_basic_orchestration -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `pip install sqlalchemy` *(fails: Tunnel connection failed: 403 Forbidden)*


------
https://chatgpt.com/codex/tasks/task_e_6883e18e6d788324b9e43a40a5492745