### PR TITLE
Add instructions for installing dependencies before tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -520,6 +520,12 @@ node --version  # Should be 18+
 
 ### Testing
 
+Install project dependencies before running tests:
+
+```bash
+pip install -r requirements.txt
+```
+
 ```bash
 # Run all tests
 pytest


### PR DESCRIPTION
## Summary
- add a testing setup snippet in README

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68847d15fbe083249cd6b68a51f0c18b