### PR TITLE
Implement provider registries

### DIFF
--- a/src/ai_karen_engine/integrations/__init__.py
+++ b/src/ai_karen_engine/integrations/__init__.py
@@ -3,5 +3,27 @@
 from ai_karen_engine.integrations.automation_manager import AutomationManager
 from ai_karen_engine.integrations.local_rpa_client import LocalRPAClient
 from ai_karen_engine.integrations.llm_router import LLMProfileRouter
+from ai_karen_engine.integrations.voice_registry import (
+    VoiceRegistry,
+    get_voice_registry,
+)
+from ai_karen_engine.integrations.video_registry import (
+    VideoRegistry,
+    get_video_registry,
+)
+from ai_karen_engine.integrations.provider_registry import (
+    ProviderRegistry,
+    ModelInfo,
+)
 
-__all__ = ["AutomationManager", "LocalRPAClient", "LLMProfileRouter"]
+__all__ = [
+    "AutomationManager",
+    "LocalRPAClient",
+    "LLMProfileRouter",
+    "ProviderRegistry",
+    "ModelInfo",
+    "VoiceRegistry",
+    "get_voice_registry",
+    "VideoRegistry",
+    "get_video_registry",
+]

--- a/src/ai_karen_engine/integrations/provider_registry.py
+++ b/src/ai_karen_engine/integrations/provider_registry.py
@@ -1,0 +1,79 @@
+"""Generic provider registry for hierarchical extension management."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Type
+
+
+@dataclass
+class ModelInfo:
+    """Information about a specific model or service offered by a provider."""
+
+    name: str
+    description: str = ""
+    capabilities: List[str] = field(default_factory=list)
+    default_settings: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class ProviderRegistration:
+    """Registration record for a provider."""
+
+    name: str
+    provider_class: Type[Any]
+    description: str = ""
+    models: List[ModelInfo] = field(default_factory=list)
+    requires_api_key: bool = False
+    default_model: Optional[str] = None
+
+
+class ProviderRegistry:
+    """Simple registry for extension providers."""
+
+    def __init__(self) -> None:
+        self._registrations: Dict[str, ProviderRegistration] = {}
+        self._instances: Dict[str, Any] = {}
+
+    def register_provider(
+        self,
+        name: str,
+        provider_class: Type[Any],
+        *,
+        description: str = "",
+        models: Optional[List[ModelInfo]] = None,
+        requires_api_key: bool = False,
+        default_model: Optional[str] = None,
+    ) -> None:
+        """Register a provider with optional models."""
+        self._registrations[name] = ProviderRegistration(
+            name=name,
+            provider_class=provider_class,
+            description=description,
+            models=models or [],
+            requires_api_key=requires_api_key,
+            default_model=default_model,
+        )
+
+    def get_provider(self, name: str, **init_kwargs: Any) -> Optional[Any]:
+        """Get or create an instance of a provider."""
+        reg = self._registrations.get(name)
+        if not reg:
+            return None
+        if name not in self._instances:
+            if reg.default_model and "model" not in init_kwargs:
+                init_kwargs["model"] = reg.default_model
+            self._instances[name] = reg.provider_class(**init_kwargs)
+        return self._instances[name]
+
+    def list_providers(self) -> List[str]:
+        """Return the list of registered provider names."""
+        return list(self._registrations.keys())
+
+    def list_models(self, provider_name: str) -> List[str]:
+        """List available models for a provider."""
+        reg = self._registrations.get(provider_name)
+        if not reg:
+            return []
+        return [m.name for m in reg.models]
+

--- a/src/ai_karen_engine/integrations/video_registry.py
+++ b/src/ai_karen_engine/integrations/video_registry.py
@@ -1,0 +1,28 @@
+"""Registry for video and visual AI providers."""
+
+from __future__ import annotations
+
+from .provider_registry import ModelInfo, ProviderRegistry
+
+
+class VideoRegistry(ProviderRegistry):
+    """Manage image and video generation providers."""
+
+    def register_default_providers(self) -> None:
+        """Hook to register built-in visual providers."""
+        # Placeholder for future built-in providers
+        pass
+
+
+_video_registry: VideoRegistry | None = None
+
+
+def get_video_registry() -> VideoRegistry:
+    """Get or create the global video registry."""
+    global _video_registry
+    if _video_registry is None:
+        _video_registry = VideoRegistry()
+        _video_registry.register_default_providers()
+    return _video_registry
+
+__all__ = ["ModelInfo", "VideoRegistry", "get_video_registry"]

--- a/src/ai_karen_engine/integrations/voice_registry.py
+++ b/src/ai_karen_engine/integrations/voice_registry.py
@@ -1,0 +1,29 @@
+"""Registry for voice and audio providers."""
+
+from __future__ import annotations
+
+from .provider_registry import ModelInfo, ProviderRegistry
+
+
+class VoiceRegistry(ProviderRegistry):
+    """Manage text-to-speech and speech-to-text providers."""
+
+    def register_default_providers(self) -> None:
+        """Hook to register built-in voice providers."""
+        # Placeholder for future built-in providers
+        pass
+
+
+# Global registry instance
+_voice_registry: VoiceRegistry | None = None
+
+
+def get_voice_registry() -> VoiceRegistry:
+    """Get or create the global voice registry."""
+    global _voice_registry
+    if _voice_registry is None:
+        _voice_registry = VoiceRegistry()
+        _voice_registry.register_default_providers()
+    return _voice_registry
+
+__all__ = ["ModelInfo", "VoiceRegistry", "get_voice_registry"]

--- a/tests/test_provider_registry.py
+++ b/tests/test_provider_registry.py
@@ -1,0 +1,27 @@
+from ai_karen_engine.integrations.provider_registry import (
+    ProviderRegistry,
+    ModelInfo,
+)
+
+
+class DummyProvider:
+    def __init__(self, model: str = "base") -> None:
+        self.model = model
+
+
+def test_register_and_get_provider():
+    registry = ProviderRegistry()
+    registry.register_provider(
+        "dummy",
+        DummyProvider,
+        description="test",
+        models=[ModelInfo(name="base")],
+        default_model="base",
+    )
+
+    provider = registry.get_provider("dummy")
+    assert isinstance(provider, DummyProvider)
+    assert provider.model == "base"
+    assert registry.list_providers() == ["dummy"]
+    assert registry.list_models("dummy") == ["base"]
+


### PR DESCRIPTION
## Summary
- add a generic `ProviderRegistry` with `ModelInfo`
- implement `VoiceRegistry` and `VideoRegistry`
- expose registries via the integrations package
- test basic provider registration

## Testing
- `ruff check src/ai_karen_engine/integrations/provider_registry.py`
- `ruff check src/ai_karen_engine/integrations/voice_registry.py`
- `ruff check src/ai_karen_engine/integrations/video_registry.py`
- `ruff check tests/test_provider_registry.py`
- `pytest tests/test_provider_registry.py -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68847afd12588324b18097a7ddfe2abb