### PR TITLE
Add extension management context

### DIFF
--- a/ui_launchers/web_ui/src/components/extensions/ExtensionBreadcrumbs.tsx
+++ b/ui_launchers/web_ui/src/components/extensions/ExtensionBreadcrumbs.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import React from 'react';
+import { Separator } from '@/components/ui/separator';
+import { useExtensionContext } from '@/extensions';
+
+export default function ExtensionBreadcrumbs() {
+  const {
+    state: { breadcrumbs },
+    dispatch,
+  } = useExtensionContext();
+
+  if (breadcrumbs.length === 0) {
+    return null;
+  }
+
+  const handleClick = (index: number) => {
+    dispatch({ type: 'RESET_BREADCRUMBS' });
+    breadcrumbs.slice(0, index).forEach((item) => {
+      dispatch({ type: 'PUSH_BREADCRUMB', item });
+    });
+  };
+
+  return (
+    <div className="flex items-center space-x-2 text-sm text-muted-foreground">
+      {breadcrumbs.map((crumb, idx) => (
+        <React.Fragment key={crumb.id}>
+          <button
+            className="hover:underline"
+            onClick={() => handleClick(idx)}
+            type="button"
+          >
+            {crumb.label}
+          </button>
+          {idx < breadcrumbs.length - 1 && <Separator orientation="vertical" className="h-4" />}
+        </React.Fragment>
+      ))}
+    </div>
+  );
+}

--- a/ui_launchers/web_ui/src/components/extensions/index.ts
+++ b/ui_launchers/web_ui/src/components/extensions/index.ts
@@ -1,0 +1,1 @@
+export { default as ExtensionBreadcrumbs } from './ExtensionBreadcrumbs';

--- a/ui_launchers/web_ui/src/extensions/ExtensionContext.tsx
+++ b/ui_launchers/web_ui/src/extensions/ExtensionContext.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import React, { createContext, useContext, useReducer } from 'react';
+import type { ExtensionAction, ExtensionState, ExtensionCategory, BreadcrumbItem } from './types';
+
+const initialState: ExtensionState = {
+  currentCategory: 'Plugins',
+  breadcrumbs: [],
+  level: 0,
+};
+
+function reducer(state: ExtensionState, action: ExtensionAction): ExtensionState {
+  switch (action.type) {
+    case 'SET_CATEGORY':
+      return {
+        ...state,
+        currentCategory: action.category,
+        breadcrumbs: [],
+        level: 0,
+      };
+    case 'PUSH_BREADCRUMB':
+      return {
+        ...state,
+        breadcrumbs: [...state.breadcrumbs, action.item],
+        level: state.level + 1,
+      };
+    case 'POP_BREADCRUMB':
+      return {
+        ...state,
+        breadcrumbs: state.breadcrumbs.slice(0, -1),
+        level: Math.max(0, state.level - 1),
+      };
+    case 'RESET_BREADCRUMBS':
+      return {
+        ...state,
+        breadcrumbs: [],
+        level: 0,
+      };
+    default:
+      return state;
+  }
+}
+
+const ExtensionContext = createContext<{ state: ExtensionState; dispatch: React.Dispatch<ExtensionAction> } | undefined>(undefined);
+
+export const ExtensionProvider: React.FC<{ initialCategory?: ExtensionCategory; children: React.ReactNode }> = ({
+  initialCategory = 'Plugins',
+  children,
+}) => {
+  const [state, dispatch] = useReducer(reducer, { ...initialState, currentCategory: initialCategory });
+
+  return <ExtensionContext.Provider value={{ state, dispatch }}>{children}</ExtensionContext.Provider>;
+};
+
+export function useExtensionContext() {
+  const context = useContext(ExtensionContext);
+  if (!context) {
+    throw new Error('useExtensionContext must be used within an ExtensionProvider');
+  }
+  return context;
+}
+
+export { type ExtensionState, type ExtensionAction, type ExtensionCategory, type BreadcrumbItem } from './types';

--- a/ui_launchers/web_ui/src/extensions/index.ts
+++ b/ui_launchers/web_ui/src/extensions/index.ts
@@ -1,0 +1,2 @@
+export * from './types';
+export * from './ExtensionContext';

--- a/ui_launchers/web_ui/src/extensions/types.ts
+++ b/ui_launchers/web_ui/src/extensions/types.ts
@@ -1,0 +1,24 @@
+export type ExtensionCategory = 'Plugins' | 'Extensions';
+
+export interface BaseNavigationItem {
+  id: string;
+  name: string;
+  description?: string;
+}
+
+export interface BreadcrumbItem {
+  id: string;
+  label: string;
+}
+
+export interface ExtensionState {
+  currentCategory: ExtensionCategory;
+  breadcrumbs: BreadcrumbItem[];
+  level: number;
+}
+
+export type ExtensionAction =
+  | { type: 'SET_CATEGORY'; category: ExtensionCategory }
+  | { type: 'PUSH_BREADCRUMB'; item: BreadcrumbItem }
+  | { type: 'POP_BREADCRUMB' }
+  | { type: 'RESET_BREADCRUMBS' };


### PR DESCRIPTION
## Summary
- create directory structure for extensions
- define extension and breadcrumb types
- add ExtensionContext for Plugins|Extensions state
- provide ExtensionBreadcrumbs component

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688458652fd88324ad375d94cfb47eb6