### PR TITLE
Add extension lifecycle operations and monitoring

### DIFF
--- a/src/ai_karen_engine/extensions/__init__.py
+++ b/src/ai_karen_engine/extensions/__init__.py
@@ -14,7 +14,9 @@ from .orchestrator import PluginOrchestrator
 from .data_manager import ExtensionDataManager
 from .validator import ExtensionValidator, validate_extension_manifest
 from .dependency_resolver import DependencyResolver
-from .resource_monitor import ResourceMonitor, ExtensionHealthChecker
+from .resource_monitor import ResourceMonitor, ExtensionHealthChecker, HealthStatus
+from .marketplace_client import MarketplaceClient
+from .metrics_dashboard import MetricsDashboard
 
 __all__ = [
     "ExtensionManager",
@@ -32,4 +34,7 @@ __all__ = [
     "DependencyResolver",
     "ResourceMonitor",
     "ExtensionHealthChecker",
+    "HealthStatus",
+    "MarketplaceClient",
+    "MetricsDashboard",
 ]

--- a/src/ai_karen_engine/extensions/marketplace_client.py
+++ b/src/ai_karen_engine/extensions/marketplace_client.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any, Dict, List
+
+
+class MarketplaceClient:
+    """Simple marketplace interface for extension downloads."""
+
+    def __init__(self, base_url: str | None = None) -> None:
+        self.base_url = base_url or "https://example.com"
+        self.logger = logging.getLogger("extension.marketplace")
+
+    async def list_available_extensions(self) -> List[Dict[str, Any]]:
+        """List available extensions from the marketplace."""
+        self.logger.info("Listing extensions from marketplace")
+        return []
+
+    async def download_extension(
+        self, extension_id: str, version: str, destination: Path
+    ) -> bool:
+        """Download an extension to the given destination."""
+        self.logger.info(
+            "Downloading %s@%s from %s", extension_id, version, self.base_url
+        )
+        # Placeholder implementation
+        return False
+

--- a/src/ai_karen_engine/extensions/metrics_dashboard.py
+++ b/src/ai_karen_engine/extensions/metrics_dashboard.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from typing import Dict
+
+from .resource_monitor import ResourceMonitor, ResourceUsage
+
+
+class MetricsDashboard:
+    """Simple metrics dashboard for extensions."""
+
+    def __init__(self, monitor: ResourceMonitor) -> None:
+        self.monitor = monitor
+
+    def get_metrics(self) -> Dict[str, Dict[str, float]]:
+        """Return resource usage metrics for all extensions."""
+        usage = self.monitor.get_all_usage()
+        return {name: usage_record.__dict__ for name, usage_record in usage.items()}
+

--- a/tests/test_extension_lifecycle_management.py
+++ b/tests/test_extension_lifecycle_management.py
@@ -1,0 +1,61 @@
+import json
+from pathlib import Path
+import sys
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from ai_karen_engine.extensions import (
+    ExtensionManager,
+    HealthStatus,
+    ExtensionStatus,
+)
+from ai_karen_engine.plugins.router import PluginRouter
+
+
+@pytest.fixture()
+def temp_extension(tmp_path):
+    ext_dir = tmp_path / "sample-extension"
+    ext_dir.mkdir()
+    manifest = {
+        "name": "sample-extension",
+        "version": "1.0.0",
+        "display_name": "Sample",
+        "description": "Sample",
+        "author": "Test",
+        "license": "MIT",
+        "category": "test",
+    }
+    (ext_dir / "extension.json").write_text(json.dumps(manifest))
+    (ext_dir / "__init__.py").write_text(
+        "from ai_karen_engine.extensions.base import BaseExtension\n"
+        "class SampleExtension(BaseExtension):\n"
+        "    async def _initialize(self):\n        "
+        "        pass\n"
+        "    async def _shutdown(self):\n        "
+        "        pass\n"
+    )
+    return ext_dir
+
+
+@pytest.fixture()
+def extension_manager(tmp_path):
+    router = PluginRouter(plugin_root=Path("plugin_marketplace"))
+    return ExtensionManager(extension_root=tmp_path, plugin_router=router)
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_operations(extension_manager, temp_extension):
+    assert await extension_manager.install_extension(
+        "sample-extension", "1.0.0", path=str(temp_extension)
+    )
+    record = await extension_manager.enable_extension("sample-extension")
+    assert record is not None
+    status = extension_manager.get_extension_status("sample-extension")
+    assert status["status"] == ExtensionStatus.ACTIVE.value
+    health = await extension_manager.check_extension_health("sample-extension")
+    assert health in HealthStatus
+    await extension_manager.disable_extension("sample-extension")
+    await extension_manager.remove_extension("sample-extension")
+    assert not (extension_manager.extension_root / "sample-extension").exists()
+


### PR DESCRIPTION
## Summary
- introduce `HealthStatus` enum and use it in `ExtensionHealthChecker`
- provide `MarketplaceClient` and `MetricsDashboard`
- extend `ExtensionManager` with install, update, enable, disable, remove operations
- expose new helpers in extension package
- add lifecycle test covering install and enable flow

## Testing
- `PYTHONPATH=src pytest tests/test_extension_lifecycle_management.py -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_6884637daac48324bb3012ba366bb39b