### PR TITLE
Implement extension core components

### DIFF
--- a/ui_launchers/web_ui/src/components/extensions/README.md
+++ b/ui_launchers/web_ui/src/components/extensions/README.md
@@ -147,12 +147,18 @@ Category (Plugins/Extensions)
 
 ```tsx
 import { ExtensionProvider } from '@/extensions';
-import { ExtensionSidebar } from '@/components/extensions';
+import { ExtensionSidebar, ExtensionHeader, ExtensionContent } from '@/components/extensions';
 
 function App() {
   return (
     <ExtensionProvider initialCategory="Plugins">
-      <ExtensionSidebar />
+      <div className="flex">
+        <ExtensionSidebar />
+        <main className="flex-1">
+          <ExtensionHeader title="Extension Manager" />
+          <ExtensionContent>{/* extension views */}</ExtensionContent>
+        </main>
+      </div>
     </ExtensionProvider>
   );
 }

--- a/ui_launchers/web_ui/src/components/extensions/core/ExtensionBreadcrumb.tsx
+++ b/ui_launchers/web_ui/src/components/extensions/core/ExtensionBreadcrumb.tsx
@@ -1,0 +1,1 @@
+export { default } from '../ExtensionBreadcrumbs';

--- a/ui_launchers/web_ui/src/components/extensions/core/ExtensionContent.tsx
+++ b/ui_launchers/web_ui/src/components/extensions/core/ExtensionContent.tsx
@@ -1,0 +1,11 @@
+"use client";
+import React from 'react';
+
+export interface ExtensionContentProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export default function ExtensionContent({ children, className }: ExtensionContentProps) {
+  return <div className={className ?? 'p-2 space-y-2'}>{children}</div>;
+}

--- a/ui_launchers/web_ui/src/components/extensions/core/ExtensionHeader.tsx
+++ b/ui_launchers/web_ui/src/components/extensions/core/ExtensionHeader.tsx
@@ -1,0 +1,21 @@
+"use client";
+import React from 'react';
+import { useExtensionContext } from '../../extensions';
+
+export interface ExtensionHeaderProps {
+  /** Optional custom title. Defaults to current category */
+  title?: string;
+}
+
+export default function ExtensionHeader({ title }: ExtensionHeaderProps) {
+  const {
+    state: { currentCategory },
+  } = useExtensionContext();
+  return (
+    <header className="p-2 border-b">
+      <h2 className="text-lg font-semibold tracking-tight">
+        {title ?? currentCategory}
+      </h2>
+    </header>
+  );
+}

--- a/ui_launchers/web_ui/src/components/extensions/core/ExtensionProvider.tsx
+++ b/ui_launchers/web_ui/src/components/extensions/core/ExtensionProvider.tsx
@@ -1,0 +1,1 @@
+export { ExtensionProvider } from '../../extensions';

--- a/ui_launchers/web_ui/src/components/extensions/core/ExtensionSidebar.tsx
+++ b/ui_launchers/web_ui/src/components/extensions/core/ExtensionSidebar.tsx
@@ -1,0 +1,1 @@
+export { default, type ExtensionSidebarProps } from '../ExtensionSidebar';

--- a/ui_launchers/web_ui/src/components/extensions/core/ExtensionStats.tsx
+++ b/ui_launchers/web_ui/src/components/extensions/core/ExtensionStats.tsx
@@ -1,0 +1,1 @@
+export { default } from '../ExtensionStats';

--- a/ui_launchers/web_ui/src/components/extensions/core/index.ts
+++ b/ui_launchers/web_ui/src/components/extensions/core/index.ts
@@ -1,11 +1,7 @@
 // Core extension management components
-// TODO: Add core components when implemented
-// export * from './ExtensionProvider';
-// export * from './ExtensionSidebar';
-// export * from './ExtensionHeader';
-// export * from './ExtensionStats';
-// export * from './ExtensionBreadcrumb';
-// export * from './ExtensionContent';
-
-// Placeholder export to make this a valid module
-export const CORE_COMPONENTS_PLACEHOLDER = 'core-components-not-implemented';
+export { ExtensionProvider } from './ExtensionProvider';
+export { default as ExtensionSidebar, type ExtensionSidebarProps } from './ExtensionSidebar';
+export { default as ExtensionHeader, type ExtensionHeaderProps } from './ExtensionHeader';
+export { default as ExtensionStats } from './ExtensionStats';
+export { default as ExtensionBreadcrumb } from './ExtensionBreadcrumb';
+export { default as ExtensionContent, type ExtensionContentProps } from './ExtensionContent';

--- a/ui_launchers/web_ui/src/components/extensions/marketplace/index.ts
+++ b/ui_launchers/web_ui/src/components/extensions/marketplace/index.ts
@@ -1,11 +1,1 @@
-// Extension marketplace components
-// TODO: Add marketplace components when implemented
-// export * from './ExtensionStore';
-// export * from './ExtensionSearch';
-// export * from './ExtensionFilters';
-// export * from './ExtensionInstaller';
-// export * from './ExtensionRating';
-// export * from './ExtensionReviews';
-
-// Placeholder export to make this a valid module
-export const MARKETPLACE_COMPONENTS_PLACEHOLDER = 'marketplace-components-not-implemented';
+// Extension marketplace components will be added in future revisions.

--- a/ui_launchers/web_ui/src/components/extensions/plugins/models/index.ts
+++ b/ui_launchers/web_ui/src/components/extensions/plugins/models/index.ts
@@ -1,10 +1,2 @@
 // Plugin model components
-// TODO: Add model components when implemented
-// export * from './LLMModelList';
-// export * from './VoiceModelList';
-// export * from './VideoModelList';
-// export * from './ModelConfigPanel';
-// export * from './ModelMetrics';
-
-// Placeholder export to make this a valid module
-export const MODEL_COMPONENTS_PLACEHOLDER = 'model-components-not-implemented';
+export { default as LLMModelConfigPanel } from '../LLMModelConfigPanel';

--- a/ui_launchers/web_ui/src/components/extensions/plugins/providers/index.ts
+++ b/ui_launchers/web_ui/src/components/extensions/plugins/providers/index.ts
@@ -1,11 +1,4 @@
 // Plugin provider components
-// TODO: Add provider components when implemented
-// export * from './LLMProviderList';
-// export * from './VoiceProviderList';
-// export * from './VideoProviderList';
-// export * from './ServiceProviderList';
-// export * from './ProviderCard';
-// export * from './ModelCard';
-
-// Placeholder export to make this a valid module
-export const PROVIDER_COMPONENTS_PLACEHOLDER = 'provider-components-not-implemented';
+export { default as LLMProviderList } from '../LLMProviderList';
+export { default as VoiceProviderList } from '../VoiceProviderList';
+export { default as VideoProviderList } from '../VideoProviderList';

--- a/ui_launchers/web_ui/src/components/extensions/shared/index.ts
+++ b/ui_launchers/web_ui/src/components/extensions/shared/index.ts
@@ -1,12 +1,3 @@
 // Shared extension components
-// TODO: Add shared components when implemented
-// export * from './ExtensionCard';
-// export * from './ExtensionControls';
-// export * from './ExtensionSettings';
-// export * from './HealthIndicator';
-// export * from './ResourceUsage';
-// export * from './PermissionManager';
-// export * from './ErrorBoundary';
-
-// Placeholder export to make this a valid module
-export const SHARED_COMPONENTS_PLACEHOLDER = 'shared-components-not-implemented';
+export { default as ExtensionControls } from '../ExtensionControls';
+export { default as ExtensionSettingsPanel } from '../ExtensionSettingsPanel';

--- a/ui_launchers/web_ui/src/components/extensions/system/categories/index.ts
+++ b/ui_launchers/web_ui/src/components/extensions/system/categories/index.ts
@@ -1,12 +1,1 @@
-// System extension category components
-// TODO: Add category components when implemented
-// export * from './AnalyticsExtensions';
-// export * from './CommunicationExtensions';
-// export * from './DevelopmentExtensions';
-// export * from './IntegrationExtensions';
-// export * from './ProductivityExtensions';
-// export * from './SecurityExtensions';
-// export * from './ExperimentalExtensions';
-
-// Placeholder export to make this a valid module
-export const CATEGORY_COMPONENTS_PLACEHOLDER = 'category-components-not-implemented';
+// System extension category components will be implemented later.


### PR DESCRIPTION
## Summary
- add Extension core component wrappers and export them
- export shared and provider components
- clean up placeholder exports and update documentation snippet

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68847d08c28083249015f99a2e790010