### PR TITLE
Add extension migration docs and feature flag

### DIFF
--- a/docs/extension_developer_guide.md
+++ b/docs/extension_developer_guide.md
@@ -1,0 +1,46 @@
+# Extension Developer Guide
+
+This guide summarizes best practices for building extensions that integrate smoothly with the AI Karen platform.
+
+## Project Layout
+
+```
+my-extension/
+├── extension.json         # Manifest
+├── __init__.py           # Extension class
+├── ui/                   # Optional React components
+├── plugins/              # Reused or custom plugins
+└── tests/                # Unit tests
+```
+
+## Key Interfaces
+
+Extensions subclass `ai_karen_engine.extensions.BaseExtension` and may override these hooks:
+
+- `initialize()` – prepare resources and register plugins or UI components.
+- `activate()` – start background tasks or services.
+- `deactivate()` – gracefully shut down and release resources.
+
+Use `ExtensionDataManager` for storing data and `PluginOrchestrator` to run plugins in workflows.
+
+## Example
+
+```python
+from ai_karen_engine.extensions import BaseExtension
+
+class TaskManagerExtension(BaseExtension):
+    async def initialize(self):
+        await self.register_plugins(["task-db", "reminder"])
+
+    async def activate(self):
+        await self.start_background_tasks()
+```
+
+## Testing
+
+Run `pytest` inside the extension directory. Include tests for manifest validation and any background tasks.
+
+## Distribution
+
+Package the extension directory as a zip file and upload it to the marketplace. The manifest version field controls update checks.
+

--- a/docs/extension_management_tutorial.md
+++ b/docs/extension_management_tutorial.md
@@ -1,0 +1,28 @@
+# Extension Management Tutorial
+
+This tutorial walks through enabling and managing extensions in the AI Karen web UI.
+
+1. **Enable the feature flag**
+   
+   Set the environment variable `KAREN_ENABLE_EXTENSIONS=true` before starting the web UI. This will replace the plugin sidebar with the new Extension Manager.
+
+2. **Browse extensions**
+   
+   Open the navigation sidebar and select **Extensions**. Categories and breadcrumbs help you drill down to specific providers, models and settings.
+
+3. **Install from marketplace**
+   
+   Use the "Install" button on any available extension. Dependencies are resolved automatically and the extension becomes active when installation completes.
+
+4. **Configure providers**
+   
+   Select an installed extension to view available providers. Adjust settings such as API keys, model parameters or audio options. Changes are applied immediately.
+
+5. **Monitor health**
+   
+   The stats panel shows CPU, memory and error information. Use this to ensure extensions are running correctly.
+
+6. **Disable or remove**
+   
+   From the extension details page you can disable or completely remove an extension. This triggers shutdown hooks and cleans up any resources.
+

--- a/docs/extension_manager_best_practices.md
+++ b/docs/extension_manager_best_practices.md
@@ -1,0 +1,7 @@
+# Extension Manager Best Practices
+
+- Keep extension categories focused on a single domain.
+- Use breadcrumbs to provide clear navigation back to higher levels.
+- Enable lazy loading for heavy components using `next/dynamic` to reduce bundle size.
+- Monitor resource statistics from the sidebar to detect issues early.
+- Use the feature flag `KAREN_ENABLE_EXTENSIONS` to roll out changes gradually.

--- a/docs/extension_migration.md
+++ b/docs/extension_migration.md
@@ -1,0 +1,49 @@
+# Migrating from Plugins to Extensions
+
+This guide outlines the steps required to move existing plugins to the hierarchical **Extensions System**.
+
+## 1. Review Plugin Functionality
+
+Identify the features provided by each plugin. Extensions can compose multiple plugins so you may merge related functionality under a single extension.
+
+## 2. Create an Extension Manifest
+
+Each extension requires an `extension.json` manifest describing metadata, capabilities and dependencies. See `extensions/README.md` for the manifest schema.
+
+```bash
+mkdir -p extensions/my-extension
+cat > extensions/my-extension/extension.json <<'MANIFEST'
+{
+  "name": "my-extension",
+  "version": "1.0.0",
+  "description": "Migrated example from plugin system",
+  "category": "custom",
+  "dependencies": {"plugins": ["my-plugin"]}
+}
+MANIFEST
+```
+
+## 3. Implement the Extension Class
+
+Create `__init__.py` implementing a subclass of `BaseExtension` and register any existing plugins through the `PluginOrchestrator`.
+
+```python
+from ai_karen_engine.extensions import BaseExtension
+
+class MyExtension(BaseExtension):
+    async def initialize(self):
+        await self.register_plugins(["my-plugin"])  # reuse existing plugin
+```
+
+## 4. Register UI Components
+
+Extensions can provide React components for the Web UI. Add any previous plugin pages under the extension and register them in `initialize()` using the UI manager.
+
+## 5. Update Configuration
+
+Replace old plugin configuration entries with extension names. The extension manager resolves dependencies and handles lifecycle events.
+
+## 6. Validate and Test
+
+Run `pytest tests/test_extension_loading.py` to ensure the extension loads correctly. Existing plugin tests should continue to work when called via the extension interface.
+

--- a/ui_launchers/web_ui/.storybook/main.ts
+++ b/ui_launchers/web_ui/.storybook/main.ts
@@ -1,0 +1,11 @@
+import type { StorybookConfig } from "@storybook/nextjs";
+
+const config: StorybookConfig = {
+  stories: ["../src/**/*.stories.@(ts|tsx)"],
+  addons: ["@storybook/addon-links", "@storybook/addon-essentials"],
+  framework: {
+    name: "@storybook/nextjs",
+    options: {}
+  },
+};
+export default config;

--- a/ui_launchers/web_ui/.storybook/preview.ts
+++ b/ui_launchers/web_ui/.storybook/preview.ts
@@ -1,0 +1,9 @@
+import type { Preview } from "@storybook/react";
+
+const preview: Preview = {
+  parameters: {
+    layout: "centered",
+  },
+};
+
+export default preview;

--- a/ui_launchers/web_ui/package.json
+++ b/ui_launchers/web_ui/package.json
@@ -10,7 +10,8 @@
     "start": "next start -p 3000",
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
-    "test": "vitest"
+    "test": "vitest",
+    "storybook": "storybook dev -p 6006"
   },
   "dependencies": {
     "@genkit-ai/googleai": "^1.8.0",
@@ -68,6 +69,8 @@
     "@testing-library/react": "^14.1.2",
     "@testing-library/user-event": "^14.4.3",
     "jsdom": "^24.0.0",
-    "msw": "^2.0.0"
+    "msw": "^2.0.0",
+    "@storybook/nextjs": "^8.1.0",
+    "@storybook/react": "^8.1.0"
   }
 }

--- a/ui_launchers/web_ui/src/app/page.tsx
+++ b/ui_launchers/web_ui/src/app/page.tsx
@@ -3,6 +3,7 @@
 
 import { useState } from 'react';
 import { Brain, MessageSquare, SettingsIcon as SettingsIconLucide, PanelLeft, Bell, SlidersHorizontal, LayoutGrid, Database, Facebook, BookOpenCheck, Mail, CalendarDays, CloudSun, PlugZap } from 'lucide-react';
+import dynamic from 'next/dynamic';
 import SettingsDialogComponent from '@/components/settings/SettingsDialog';
 import DatabaseConnectorPluginPage from '@/components/plugins/DatabaseConnectorPluginPage';
 import FacebookPluginPage from '@/components/plugins/FacebookPluginPage';
@@ -35,6 +36,9 @@ import {
 import { Separator } from '@/components/ui/separator';
 import NotificationsSection from '@/components/sidebar/NotificationsSection';
 import ChatInterface from '@/components/chat/ChatInterface';
+import { webUIConfig } from '@/lib/config';
+
+const ExtensionSidebar = dynamic(() => import('@/components/extensions/ExtensionSidebar'));
 
 type ActiveView = 'chat' | 'settings' | 'commsCenter' | 'pluginDatabaseConnector' | 'pluginFacebook' | 'pluginGmail' | 'pluginDateTime' | 'pluginWeather' | 'pluginOverview';
 
@@ -70,120 +74,120 @@ export default function HomePage() {
         </header>
 
         <div className="flex flex-1 min-h-0">
-          <Sidebar
-            variant="sidebar"
-            collapsible="icon"
-            className="border-r z-20"
-          >
-            <AppSidebarHeader>
-              <h2 className="text-lg font-semibold tracking-tight px-2 py-1">Navigation</h2>
-            </AppSidebarHeader>
-            <Separator className="my-1" />
-            <AppSidebarContent className="p-2">
-              <SidebarMenu>
-                <SidebarMenuItem>
-                  <SidebarMenuButton
-                    onClick={() => setActiveMainView('chat')}
-                    isActive={activeMainView === 'chat'}
-                    className="w-full"
-                  >
-                    <MessageSquare />
-                    Chat
-                  </SidebarMenuButton>
-                </SidebarMenuItem>
-                <SidebarMenuItem>
-                  <SidebarMenuButton
-                    onClick={() => setActiveMainView('settings')}
-                    isActive={activeMainView === 'settings'}
-                    className="w-full"
-                  >
-                    <SettingsIconLucide />
-                    Settings
-                  </SidebarMenuButton>
-                </SidebarMenuItem>
-                <SidebarMenuItem>
-                   <SidebarMenuButton
-                    onClick={() => setActiveMainView('commsCenter')}
-                    isActive={activeMainView === 'commsCenter'}
-                    className="w-full"
-                  >
-                    <Bell />
-                    Comms Center
-                  </SidebarMenuButton>
-                </SidebarMenuItem>
-              </SidebarMenu>
-
-              <Separator className="my-2" />
-              <SidebarGroup>
-                <SidebarGroupLabel className="text-sm">Plugins</SidebarGroupLabel>
+          {webUIConfig.enableExtensions ? (
+            <ExtensionSidebar />
+          ) : (
+            <Sidebar variant="sidebar" collapsible="icon" className="border-r z-20">
+              <AppSidebarHeader>
+                <h2 className="text-lg font-semibold tracking-tight px-2 py-1">Navigation</h2>
+              </AppSidebarHeader>
+              <Separator className="my-1" />
+              <AppSidebarContent className="p-2">
                 <SidebarMenu>
                   <SidebarMenuItem>
                     <SidebarMenuButton
-                      onClick={() => setActiveMainView('pluginOverview')}
-                      isActive={activeMainView === 'pluginOverview'}
+                      onClick={() => setActiveMainView('chat')}
+                      isActive={activeMainView === 'chat'}
                       className="w-full"
                     >
-                      <PlugZap />
-                      Plugin Overview
+                      <MessageSquare />
+                      Chat
                     </SidebarMenuButton>
                   </SidebarMenuItem>
                   <SidebarMenuItem>
                     <SidebarMenuButton
-                      onClick={() => setActiveMainView('pluginDatabaseConnector')}
-                      isActive={activeMainView === 'pluginDatabaseConnector'}
+                      onClick={() => setActiveMainView('settings')}
+                      isActive={activeMainView === 'settings'}
                       className="w-full"
                     >
-                      <Database />
-                      Database Connector
+                      <SettingsIconLucide />
+                      Settings
                     </SidebarMenuButton>
                   </SidebarMenuItem>
                   <SidebarMenuItem>
                     <SidebarMenuButton
-                      onClick={() => setActiveMainView('pluginFacebook')}
-                      isActive={activeMainView === 'pluginFacebook'}
+                      onClick={() => setActiveMainView('commsCenter')}
+                      isActive={activeMainView === 'commsCenter'}
                       className="w-full"
                     >
-                      <Facebook />
-                      Facebook Integration
-                    </SidebarMenuButton>
-                  </SidebarMenuItem>
-                  <SidebarMenuItem>
-                    <SidebarMenuButton
-                      onClick={() => setActiveMainView('pluginGmail')}
-                      isActive={activeMainView === 'pluginGmail'}
-                      className="w-full"
-                    >
-                      <Mail />
-                      Gmail Integration
-                    </SidebarMenuButton>
-                  </SidebarMenuItem>
-                  <SidebarMenuItem>
-                    <SidebarMenuButton
-                      onClick={() => setActiveMainView('pluginDateTime')}
-                      isActive={activeMainView === 'pluginDateTime'}
-                      className="w-full"
-                    >
-                      <CalendarDays />
-                      Date/Time Service
-                    </SidebarMenuButton>
-                  </SidebarMenuItem>
-                  <SidebarMenuItem>
-                    <SidebarMenuButton
-                      onClick={() => setActiveMainView('pluginWeather')}
-                      isActive={activeMainView === 'pluginWeather'}
-                      className="w-full"
-                    >
-                      <CloudSun />
-                      Weather Service
+                      <Bell />
+                      Comms Center
                     </SidebarMenuButton>
                   </SidebarMenuItem>
                 </SidebarMenu>
-              </SidebarGroup>
-            </AppSidebarContent>
-            <AppSidebarFooter className="p-2 border-t">
-              <p className="text-xs text-muted-foreground text-center">Karen AI Menu</p>
-            </AppSidebarFooter>
-          </Sidebar>
+
+                <Separator className="my-2" />
+                <SidebarGroup>
+                  <SidebarGroupLabel className="text-sm">Plugins</SidebarGroupLabel>
+                  <SidebarMenu>
+                    <SidebarMenuItem>
+                      <SidebarMenuButton
+                        onClick={() => setActiveMainView('pluginOverview')}
+                        isActive={activeMainView === 'pluginOverview'}
+                        className="w-full"
+                      >
+                        <PlugZap />
+                        Plugin Overview
+                      </SidebarMenuButton>
+                    </SidebarMenuItem>
+                    <SidebarMenuItem>
+                      <SidebarMenuButton
+                        onClick={() => setActiveMainView('pluginDatabaseConnector')}
+                        isActive={activeMainView === 'pluginDatabaseConnector'}
+                        className="w-full"
+                      >
+                        <Database />
+                        Database Connector
+                      </SidebarMenuButton>
+                    </SidebarMenuItem>
+                    <SidebarMenuItem>
+                      <SidebarMenuButton
+                        onClick={() => setActiveMainView('pluginFacebook')}
+                        isActive={activeMainView === 'pluginFacebook'}
+                        className="w-full"
+                      >
+                        <Facebook />
+                        Facebook Integration
+                      </SidebarMenuButton>
+                    </SidebarMenuItem>
+                    <SidebarMenuItem>
+                      <SidebarMenuButton
+                        onClick={() => setActiveMainView('pluginGmail')}
+                        isActive={activeMainView === 'pluginGmail'}
+                        className="w-full"
+                      >
+                        <Mail />
+                        Gmail Integration
+                      </SidebarMenuButton>
+                    </SidebarMenuItem>
+                    <SidebarMenuItem>
+                      <SidebarMenuButton
+                        onClick={() => setActiveMainView('pluginDateTime')}
+                        isActive={activeMainView === 'pluginDateTime'}
+                        className="w-full"
+                      >
+                        <CalendarDays />
+                        Date/Time Service
+                      </SidebarMenuButton>
+                    </SidebarMenuItem>
+                    <SidebarMenuItem>
+                      <SidebarMenuButton
+                        onClick={() => setActiveMainView('pluginWeather')}
+                        isActive={activeMainView === 'pluginWeather'}
+                        className="w-full"
+                      >
+                        <CloudSun />
+                        Weather Service
+                      </SidebarMenuButton>
+                    </SidebarMenuItem>
+                  </SidebarMenu>
+                </SidebarGroup>
+              </AppSidebarContent>
+              <AppSidebarFooter className="p-2 border-t">
+                <p className="text-xs text-muted-foreground text-center">Karen AI Menu</p>
+              </AppSidebarFooter>
+            </Sidebar>
+          )}
 
           <SidebarInset className="flex-1 flex flex-col min-h-0">
             <main className="flex-1 flex flex-col min-h-0 p-4 md:p-6 overflow-y-auto">

--- a/ui_launchers/web_ui/src/components/extensions/ExtensionBreadcrumbs.tsx
+++ b/ui_launchers/web_ui/src/components/extensions/ExtensionBreadcrumbs.tsx
@@ -1,3 +1,8 @@
+/**
+ * Breadcrumb navigation for the Extension Manager sidebar.
+ * Displays the current hierarchy path and allows quick navigation
+ * back to a parent level.
+ */
 "use client";
 
 import React from 'react';

--- a/ui_launchers/web_ui/src/components/extensions/ExtensionSidebar.stories.tsx
+++ b/ui_launchers/web_ui/src/components/extensions/ExtensionSidebar.stories.tsx
@@ -1,0 +1,14 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import ExtensionSidebar from "./ExtensionSidebar";
+
+const meta: Meta<typeof ExtensionSidebar> = {
+  title: "Extensions/ExtensionSidebar",
+  component: ExtensionSidebar,
+};
+export default meta;
+
+type Story = StoryObj<typeof ExtensionSidebar>;
+
+export const Default: Story = {
+  render: () => <ExtensionSidebar />,
+};

--- a/ui_launchers/web_ui/src/extensions/ExtensionContext.tsx
+++ b/ui_launchers/web_ui/src/extensions/ExtensionContext.tsx
@@ -1,3 +1,6 @@
+/**
+ * React context and provider for extension navigation state.
+ */
 "use client";
 
 import React, { createContext, useContext, useReducer } from 'react';

--- a/ui_launchers/web_ui/src/extensions/types.ts
+++ b/ui_launchers/web_ui/src/extensions/types.ts
@@ -1,21 +1,26 @@
+/** Types used by the Extension Manager React context */
 export type ExtensionCategory = 'Plugins' | 'Extensions';
 
+/** Identifier and label for navigation items */
 export interface BaseNavigationItem {
   id: string;
   name: string;
   description?: string;
 }
 
+/** Breadcrumb displayed in the sidebar UI */
 export interface BreadcrumbItem {
   id: string;
   label: string;
 }
+/** State stored in ExtensionContext */
 
 export interface ExtensionState {
   currentCategory: ExtensionCategory;
   breadcrumbs: BreadcrumbItem[];
   level: number;
 }
+/** Actions that mutate ExtensionState */
 
 export type ExtensionAction =
   | { type: 'SET_CATEGORY'; category: ExtensionCategory }

--- a/ui_launchers/web_ui/src/lib/config.ts
+++ b/ui_launchers/web_ui/src/lib/config.ts
@@ -23,6 +23,7 @@ export interface WebUIConfig {
   enableMemory: boolean;
   enableExperimentalFeatures: boolean;
   enableVoice: boolean;
+  enableExtensions: boolean;
 
   // Health checks
   healthCheckInterval: number;
@@ -85,6 +86,7 @@ export function getWebUIConfig(): WebUIConfig {
     enableMemory: parseBooleanEnv(process.env.KAREN_ENABLE_MEMORY, true),
     enableExperimentalFeatures: parseBooleanEnv(process.env.KAREN_ENABLE_EXPERIMENTAL_FEATURES, false),
     enableVoice: parseBooleanEnv(process.env.KAREN_ENABLE_VOICE, false),
+    enableExtensions: parseBooleanEnv(process.env.KAREN_ENABLE_EXTENSIONS, false),
 
     // Health checks
     healthCheckInterval: parseNumberEnv(process.env.KAREN_HEALTH_CHECK_INTERVAL, 30000),
@@ -177,6 +179,7 @@ export function logConfigInfo(config: WebUIConfig): void {
     memory: config.enableMemory,
     experimental: config.enableExperimentalFeatures,
     voice: config.enableVoice,
+    extensions: config.enableExtensions,
   });
   console.log('Health Checks:', {
     enabled: config.enableHealthChecks,


### PR DESCRIPTION
## Summary
- document how to migrate plugins to extensions and how to manage them
- add developer and best-practices guides for extensions
- set up Storybook with a sample ExtensionSidebar story
- document extension feature flag and add lazy-loaded ExtensionSidebar
- add `enableExtensions` flag in configuration

## Testing
- `pytest -k extension_manager -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68846b3d3f5c83249ed0ce51bc2f73b2