### PR TITLE
Add extension sidebar and navigation reducer

### DIFF
--- a/ui_launchers/web_ui/src/components/extensions/ExtensionBreadcrumbs.tsx
+++ b/ui_launchers/web_ui/src/components/extensions/ExtensionBreadcrumbs.tsx
@@ -15,10 +15,7 @@ export default function ExtensionBreadcrumbs() {
   }
 
   const handleClick = (index: number) => {
-    dispatch({ type: 'RESET_BREADCRUMBS' });
-    breadcrumbs.slice(0, index).forEach((item) => {
-      dispatch({ type: 'PUSH_BREADCRUMB', item });
-    });
+    dispatch({ type: 'SET_LEVEL', level: index + 1 });
   };
 
   return (

--- a/ui_launchers/web_ui/src/components/extensions/ExtensionSidebar.tsx
+++ b/ui_launchers/web_ui/src/components/extensions/ExtensionSidebar.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import React from "react";
+import {
+  Sidebar,
+  SidebarProvider,
+  SidebarTrigger,
+  SidebarHeader,
+  SidebarContent,
+  SidebarFooter,
+} from "@/components/ui/sidebar";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Button } from "@/components/ui/button";
+import { ArrowLeft } from "lucide-react";
+import ExtensionBreadcrumbs from "./ExtensionBreadcrumbs";
+import { useExtensionContext, ExtensionProvider } from "@/extensions";
+
+function SidebarInner() {
+  const {
+    state: { currentCategory, level },
+    dispatch,
+  } = useExtensionContext();
+
+  return (
+    <Sidebar variant="sidebar" collapsible="icon" className="border-r z-20">
+      <SidebarHeader className="space-y-2">
+        <Tabs
+          value={currentCategory}
+          onValueChange={(val) =>
+            dispatch({ type: "SET_CATEGORY", category: val as any })
+          }
+          className="w-full"
+        >
+          <TabsList className="grid w-full grid-cols-2">
+            <TabsTrigger value="Plugins">Plugins</TabsTrigger>
+            <TabsTrigger value="Extensions">Extensions</TabsTrigger>
+          </TabsList>
+        </Tabs>
+        {level > 0 && (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="px-1 gap-1 h-6"
+            onClick={() => dispatch({ type: "GO_BACK" })}
+          >
+            <ArrowLeft className="h-3 w-3" /> Back
+          </Button>
+        )}
+        <ExtensionBreadcrumbs />
+      </SidebarHeader>
+      <SidebarContent className="p-2 space-y-2">
+        {/* Navigation items will be added in future tasks */}
+      </SidebarContent>
+      <SidebarFooter className="p-2 border-t">
+        <p className="text-xs text-muted-foreground text-center">
+          Extension Manager
+        </p>
+      </SidebarFooter>
+    </Sidebar>
+  );
+}
+
+export default function ExtensionSidebar() {
+  return (
+    <ExtensionProvider>
+      <SidebarProvider>
+        <SidebarInner />
+      </SidebarProvider>
+    </ExtensionProvider>
+  );
+}

--- a/ui_launchers/web_ui/src/components/extensions/index.ts
+++ b/ui_launchers/web_ui/src/components/extensions/index.ts
@@ -1,1 +1,2 @@
 export { default as ExtensionBreadcrumbs } from './ExtensionBreadcrumbs';
+export { default as ExtensionSidebar } from './ExtensionSidebar';

--- a/ui_launchers/web_ui/src/extensions/ExtensionContext.tsx
+++ b/ui_launchers/web_ui/src/extensions/ExtensionContext.tsx
@@ -30,6 +30,18 @@ function reducer(state: ExtensionState, action: ExtensionAction): ExtensionState
         breadcrumbs: state.breadcrumbs.slice(0, -1),
         level: Math.max(0, state.level - 1),
       };
+    case 'GO_BACK':
+      return {
+        ...state,
+        breadcrumbs: state.breadcrumbs.slice(0, -1),
+        level: Math.max(0, state.level - 1),
+      };
+    case 'SET_LEVEL':
+      return {
+        ...state,
+        breadcrumbs: state.breadcrumbs.slice(0, action.level),
+        level: Math.max(0, action.level),
+      };
     case 'RESET_BREADCRUMBS':
       return {
         ...state,

--- a/ui_launchers/web_ui/src/extensions/types.ts
+++ b/ui_launchers/web_ui/src/extensions/types.ts
@@ -21,4 +21,6 @@ export type ExtensionAction =
   | { type: 'SET_CATEGORY'; category: ExtensionCategory }
   | { type: 'PUSH_BREADCRUMB'; item: BreadcrumbItem }
   | { type: 'POP_BREADCRUMB' }
-  | { type: 'RESET_BREADCRUMBS' };
+  | { type: 'RESET_BREADCRUMBS' }
+  | { type: 'GO_BACK' }
+  | { type: 'SET_LEVEL'; level: number };


### PR DESCRIPTION
## Summary
- add actions for extension navigation like GO_BACK and SET_LEVEL
- manage breadcrumbs via new reducer cases
- implement `ExtensionSidebar` with category tabs and back button
- export new component

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68845ac14c0c83249f7b577ead385fdc