### PR TITLE
Add extension sidebar header and stats

### DIFF
--- a/ui_launchers/web_ui/src/components/extensions/ExtensionHeader.tsx
+++ b/ui_launchers/web_ui/src/components/extensions/ExtensionHeader.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import React from "react";
+import {
+  SidebarHeader,
+  SidebarTrigger,
+} from "@/components/ui/sidebar";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Button } from "@/components/ui/button";
+import { ArrowLeft } from "lucide-react";
+import ExtensionBreadcrumbs from "./ExtensionBreadcrumbs";
+import ExtensionStats from "./ExtensionStats";
+import { useExtensionContext } from "@/extensions";
+
+export default function ExtensionHeader() {
+  const {
+    state: { currentCategory, level },
+    dispatch,
+  } = useExtensionContext();
+
+  return (
+    <SidebarHeader className="space-y-2">
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-semibold">Extension Manager</h2>
+        <SidebarTrigger />
+      </div>
+      <Tabs
+        value={currentCategory}
+        onValueChange={(val) => dispatch({ type: "SET_CATEGORY", category: val as any })}
+        className="w-full"
+      >
+        <TabsList className="grid w-full grid-cols-2">
+          <TabsTrigger value="Plugins">Plugins</TabsTrigger>
+          <TabsTrigger value="Extensions">Extensions</TabsTrigger>
+        </TabsList>
+      </Tabs>
+      {level > 0 && (
+        <Button
+          variant="ghost"
+          size="sm"
+          className="px-1 gap-1 h-6"
+          onClick={() => dispatch({ type: "GO_BACK" })}
+        >
+          <ArrowLeft className="h-3 w-3" /> Back
+        </Button>
+      )}
+      <ExtensionBreadcrumbs />
+      <ExtensionStats />
+    </SidebarHeader>
+  );
+}

--- a/ui_launchers/web_ui/src/components/extensions/ExtensionSidebar.tsx
+++ b/ui_launchers/web_ui/src/components/extensions/ExtensionSidebar.tsx
@@ -4,18 +4,12 @@ import React from "react";
 import {
   Sidebar,
   SidebarProvider,
-  SidebarTrigger,
-  SidebarHeader,
   SidebarContent,
   SidebarFooter,
   SidebarRail,
 } from "@/components/ui/sidebar";
-import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { Button } from "@/components/ui/button";
-import { ArrowLeft } from "lucide-react";
-import ExtensionBreadcrumbs from "./ExtensionBreadcrumbs";
-import ExtensionStats from "./ExtensionStats";
-import { useExtensionContext, ExtensionProvider } from "@/extensions";
+import ExtensionHeader from "./ExtensionHeader";
+import { ExtensionProvider } from "@/extensions";
 import { ErrorBoundary } from "@/components/ui/error-boundary";
 
 export interface ExtensionSidebarProps {
@@ -27,45 +21,11 @@ export interface ExtensionSidebarProps {
 }
 
 function SidebarInner() {
-  const {
-    state: { currentCategory, level },
-    dispatch,
-  } = useExtensionContext();
-
   return (
     <>
       <SidebarRail />
       <Sidebar variant="sidebar" collapsible="icon" className="border-r z-20">
-        <SidebarHeader className="space-y-2">
-          <div className="flex items-center justify-between">
-            <h2 className="text-lg font-semibold">Extension Manager</h2>
-            <SidebarTrigger />
-          </div>
-        <Tabs
-          value={currentCategory}
-          onValueChange={(val) =>
-            dispatch({ type: "SET_CATEGORY", category: val as any })
-          }
-          className="w-full"
-        >
-          <TabsList className="grid w-full grid-cols-2">
-            <TabsTrigger value="Plugins">Plugins</TabsTrigger>
-            <TabsTrigger value="Extensions">Extensions</TabsTrigger>
-          </TabsList>
-        </Tabs>
-        {level > 0 && (
-          <Button
-            variant="ghost"
-            size="sm"
-            className="px-1 gap-1 h-6"
-            onClick={() => dispatch({ type: "GO_BACK" })}
-          >
-            <ArrowLeft className="h-3 w-3" /> Back
-          </Button>
-        )}
-        <ExtensionBreadcrumbs />
-        <ExtensionStats />
-      </SidebarHeader>
+        <ExtensionHeader />
       <SidebarContent className="p-2 space-y-2">
         {/* Navigation items will be added in future tasks */}
       </SidebarContent>

--- a/ui_launchers/web_ui/src/components/extensions/README.md
+++ b/ui_launchers/web_ui/src/components/extensions/README.md
@@ -140,6 +140,9 @@ Category (Plugins/Extensions)
 - Shared components for common functionality
 - Category-specific components
 - Responsive design with Shadcn/ui integration
+- Sidebar header with toggle button
+- Stats overview for plugins and extensions
+- Breadcrumb navigation component
 
 ## Usage
 

--- a/ui_launchers/web_ui/src/components/extensions/core/index.ts
+++ b/ui_launchers/web_ui/src/components/extensions/core/index.ts
@@ -1,11 +1,5 @@
 // Core extension management components
-// TODO: Add core components when implemented
-// export * from './ExtensionProvider';
-// export * from './ExtensionSidebar';
-// export * from './ExtensionHeader';
-// export * from './ExtensionStats';
-// export * from './ExtensionBreadcrumb';
-// export * from './ExtensionContent';
-
-// Placeholder export to make this a valid module
-export const CORE_COMPONENTS_PLACEHOLDER = 'core-components-not-implemented';
+export * from '../ExtensionHeader';
+export * from '../ExtensionSidebar';
+export * from '../ExtensionStats';
+export * from '../ExtensionBreadcrumbs';

--- a/ui_launchers/web_ui/src/components/extensions/index.ts
+++ b/ui_launchers/web_ui/src/components/extensions/index.ts
@@ -3,6 +3,7 @@ export { default as ExtensionBreadcrumbs } from './ExtensionBreadcrumbs';
 export { default as ExtensionSidebar } from './ExtensionSidebar';
 export type { ExtensionSidebarProps } from './ExtensionSidebar';
 export { default as ExtensionStats } from './ExtensionStats';
+export { default as ExtensionHeader } from './ExtensionHeader';
 export { default as ExtensionSettingsPanel } from './ExtensionSettingsPanel';
 export { default as ExtensionControls } from './ExtensionControls';
 


### PR DESCRIPTION
## Summary
- create `ExtensionHeader` for sidebar title and navigation controls
- refactor `ExtensionSidebar` to use new header component
- export header from component indexes
- document header, stats and breadcrumb components

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68847aba9a288324ba8c55a9df8f7594