### PR TITLE
Add extension sidebar stats and provider components

### DIFF
--- a/ui_launchers/web_ui/src/components/extensions/ExtensionSidebar.tsx
+++ b/ui_launchers/web_ui/src/components/extensions/ExtensionSidebar.tsx
@@ -13,6 +13,7 @@ import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Button } from "@/components/ui/button";
 import { ArrowLeft } from "lucide-react";
 import ExtensionBreadcrumbs from "./ExtensionBreadcrumbs";
+import ExtensionStats from "./ExtensionStats";
 import { useExtensionContext, ExtensionProvider } from "@/extensions";
 
 function SidebarInner() {
@@ -24,6 +25,10 @@ function SidebarInner() {
   return (
     <Sidebar variant="sidebar" collapsible="icon" className="border-r z-20">
       <SidebarHeader className="space-y-2">
+        <div className="flex items-center justify-between">
+          <h2 className="text-lg font-semibold">Extension Manager</h2>
+          <SidebarTrigger />
+        </div>
         <Tabs
           value={currentCategory}
           onValueChange={(val) =>
@@ -47,6 +52,7 @@ function SidebarInner() {
           </Button>
         )}
         <ExtensionBreadcrumbs />
+        <ExtensionStats />
       </SidebarHeader>
       <SidebarContent className="p-2 space-y-2">
         {/* Navigation items will be added in future tasks */}

--- a/ui_launchers/web_ui/src/components/extensions/ExtensionStats.tsx
+++ b/ui_launchers/web_ui/src/components/extensions/ExtensionStats.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Card, CardContent } from "@/components/ui/card";
+import { getPluginService, getExtensionService } from "@/services";
+
+export default function ExtensionStats() {
+  const [pluginCount, setPluginCount] = useState(0);
+  const [extensionCount, setExtensionCount] = useState(0);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const plugins = await getPluginService().getAvailablePlugins();
+        setPluginCount(plugins.length);
+      } catch (error) {
+        console.error("Failed to load plugins", error);
+      }
+      try {
+        const exts = await getExtensionService().getInstalledExtensions();
+        setExtensionCount(exts.length);
+      } catch (error) {
+        console.error("Failed to load extensions", error);
+      }
+    }
+    load();
+  }, []);
+
+  return (
+    <Card>
+      <CardContent className="py-2 text-sm grid grid-cols-2 gap-2">
+        <div className="flex items-center justify-between">
+          <span>Plugins</span>
+          <span className="font-medium">{pluginCount}</span>
+        </div>
+        <div className="flex items-center justify-between">
+          <span>Extensions</span>
+          <span className="font-medium">{extensionCount}</span>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/ui_launchers/web_ui/src/components/extensions/index.ts
+++ b/ui_launchers/web_ui/src/components/extensions/index.ts
@@ -1,2 +1,4 @@
 export { default as ExtensionBreadcrumbs } from './ExtensionBreadcrumbs';
 export { default as ExtensionSidebar } from './ExtensionSidebar';
+export { default as ExtensionStats } from './ExtensionStats';
+export * from './plugins';

--- a/ui_launchers/web_ui/src/components/extensions/plugins/LLMModelConfigPanel.tsx
+++ b/ui_launchers/web_ui/src/components/extensions/plugins/LLMModelConfigPanel.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useForm } from "react-hook-form";
+import { Card, CardContent, CardHeader, CardTitle, CardFooter } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
+import { Slider } from "@/components/ui/slider";
+import { Textarea } from "@/components/ui/textarea";
+
+export interface LLMModelConfig {
+  temperature: number;
+  maxTokens: number;
+  systemPrompt: string;
+  apiKey: string;
+}
+
+export default function LLMModelConfigPanel({ onSave }: { onSave?: (cfg: LLMModelConfig) => void }) {
+  const { register, handleSubmit, watch, setValue } = useForm<LLMModelConfig>({
+    defaultValues: { temperature: 0.7, maxTokens: 2048, systemPrompt: "", apiKey: "" },
+  });
+
+  const temp = watch("temperature");
+
+  return (
+    <form onSubmit={handleSubmit((data) => onSave?.(data))} className="space-y-4">
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-sm">Model Configuration</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-1">
+            <Label>Temperature ({temp.toFixed(2)})</Label>
+            <Slider
+              min={0}
+              max={1}
+              step={0.01}
+              value={[temp]}
+              onValueChange={(val) => setValue("temperature", val[0])}
+            />
+          </div>
+          <div className="space-y-1">
+            <Label htmlFor="maxTokens">Max Tokens</Label>
+            <Input id="maxTokens" type="number" {...register("maxTokens", { valueAsNumber: true })} />
+          </div>
+          <div className="space-y-1">
+            <Label htmlFor="systemPrompt">System Prompt</Label>
+            <Textarea id="systemPrompt" rows={3} {...register("systemPrompt")} />
+          </div>
+          <div className="space-y-1">
+            <Label htmlFor="apiKey">API Key</Label>
+            <Input id="apiKey" type="password" {...register("apiKey")} />
+          </div>
+        </CardContent>
+        <CardFooter className="flex justify-end">
+          <Button size="sm" type="submit">Save</Button>
+        </CardFooter>
+      </Card>
+    </form>
+  );
+}

--- a/ui_launchers/web_ui/src/components/extensions/plugins/LLMProviderList.tsx
+++ b/ui_launchers/web_ui/src/components/extensions/plugins/LLMProviderList.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Card, CardHeader, CardTitle, CardContent, CardFooter } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Plug } from "lucide-react";
+
+interface ProviderInfo {
+  id: string;
+  name: string;
+  status: "healthy" | "error" | "unknown";
+  model: string;
+}
+
+export default function LLMProviderList() {
+  const [providers, setProviders] = useState<ProviderInfo[]>([]);
+
+  useEffect(() => {
+    // Placeholder provider data. In a real implementation this would be fetched
+    // from the backend service.
+    setProviders([
+      { id: "openai", name: "OpenAI", status: "healthy", model: "gpt-3.5-turbo" },
+      { id: "anthropic", name: "Anthropic", status: "unknown", model: "claude-3" },
+    ]);
+  }, []);
+
+  return (
+    <div className="space-y-4">
+      {providers.map((p) => (
+        <Card key={p.id}>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm flex items-center gap-1">
+              <Plug className="h-4 w-4" /> {p.name}
+            </CardTitle>
+            <Badge variant={p.status === "healthy" ? "default" : "destructive"}>{p.status}</Badge>
+          </CardHeader>
+          <CardContent className="text-sm">
+            Model: <span className="font-mono">{p.model}</span>
+          </CardContent>
+          <CardFooter>
+            <Button size="sm" variant="outline">Configure</Button>
+          </CardFooter>
+        </Card>
+      ))}
+    </div>
+  );
+}

--- a/ui_launchers/web_ui/src/components/extensions/plugins/VideoProviderList.tsx
+++ b/ui_launchers/web_ui/src/components/extensions/plugins/VideoProviderList.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Video } from "lucide-react";
+
+interface VideoProvider {
+  id: string;
+  name: string;
+  status: "ready" | "unavailable";
+}
+
+export default function VideoProviderList() {
+  const [providers, setProviders] = useState<VideoProvider[]>([]);
+
+  useEffect(() => {
+    // Placeholder data. Real implementation would check backend for available visual providers
+    setProviders([
+      { id: "d-id", name: "D-ID", status: "ready" },
+      { id: "synthesia", name: "Synthesia", status: "unavailable" },
+    ]);
+  }, []);
+
+  return (
+    <div className="space-y-4">
+      {providers.map((p) => (
+        <Card key={p.id}>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm flex items-center gap-1">
+              <Video className="h-4 w-4" /> {p.name}
+            </CardTitle>
+            <Badge variant={p.status === "ready" ? "default" : "secondary"}>{p.status}</Badge>
+          </CardHeader>
+          <CardContent className="text-sm">Visual provider</CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}

--- a/ui_launchers/web_ui/src/components/extensions/plugins/VoiceProviderList.tsx
+++ b/ui_launchers/web_ui/src/components/extensions/plugins/VoiceProviderList.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Volume2 } from "lucide-react";
+
+interface VoiceProvider {
+  id: string;
+  name: string;
+  previewText?: string;
+}
+
+export default function VoiceProviderList() {
+  const [providers, setProviders] = useState<VoiceProvider[]>([]);
+
+  useEffect(() => {
+    // Placeholder providers. Real implementation would detect installed voices or fetch from backend
+    setProviders([
+      { id: "system", name: "System Voices", previewText: "Hello from your system" },
+    ]);
+  }, []);
+
+  const handlePreview = (text: string) => {
+    if (typeof window !== "undefined" && window.speechSynthesis) {
+      const utterance = new SpeechSynthesisUtterance(text);
+      window.speechSynthesis.speak(utterance);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      {providers.map((p) => (
+        <Card key={p.id}>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm flex items-center gap-1">
+              <Volume2 className="h-4 w-4" /> {p.name}
+            </CardTitle>
+          </CardHeader>
+          {p.previewText && (
+            <CardContent>
+              <Button size="sm" variant="outline" onClick={() => handlePreview(p.previewText)}>
+                Preview Voice
+              </Button>
+            </CardContent>
+          )}
+        </Card>
+      ))}
+    </div>
+  );
+}

--- a/ui_launchers/web_ui/src/components/extensions/plugins/index.ts
+++ b/ui_launchers/web_ui/src/components/extensions/plugins/index.ts
@@ -1,0 +1,4 @@
+export { default as LLMProviderList } from './LLMProviderList';
+export { default as LLMModelConfigPanel } from './LLMModelConfigPanel';
+export { default as VoiceProviderList } from './VoiceProviderList';
+export { default as VideoProviderList } from './VideoProviderList';

--- a/ui_launchers/web_ui/src/services/extensionService.ts
+++ b/ui_launchers/web_ui/src/services/extensionService.ts
@@ -1,0 +1,41 @@
+/**
+ * Extension Service - manages installed extensions (placeholder implementation)
+ */
+
+export interface ExtensionInfo {
+  name: string;
+  description: string;
+  enabled: boolean;
+}
+
+class ExtensionService {
+  private extensions: ExtensionInfo[] = [
+    { name: 'Sample Extension', description: 'Example extension', enabled: true },
+  ];
+
+  clearCache(): void {
+    // Placeholder: nothing to clear
+  }
+
+  getCacheStats(): { size: number; keys: string[] } {
+    return { size: this.extensions.length, keys: this.extensions.map(e => e.name) };
+  }
+
+  async getInstalledExtensions(): Promise<ExtensionInfo[]> {
+    return this.extensions;
+  }
+}
+
+let extensionService: ExtensionService | null = null;
+
+export function getExtensionService(): ExtensionService {
+  if (!extensionService) {
+    extensionService = new ExtensionService();
+  }
+  return extensionService;
+}
+
+export function initializeExtensionService(): ExtensionService {
+  extensionService = new ExtensionService();
+  return extensionService;
+}

--- a/ui_launchers/web_ui/src/services/index.ts
+++ b/ui_launchers/web_ui/src/services/index.ts
@@ -7,6 +7,7 @@
 export { ChatService, getChatService, initializeChatService } from './chatService';
 export { MemoryService, getMemoryService, initializeMemoryService } from './memoryService';
 export { PluginService, getPluginService, initializePluginService } from './pluginService';
+export { ExtensionService, getExtensionService, initializeExtensionService } from './extensionService';
 
 // Export service types
 export type { ConversationSession, ProcessMessageOptions } from './chatService';
@@ -15,23 +16,26 @@ export type {
   MemoryStats, 
   MemoryContext 
 } from './memoryService';
-export type { 
-  PluginCategory, 
-  PluginExecutionOptions, 
-  PluginValidationResult, 
-  PluginMetrics 
+export type {
+  PluginCategory,
+  PluginExecutionOptions,
+  PluginValidationResult,
+  PluginMetrics
 } from './pluginService';
+export type { ExtensionInfo } from './extensionService';
 
 // Service initialization helper
 export function initializeAllServices() {
   const chatService = initializeChatService();
   const memoryService = initializeMemoryService();
   const pluginService = initializePluginService();
-  
+  const extensionService = initializeExtensionService();
+
   return {
     chatService,
     memoryService,
     pluginService,
+    extensionService,
   };
 }
 
@@ -40,12 +44,14 @@ export async function checkServicesHealth(): Promise<{
   chat: boolean;
   memory: boolean;
   plugins: boolean;
+  extensions: boolean;
   overall: boolean;
 }> {
   const results = {
     chat: false,
     memory: false,
     plugins: false,
+    extensions: false,
     overall: false,
   };
 
@@ -73,7 +79,15 @@ export async function checkServicesHealth(): Promise<{
     console.error('Plugin service health check failed:', error);
   }
 
-  results.overall = results.chat && results.memory && results.plugins;
+  try {
+    // Test extension service
+    const extService = getExtensionService();
+    results.extensions = true;
+  } catch (error) {
+    console.error('Extension service health check failed:', error);
+  }
+
+  results.overall = results.chat && results.memory && results.plugins && results.extensions;
   return results;
 }
 
@@ -83,6 +97,7 @@ export function clearAllServiceCaches(): void {
     getChatService().clearCache();
     getMemoryService().clearCache();
     getPluginService().clearCache();
+    getExtensionService().clearCache?.();
   } catch (error) {
     console.error('Failed to clear service caches:', error);
   }
@@ -100,10 +115,12 @@ export function getAllServiceCacheStats(): {
     executionHistory: { size: number; keys: string[] };
     metricsCache: { size: number; keys: string[] };
   };
+  extensions: { size: number; keys: string[] };
 } {
   return {
     chat: getChatService().getCacheStats(),
     memory: getMemoryService().getCacheStats(),
     plugins: getPluginService().getCacheStats(),
+    extensions: getExtensionService().getCacheStats(),
   };
 }


### PR DESCRIPTION
## Summary
- add ExtensionStats component to show plugin/extension counts
- extend ExtensionSidebar with header, toggle button, and stats
- add provider components for LLMs, voice, and video
- create model configuration panel UI
- add basic ExtensionService and export via services index

## Testing
- `npm run lint` *(fails: `next: not found`)*
- `pytest -k "nothing" -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68845d56e0b48324ad632628520503ed