### PR TITLE
Add provider hierarchy module with default registries

### DIFF
--- a/src/ai_karen_engine/integrations/__init__.py
+++ b/src/ai_karen_engine/integrations/__init__.py
@@ -6,10 +6,14 @@ from ai_karen_engine.integrations.llm_router import LLMProfileRouter
 from ai_karen_engine.integrations.voice_registry import (
     VoiceRegistry,
     get_voice_registry,
+    VoiceProviderBase,
+    DummyVoiceProvider,
 )
 from ai_karen_engine.integrations.video_registry import (
     VideoRegistry,
     get_video_registry,
+    VideoProviderBase,
+    DummyVideoProvider,
 )
 from ai_karen_engine.integrations.provider_registry import (
     ProviderRegistry,
@@ -23,7 +27,11 @@ __all__ = [
     "ProviderRegistry",
     "ModelInfo",
     "VoiceRegistry",
+    "VoiceProviderBase",
+    "DummyVoiceProvider",
     "get_voice_registry",
     "VideoRegistry",
+    "VideoProviderBase",
+    "DummyVideoProvider",
     "get_video_registry",
 ]

--- a/src/ai_karen_engine/integrations/provider_hierarchy.py
+++ b/src/ai_karen_engine/integrations/provider_hierarchy.py
@@ -1,0 +1,30 @@
+"""Utilities for building hierarchical provider information."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from ai_karen_engine.integrations.llm_registry import get_registry as get_llm_registry
+from ai_karen_engine.integrations.voice_registry import get_voice_registry
+from ai_karen_engine.integrations.video_registry import get_video_registry
+
+
+def get_provider_hierarchy() -> Dict[str, List[Dict[str, Any]]]:
+    """Return hierarchical provider->model information for UI consumption."""
+    hierarchy: Dict[str, List[Dict[str, Any]]] = {"llm": [], "voice": [], "video": []}
+
+    llm_reg = get_llm_registry()
+    for name in llm_reg.list_providers():
+        hierarchy["llm"].append({"name": name, "models": llm_reg.list_models(name)})
+
+    voice_reg = get_voice_registry()
+    for name in voice_reg.list_providers():
+        hierarchy["voice"].append({"name": name, "models": voice_reg.list_models(name)})
+
+    video_reg = get_video_registry()
+    for name in video_reg.list_providers():
+        hierarchy["video"].append({"name": name, "models": video_reg.list_models(name)})
+
+    return hierarchy
+
+__all__ = ["get_provider_hierarchy"]

--- a/src/ai_karen_engine/integrations/video_providers.py
+++ b/src/ai_karen_engine/integrations/video_providers.py
@@ -1,0 +1,40 @@
+"""Base classes and example providers for video and visual integrations."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+
+class VideoProviderBase:
+    """Base interface for image or video generation providers."""
+
+    def __init__(self, model: str | None = None) -> None:
+        self.model = model or "default"
+
+    def generate_image(self, prompt: str, **kwargs: Any) -> bytes:  # pragma: no cover - abstract
+        """Generate an image from a prompt."""
+        raise NotImplementedError
+
+    def generate_video(self, prompt: str, **kwargs: Any) -> bytes:  # pragma: no cover - abstract
+        """Generate a video from a prompt."""
+        raise NotImplementedError
+
+    def available_models(self) -> List[str]:
+        return [self.model]
+
+
+class DummyVideoProvider(VideoProviderBase):
+    """Placeholder provider used for demos and tests."""
+
+    def generate_image(self, prompt: str, **kwargs: Any) -> bytes:
+        return f"IMAGE:{prompt}".encode()
+
+    def generate_video(self, prompt: str, **kwargs: Any) -> bytes:
+        return f"VIDEO:{prompt}".encode()
+
+
+__all__ = [
+    "VideoProviderBase",
+    "DummyVideoProvider",
+]
+

--- a/src/ai_karen_engine/integrations/video_registry.py
+++ b/src/ai_karen_engine/integrations/video_registry.py
@@ -3,15 +3,22 @@
 from __future__ import annotations
 
 from .provider_registry import ModelInfo, ProviderRegistry
+from .video_providers import DummyVideoProvider, VideoProviderBase
 
 
 class VideoRegistry(ProviderRegistry):
     """Manage image and video generation providers."""
 
     def register_default_providers(self) -> None:
-        """Hook to register built-in visual providers."""
-        # Placeholder for future built-in providers
-        pass
+        """Register built-in visual providers."""
+        self.register_provider(
+            "dummy",
+            DummyVideoProvider,
+            description="Example video provider",
+            models=[ModelInfo(name="dummy-video")],
+            requires_api_key=False,
+            default_model="dummy-video",
+        )
 
 
 _video_registry: VideoRegistry | None = None
@@ -25,4 +32,10 @@ def get_video_registry() -> VideoRegistry:
         _video_registry.register_default_providers()
     return _video_registry
 
-__all__ = ["ModelInfo", "VideoRegistry", "get_video_registry"]
+__all__ = [
+    "ModelInfo",
+    "VideoProviderBase",
+    "DummyVideoProvider",
+    "VideoRegistry",
+    "get_video_registry",
+]

--- a/src/ai_karen_engine/integrations/voice_providers.py
+++ b/src/ai_karen_engine/integrations/voice_providers.py
@@ -1,0 +1,41 @@
+"""Base classes and example providers for voice integrations."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+
+class VoiceProviderBase:
+    """Base interface for text-to-speech and speech-to-text providers."""
+
+    def __init__(self, model: str | None = None) -> None:
+        self.model = model or "default"
+
+    def synthesize_speech(self, text: str, **kwargs: Any) -> bytes:  # pragma: no cover - abstract
+        """Generate speech audio for the given text."""
+        raise NotImplementedError
+
+    def recognize_speech(self, audio: bytes, **kwargs: Any) -> str:  # pragma: no cover - abstract
+        """Transcribe speech audio into text."""
+        raise NotImplementedError
+
+    def available_models(self) -> List[str]:
+        """Return list of supported models for this provider."""
+        return [self.model]
+
+
+class DummyVoiceProvider(VoiceProviderBase):
+    """Simple placeholder provider used for testing and demos."""
+
+    def synthesize_speech(self, text: str, **kwargs: Any) -> bytes:
+        return f"VOICE:{text}".encode()
+
+    def recognize_speech(self, audio: bytes, **kwargs: Any) -> str:
+        return audio.decode().replace("VOICE:", "")
+
+
+__all__ = [
+    "VoiceProviderBase",
+    "DummyVoiceProvider",
+]
+

--- a/src/ai_karen_engine/integrations/voice_registry.py
+++ b/src/ai_karen_engine/integrations/voice_registry.py
@@ -3,15 +3,22 @@
 from __future__ import annotations
 
 from .provider_registry import ModelInfo, ProviderRegistry
+from .voice_providers import DummyVoiceProvider, VoiceProviderBase
 
 
 class VoiceRegistry(ProviderRegistry):
     """Manage text-to-speech and speech-to-text providers."""
 
     def register_default_providers(self) -> None:
-        """Hook to register built-in voice providers."""
-        # Placeholder for future built-in providers
-        pass
+        """Register built-in voice providers."""
+        self.register_provider(
+            "dummy",
+            DummyVoiceProvider,
+            description="Example voice provider",
+            models=[ModelInfo(name="dummy-voice")],
+            requires_api_key=False,
+            default_model="dummy-voice",
+        )
 
 
 # Global registry instance
@@ -26,4 +33,10 @@ def get_voice_registry() -> VoiceRegistry:
         _voice_registry.register_default_providers()
     return _voice_registry
 
-__all__ = ["ModelInfo", "VoiceRegistry", "get_voice_registry"]
+__all__ = [
+    "ModelInfo",
+    "VoiceProviderBase",
+    "DummyVoiceProvider",
+    "VoiceRegistry",
+    "get_voice_registry",
+]

--- a/tests/integrations/test_provider_hierarchy.py
+++ b/tests/integrations/test_provider_hierarchy.py
@@ -1,0 +1,14 @@
+import pytest
+from ai_karen_engine.integrations.provider_hierarchy import get_provider_hierarchy
+
+
+def test_provider_hierarchy_structure():
+    hierarchy = get_provider_hierarchy()
+    assert "llm" in hierarchy
+    assert "voice" in hierarchy
+    assert "video" in hierarchy
+    # ensure dummy providers are included
+    voice_names = [p["name"] for p in hierarchy["voice"]]
+    video_names = [p["name"] for p in hierarchy["video"]]
+    assert "dummy" in voice_names
+    assert "dummy" in video_names


### PR DESCRIPTION
## Summary
- implement `voice_providers` and `video_providers` with basic provider classes
- register dummy voice/video providers in provider registries
- expose new providers in `integrations/__init__.py`
- add `provider_hierarchy` utility to return hierarchical provider data
- provide simple test for hierarchy

## Testing
- `pytest -q tests/integrations/test_provider_hierarchy.py` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_688481bd664883249b050053ae500860