### PR TITLE
Add env toggles for memory surprise check

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,8 @@ helm install ai-karen ./charts/kari/ \
 | `LOG_LEVEL` | Logging level | `INFO` |
 | `KARI_CORS_ORIGINS` | Comma-separated list of allowed CORS origins | `*` |
 | `KARI_ECO_MODE` | Skip heavy NLP model loading | `false` |
+| `KARI_MEMORY_SURPRISE_THRESHOLD` | Novelty threshold for storing memory | `0.85` |
+| `KARI_DISABLE_MEMORY_SURPRISE_FILTER` | Disable surprise filtering to store all memories | `false` |
 
 ---
 

--- a/docs/development_guide.md
+++ b/docs/development_guide.md
@@ -51,6 +51,8 @@ Set these required environment variables before development:
 - `KARI_ENV` - Selects the runtime environment. Use `local` (the default) to
   run entirely on your machine without relying on external services.
 - `KARI_ECO_MODE` - Skip heavy NLP model loading for low-resource environments
+- `KARI_MEMORY_SURPRISE_THRESHOLD` - Novelty threshold for memory storage (default: 0.85)
+- `KARI_DISABLE_MEMORY_SURPRISE_FILTER` - Disable surprise filtering to store all memories
 
 ### Local Development Setup
 

--- a/tests/test_memory_manager_surprise.py
+++ b/tests/test_memory_manager_surprise.py
@@ -1,0 +1,33 @@
+import numpy as np
+import pytest
+
+from src.ai_karen_engine.database.memory_manager import MemoryManager
+
+
+class DummyMilvusClient:
+    def __init__(self):
+        self.called = False
+
+    async def search(self, *args, **kwargs):
+        self.called = True
+        return [[type("Result", (), {"distance": 0.9})()]]
+
+
+class DummyEmbeddingManager:
+    pass
+
+
+class DummyDBClient:
+    pass
+
+
+@pytest.mark.asyncio
+async def test_disable_surprise_filter(monkeypatch):
+    monkeypatch.setenv("KARI_DISABLE_MEMORY_SURPRISE_FILTER", "true")
+    manager = MemoryManager(
+        DummyDBClient(), DummyMilvusClient(), DummyEmbeddingManager()
+    )
+    assert manager.disable_surprise_check is True
+    result = await manager._check_surprise("tenant", np.array([0.1, 0.2]))
+    assert result is True
+    assert not manager.milvus_client.called


### PR DESCRIPTION
## Summary
- allow controlling memory surprise filtering via `KARI_DISABLE_MEMORY_SURPRISE_FILTER`
- make threshold configurable with `KARI_MEMORY_SURPRISE_THRESHOLD`
- document new environment variables
- test disabling the surprise filter

## Testing
- `ruff check src/ai_karen_engine/database/memory_manager.py tests/test_memory_manager_surprise.py`
- `black src/ai_karen_engine/database/memory_manager.py tests/test_memory_manager_surprise.py`
- `PYTHONPATH=src pytest tests/test_memory_manager_surprise.py -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6883e7c7dda88324a7897814a8078710