### PR TITLE
Implement ExtensionSidebar component props

### DIFF
--- a/ui_launchers/web_ui/src/components/extensions/ExtensionSidebar.stories.tsx
+++ b/ui_launchers/web_ui/src/components/extensions/ExtensionSidebar.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import ExtensionSidebar from "./ExtensionSidebar";
+import type { ExtensionSidebarProps } from "./ExtensionSidebar";
 
 const meta: Meta<typeof ExtensionSidebar> = {
   title: "Extensions/ExtensionSidebar",
@@ -10,5 +11,10 @@ export default meta;
 type Story = StoryObj<typeof ExtensionSidebar>;
 
 export const Default: Story = {
-  render: () => <ExtensionSidebar />,
+  render: (args: ExtensionSidebarProps) => (
+    <ExtensionSidebar {...args} />
+  ),
+  args: {
+    initialCategory: "Plugins",
+  },
 };

--- a/ui_launchers/web_ui/src/components/extensions/ExtensionSidebar.tsx
+++ b/ui_launchers/web_ui/src/components/extensions/ExtensionSidebar.tsx
@@ -8,6 +8,7 @@ import {
   SidebarHeader,
   SidebarContent,
   SidebarFooter,
+  SidebarRail,
 } from "@/components/ui/sidebar";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Button } from "@/components/ui/button";
@@ -17,6 +18,14 @@ import ExtensionStats from "./ExtensionStats";
 import { useExtensionContext, ExtensionProvider } from "@/extensions";
 import { ErrorBoundary } from "@/components/ui/error-boundary";
 
+export interface ExtensionSidebarProps {
+  /**
+   * Initial category displayed when the sidebar mounts.
+   * Defaults to `"Plugins"`.
+   */
+  initialCategory?: "Plugins" | "Extensions";
+}
+
 function SidebarInner() {
   const {
     state: { currentCategory, level },
@@ -24,12 +33,14 @@ function SidebarInner() {
   } = useExtensionContext();
 
   return (
-    <Sidebar variant="sidebar" collapsible="icon" className="border-r z-20">
-      <SidebarHeader className="space-y-2">
-        <div className="flex items-center justify-between">
-          <h2 className="text-lg font-semibold">Extension Manager</h2>
-          <SidebarTrigger />
-        </div>
+    <>
+      <SidebarRail />
+      <Sidebar variant="sidebar" collapsible="icon" className="border-r z-20">
+        <SidebarHeader className="space-y-2">
+          <div className="flex items-center justify-between">
+            <h2 className="text-lg font-semibold">Extension Manager</h2>
+            <SidebarTrigger />
+          </div>
         <Tabs
           value={currentCategory}
           onValueChange={(val) =>
@@ -63,14 +74,17 @@ function SidebarInner() {
           Extension Manager
         </p>
       </SidebarFooter>
-    </Sidebar>
+      </Sidebar>
+    </>
   );
 }
 
-export default function ExtensionSidebar() {
+export default function ExtensionSidebar({
+  initialCategory = "Plugins",
+}: ExtensionSidebarProps) {
   return (
     <ErrorBoundary>
-      <ExtensionProvider>
+      <ExtensionProvider initialCategory={initialCategory}>
         <SidebarProvider>
           <SidebarInner />
         </SidebarProvider>

--- a/ui_launchers/web_ui/src/components/extensions/index.ts
+++ b/ui_launchers/web_ui/src/components/extensions/index.ts
@@ -1,5 +1,6 @@
 export { default as ExtensionBreadcrumbs } from './ExtensionBreadcrumbs';
 export { default as ExtensionSidebar } from './ExtensionSidebar';
+export type { ExtensionSidebarProps } from './ExtensionSidebar';
 export { default as ExtensionStats } from './ExtensionStats';
 export * from './plugins';
 export { default as AgentList } from './automation/AgentList';


### PR DESCRIPTION
## Summary
- allow `ExtensionSidebar` to accept `initialCategory`
- export `ExtensionSidebarProps` for consumers
- add SidebarRail handle and update storybook example

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden - registry access blocked)*
- `PYTHONPATH=src pytest tests/test_extension_discovery.py::test_extension_discovery -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_688477da806883249a96dd3c1291d8c5