### PR TITLE
Add responsive grid component and a11y updates

### DIFF
--- a/ui_launchers/web_ui/package.json
+++ b/ui_launchers/web_ui/package.json
@@ -9,7 +9,8 @@
     "build": "next build",
     "start": "next start -p 3000",
     "lint": "next lint",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest"
   },
   "dependencies": {
     "@genkit-ai/googleai": "^1.8.0",
@@ -62,6 +63,11 @@
     "genkit-cli": "^1.8.0",
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^1.5.0",
+    "@testing-library/react": "^14.1.2",
+    "@testing-library/user-event": "^14.4.3",
+    "jsdom": "^24.0.0",
+    "msw": "^2.0.0"
   }
 }

--- a/ui_launchers/web_ui/src/__tests__/api.integration.test.tsx
+++ b/ui_launchers/web_ui/src/__tests__/api.integration.test.tsx
@@ -1,0 +1,19 @@
+import { rest } from 'msw';
+import { setupServer } from 'msw/node';
+import { render, screen, waitFor } from '@testing-library/react';
+
+const server = setupServer(
+  rest.get('/api/hello', (_req, res, ctx) => {
+    return res(ctx.json({ message: 'hello' }));
+  })
+);
+
+beforeAll(() => server.listen());
+afterAll(() => server.close());
+afterEach(() => server.resetHandlers());
+
+test('fetches data from mocked api', async () => {
+  const response = await fetch('/api/hello');
+  const data = await response.json();
+  expect(data).toEqual({ message: 'hello' });
+});

--- a/ui_launchers/web_ui/src/components/plugins/BookDetailsPluginPage.tsx
+++ b/ui_launchers/web_ui/src/components/plugins/BookDetailsPluginPage.tsx
@@ -2,6 +2,7 @@
 "use client";
 
 import { Card, CardContent, CardDescription, CardHeader, CardTitle, CardFooter } from "@/components/ui/card";
+import ResponsiveCardGrid from "@/components/ui/responsive-card-grid";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -94,7 +95,8 @@ export default function DatabaseConnectorPluginPage() { // Renamed component fun
             View discovered tables and their data (Conceptual placeholder).
           </CardDescription>
         </CardHeader>
-        <CardContent className="grid grid-cols-1 md:grid-cols-3 gap-6">
+        <CardContent>
+          <ResponsiveCardGrid className="md:grid-cols-3">
           <div className="md:col-span-1 space-y-3">
             <h4 className="font-medium text-sm flex items-center"><TableIcon className="mr-2 h-4 w-4"/>Discovered Tables</h4>
             <div className="h-48 border rounded-md p-3 bg-muted/50 overflow-y-auto">
@@ -111,6 +113,7 @@ export default function DatabaseConnectorPluginPage() { // Renamed component fun
               <p className="text-xs text-muted-foreground italic">(Data rows would appear here)</p>
             </div>
           </div>
+          </ResponsiveCardGrid>
         </CardContent>
       </Card>
 

--- a/ui_launchers/web_ui/src/components/plugins/FacebookPluginPage.tsx
+++ b/ui_launchers/web_ui/src/components/plugins/FacebookPluginPage.tsx
@@ -2,6 +2,7 @@
 "use client";
 
 import { Card, CardContent, CardDescription, CardHeader, CardTitle, CardFooter } from "@/components/ui/card";
+import ResponsiveCardGrid from "@/components/ui/responsive-card-grid";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -69,7 +70,8 @@ export default function FacebookPluginPage() {
             Perform actions on your connected Facebook account (Conceptual placeholders).
           </CardDescription>
         </CardHeader>
-        <CardContent className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+        <CardContent>
+          <ResponsiveCardGrid>
           <Button variant="outline" disabled className="w-full">
             <MessageSquare className="mr-2 h-4 w-4"/> Fetch Recent Posts
           </Button>
@@ -79,6 +81,7 @@ export default function FacebookPluginPage() {
            <Button variant="outline" disabled className="w-full">
             <BarChart3 className="mr-2 h-4 w-4"/> Analyze Page Insights
           </Button>
+          </ResponsiveCardGrid>
         </CardContent>
       </Card>
 

--- a/ui_launchers/web_ui/src/components/plugins/GmailPluginPage.tsx
+++ b/ui_launchers/web_ui/src/components/plugins/GmailPluginPage.tsx
@@ -2,6 +2,7 @@
 "use client";
 
 import { Card, CardContent, CardDescription, CardHeader, CardTitle, CardFooter } from "@/components/ui/card";
+import ResponsiveCardGrid from "@/components/ui/responsive-card-grid";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -72,7 +73,8 @@ export default function GmailPluginPage() {
             Interact with these mocked Gmail features by talking to Karen in the chat.
           </CardDescription>
         </CardHeader>
-        <CardContent className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <CardContent>
+          <ResponsiveCardGrid>
           <div className="p-3 border rounded-md bg-muted/30">
             <div className="flex items-center mb-1">
               <Inbox className="mr-2 h-4 w-4 text-primary/80"/>
@@ -87,6 +89,7 @@ export default function GmailPluginPage() {
             </div>
             <p className="text-xs text-muted-foreground">Ask Karen: "Compose an email to..."</p>
           </div>
+          </ResponsiveCardGrid>
         </CardContent>
       </Card>
 

--- a/ui_launchers/web_ui/src/components/plugins/PluginOverviewPage.tsx
+++ b/ui_launchers/web_ui/src/components/plugins/PluginOverviewPage.tsx
@@ -2,6 +2,7 @@
 "use client";
 
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import ResponsiveCardGrid from "@/components/ui/responsive-card-grid";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { PlugZap, MessageSquare, Info, Settings2, CalendarDays, CloudSun, Database, Facebook, Mail } from "lucide-react";
 
@@ -59,16 +60,18 @@ export default function PluginOverviewPage() {
             Here are some of the tools Karen AI can currently utilize:
           </CardDescription>
         </CardHeader>
-        <CardContent className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-          {integratedTools.map((tool) => (
-            <div key={tool.name} className="p-4 border rounded-lg bg-muted/30 flex items-start space-x-3">
-              <div className="shrink-0 mt-1">{tool.icon}</div>
-              <div>
-                <h4 className="font-semibold text-sm">{tool.name}</h4>
-                <p className="text-xs text-muted-foreground">{tool.description}</p>
+        <CardContent>
+          <ResponsiveCardGrid>
+            {integratedTools.map((tool) => (
+              <div key={tool.name} className="p-4 border rounded-lg bg-muted/30 flex items-start space-x-3">
+                <div className="shrink-0 mt-1">{tool.icon}</div>
+                <div>
+                  <h4 className="font-semibold text-sm">{tool.name}</h4>
+                  <p className="text-xs text-muted-foreground">{tool.description}</p>
+                </div>
               </div>
-            </div>
-          ))}
+            ))}
+          </ResponsiveCardGrid>
         </CardContent>
       </Card>
 

--- a/ui_launchers/web_ui/src/components/ui/__tests__/responsive-card-grid.test.tsx
+++ b/ui_launchers/web_ui/src/components/ui/__tests__/responsive-card-grid.test.tsx
@@ -1,0 +1,13 @@
+import { render, screen } from "@testing-library/react";
+import ResponsiveCardGrid from "../responsive-card-grid";
+
+test("renders children in a responsive grid", () => {
+  render(
+    <ResponsiveCardGrid data-testid="grid">
+      <div>one</div>
+      <div>two</div>
+    </ResponsiveCardGrid>
+  );
+  const grid = screen.getByTestId("grid");
+  expect(grid.className).toMatch(/grid/);
+});

--- a/ui_launchers/web_ui/src/components/ui/__tests__/sidebar.test.tsx
+++ b/ui_launchers/web_ui/src/components/ui/__tests__/sidebar.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { SidebarProvider, Sidebar, SidebarMenu, SidebarMenuItem, SidebarMenuButton } from "../sidebar";
+
+test("sidebar menu button is keyboard accessible", async () => {
+  render(
+    <SidebarProvider defaultOpen>
+      <Sidebar>
+        <SidebarMenu>
+          <SidebarMenuItem>
+            <SidebarMenuButton>Home</SidebarMenuButton>
+          </SidebarMenuItem>
+        </SidebarMenu>
+      </Sidebar>
+    </SidebarProvider>
+  );
+  const button = screen.getByRole("menuitem", { name: /home/i });
+  await userEvent.tab();
+  expect(button).toHaveFocus();
+  await userEvent.keyboard("{Enter}");
+});

--- a/ui_launchers/web_ui/src/components/ui/responsive-card-grid.tsx
+++ b/ui_launchers/web_ui/src/components/ui/responsive-card-grid.tsx
@@ -1,0 +1,17 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+interface ResponsiveCardGridProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+const ResponsiveCardGrid = React.forwardRef<HTMLDivElement, ResponsiveCardGridProps>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn("grid gap-4 sm:grid-cols-2 lg:grid-cols-3", className)}
+      {...props}
+    />
+  )
+);
+ResponsiveCardGrid.displayName = "ResponsiveCardGrid";
+
+export default ResponsiveCardGrid;

--- a/ui_launchers/web_ui/src/components/ui/sidebar.tsx
+++ b/ui_launchers/web_ui/src/components/ui/sidebar.tsx
@@ -193,6 +193,8 @@ const Sidebar = React.forwardRef<
           <SheetContent
             data-sidebar="sidebar"
             data-mobile="true"
+            role="navigation"
+            aria-label="Sidebar"
             className="w-[--sidebar-width] bg-sidebar text-sidebar-foreground flex flex-col" // Removed p-0
             style={
               {
@@ -220,6 +222,8 @@ const Sidebar = React.forwardRef<
         data-collapsible={state === "collapsed" ? collapsible : ""}
         data-variant={variant}
         data-side={side}
+        role="navigation"
+        aria-label="Sidebar"
       >
         <div
           className={cn(
@@ -497,6 +501,7 @@ const SidebarMenu = React.forwardRef<
   <ul
     ref={ref}
     data-sidebar="menu"
+    role="menu"
     className={cn("flex w-full min-w-0 flex-col gap-1", className)}
     {...props}
   />
@@ -567,6 +572,13 @@ const SidebarMenuButton = React.forwardRef<
         data-sidebar="menu-button"
         data-size={size}
         data-active={isActive}
+        role="menuitem"
+        onKeyDown={(e: React.KeyboardEvent<HTMLButtonElement>) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            (props.onClick as any)?.(e as any);
+          }
+        }}
         className={cn(sidebarMenuButtonVariants({ variant, size }), className)}
         {...props}
       />
@@ -724,6 +736,14 @@ const SidebarMenuSubButton = React.forwardRef<
       data-sidebar="menu-sub-button"
       data-size={size}
       data-active={isActive}
+      role="menuitem"
+      tabIndex={0}
+      onKeyDown={(e: React.KeyboardEvent<HTMLAnchorElement>) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          (props.onClick as any)?.(e as any);
+        }
+      }}
       className={cn(
         "flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 text-sidebar-foreground outline-none ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0 [&>svg]:text-sidebar-accent-foreground",
         "data-[active=true]:bg-sidebar-accent data-[active=true]:text-sidebar-accent-foreground",


### PR DESCRIPTION
## Summary
- improve sidebar accessibility with navigation roles and keyboard handling
- add `ResponsiveCardGrid` helper and use in plugin pages
- create example unit and integration tests for the web UI
- include testing dependencies and scripts

## Testing
- `pytest tests/test_imports.py::test_imports -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit)*

------
https://chatgpt.com/codex/tasks/task_e_6884696e5e1083248f7fb794eeb0ebc6