### PR TITLE
Implement extension hooks and services

### DIFF
--- a/ui_launchers/web_ui/src/hooks/extensions/__tests__/useExtensionNavigation.test.tsx
+++ b/ui_launchers/web_ui/src/hooks/extensions/__tests__/useExtensionNavigation.test.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { renderHook, act } from '@testing-library/react';
+import { ExtensionProvider } from '@/extensions/ExtensionContext';
+import { useExtensionNavigation } from '../useExtensionNavigation';
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <ExtensionProvider>{children}</ExtensionProvider>
+);
+
+describe('useExtensionNavigation', () => {
+  it('returns default navigation state', () => {
+    const { result } = renderHook(() => useExtensionNavigation(), { wrapper });
+    expect(result.current.navigation.currentCategory).toBe('Plugins');
+    expect(result.current.navigation.currentLevel).toBe('category');
+  });
+
+  it('can switch category', () => {
+    const { result } = renderHook(() => useExtensionNavigation(), { wrapper });
+    act(() => {
+      result.current.setCategory('Extensions');
+    });
+    expect(result.current.navigation.currentCategory).toBe('Extensions');
+  });
+
+  it('can go back after breadcrumb push', () => {
+    const { result } = renderHook(() => useExtensionNavigation(), { wrapper });
+    act(() => {
+      result.current.pushBreadcrumb({ level: 'submenu', name: 'LLM', id: 'llm' });
+    });
+    expect(result.current.navigation.currentLevel).toBe('submenu');
+    act(() => {
+      result.current.goBack();
+    });
+    expect(result.current.navigation.currentLevel).toBe('category');
+  });
+});

--- a/ui_launchers/web_ui/src/hooks/extensions/__tests__/useExtensions.test.tsx
+++ b/ui_launchers/web_ui/src/hooks/extensions/__tests__/useExtensions.test.tsx
@@ -1,0 +1,19 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { vi } from 'vitest';
+import { useExtensions } from '../useExtensions';
+
+global.fetch = vi.fn(() =>
+  Promise.resolve({
+    ok: true,
+    json: () => Promise.resolve({ extensions: [] }),
+  })
+) as any;
+
+describe('useExtensions', () => {
+  it('fetches extensions on mount', async () => {
+    const { result } = renderHook(() => useExtensions());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(global.fetch).toHaveBeenCalled();
+    expect(result.current.extensions).toEqual([]);
+  });
+});

--- a/ui_launchers/web_ui/src/hooks/extensions/useExtensionCache.ts
+++ b/ui_launchers/web_ui/src/hooks/extensions/useExtensionCache.ts
@@ -1,0 +1,17 @@
+"use client";
+import { useRef } from "react";
+import type { ExtensionCacheConfig } from "@/services/extensions";
+
+export function useExtensionCache(config?: Partial<ExtensionCacheConfig>) {
+  const cacheRef = useRef<Record<string, any>>({});
+
+  const get = (key: string) => cacheRef.current[key];
+  const set = (key: string, value: any) => {
+    cacheRef.current[key] = value;
+  };
+  const clear = () => {
+    cacheRef.current = {};
+  };
+
+  return { get, set, clear, config };
+}

--- a/ui_launchers/web_ui/src/hooks/extensions/useExtensionControls.ts
+++ b/ui_launchers/web_ui/src/hooks/extensions/useExtensionControls.ts
@@ -1,0 +1,7 @@
+"use client";
+export function useExtensionControls(extensionId: string) {
+  const runControl = async (action: string, params?: Record<string, any>) => {
+    console.log("run", extensionId, action, params);
+  };
+  return { runControl };
+}

--- a/ui_launchers/web_ui/src/hooks/extensions/useExtensionHealth.ts
+++ b/ui_launchers/web_ui/src/hooks/extensions/useExtensionHealth.ts
@@ -1,0 +1,13 @@
+"use client";
+import { useState } from "react";
+
+export interface ExtensionHealth {
+  status: string;
+}
+
+export function useExtensionHealth(extensionId: string) {
+  const [health, setHealth] = useState<ExtensionHealth | null>(null);
+
+  // Placeholder implementation
+  return { health, refresh: async () => setHealth({ status: "unknown" }) };
+}

--- a/ui_launchers/web_ui/src/hooks/extensions/useExtensionMarketplace.ts
+++ b/ui_launchers/web_ui/src/hooks/extensions/useExtensionMarketplace.ts
@@ -1,0 +1,12 @@
+"use client";
+import { useState } from "react";
+
+export interface MarketplaceExtension {
+  id: string;
+  name: string;
+}
+
+export function useExtensionMarketplace() {
+  const [extensions, setExtensions] = useState<MarketplaceExtension[]>([]);
+  return { extensions, refresh: async () => setExtensions([]) };
+}

--- a/ui_launchers/web_ui/src/hooks/extensions/useExtensionNavigation.ts
+++ b/ui_launchers/web_ui/src/hooks/extensions/useExtensionNavigation.ts
@@ -1,0 +1,40 @@
+"use client";
+import { useCallback } from "react";
+import { useExtensionContext, type BreadcrumbItem, type ExtensionCategory } from "@/extensions";
+import { useNavigationActions } from "@/lib/extensions/navigationUtils";
+
+export interface UseExtensionNavigation {
+  navigation: ReturnType<typeof useExtensionContext>["state"]["navigation"];
+  setCategory: (category: ExtensionCategory) => void;
+  pushBreadcrumb: (item: BreadcrumbItem) => void;
+  goBack: () => void;
+  reset: () => void;
+  navigate: ReturnType<typeof useNavigationActions>["navigate"];
+}
+
+export function useExtensionNavigation(): UseExtensionNavigation {
+  const { state, dispatch } = useExtensionContext();
+  const { dispatchMultiple, navigate } = useNavigationActions(dispatch);
+
+  const setCategory = useCallback(
+    (category: ExtensionCategory) => dispatch({ type: "SET_CATEGORY", category }),
+    [dispatch],
+  );
+
+  const pushBreadcrumb = useCallback(
+    (item: BreadcrumbItem) => dispatch({ type: "PUSH_BREADCRUMB", item }),
+    [dispatch],
+  );
+
+  const goBack = useCallback(() => dispatch({ type: "GO_BACK" }), [dispatch]);
+  const reset = useCallback(() => dispatch({ type: "RESET_BREADCRUMBS" }), [dispatch]);
+
+  return {
+    navigation: state.navigation,
+    setCategory,
+    pushBreadcrumb,
+    goBack,
+    reset,
+    navigate,
+  };
+}

--- a/ui_launchers/web_ui/src/hooks/extensions/useExtensionSettings.ts
+++ b/ui_launchers/web_ui/src/hooks/extensions/useExtensionSettings.ts
@@ -1,0 +1,15 @@
+"use client";
+import { useState } from "react";
+
+export type ExtensionSettings = Record<string, any>;
+
+export function useExtensionSettings(extensionId: string) {
+  const [settings, setSettings] = useState<ExtensionSettings>({});
+
+  // Placeholder save
+  const save = async (values: ExtensionSettings) => {
+    setSettings(values);
+  };
+
+  return { settings, save };
+}

--- a/ui_launchers/web_ui/src/hooks/extensions/useExtensions.ts
+++ b/ui_launchers/web_ui/src/hooks/extensions/useExtensions.ts
@@ -1,0 +1,44 @@
+"use client";
+import { useEffect, useState } from "react";
+import type { ExtensionPlugin } from "@/extensions";
+
+export interface UseExtensionsResult {
+  extensions: ExtensionPlugin[];
+  loading: boolean;
+  error: string | null;
+  refresh: () => Promise<void>;
+}
+
+export function useExtensions(): UseExtensionsResult {
+  const [extensions, setExtensions] = useState<ExtensionPlugin[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchExtensions = async () => {
+    setLoading(true);
+    try {
+      const res = await fetch("/api/extensions");
+      if (!res.ok) {
+        throw new Error(`HTTP ${res.status}`);
+      }
+      const data = await res.json();
+      setExtensions(Array.isArray(data.extensions) ? data.extensions : []);
+      setError(null);
+    } catch (err: any) {
+      setError(err.message ?? "Failed to fetch extensions");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchExtensions();
+  }, []);
+
+  return {
+    extensions,
+    loading,
+    error,
+    refresh: fetchExtensions,
+  };
+}

--- a/ui_launchers/web_ui/src/services/extensions/cacheService.ts
+++ b/ui_launchers/web_ui/src/services/extensions/cacheService.ts
@@ -1,0 +1,11 @@
+import type { ExtensionCacheConfig } from './types';
+
+let cacheConfig: ExtensionCacheConfig | null = null;
+
+export function setCacheConfig(config: ExtensionCacheConfig) {
+  cacheConfig = config;
+}
+
+export function getCacheConfig(): ExtensionCacheConfig | null {
+  return cacheConfig;
+}

--- a/ui_launchers/web_ui/src/services/extensions/extensionAPI.ts
+++ b/ui_launchers/web_ui/src/services/extensions/extensionAPI.ts
@@ -1,0 +1,20 @@
+import type { ExtensionAPIRequest, ExtensionAPIResponse } from './types';
+
+export async function extensionAPI<T = any>(
+  req: ExtensionAPIRequest,
+): Promise<ExtensionAPIResponse<T>> {
+  try {
+    const res = await fetch(req.endpoint, {
+      method: req.method,
+      headers: { 'Content-Type': 'application/json', ...(req.headers || {}) },
+      body: req.data ? JSON.stringify(req.data) : undefined,
+    });
+    const data = await res.json();
+    return { success: res.ok, data };
+  } catch (error: any) {
+    return {
+      success: false,
+      error: { code: 'network_error', message: error.message, details: error },
+    };
+  }
+}

--- a/ui_launchers/web_ui/src/services/extensions/marketplaceService.ts
+++ b/ui_launchers/web_ui/src/services/extensions/marketplaceService.ts
@@ -1,0 +1,17 @@
+import { extensionAPI } from './extensionAPI';
+import type { ExtensionAPIResponse, ExtensionQueryParams, ExtensionInstallRequest, ExtensionUpdateRequest } from './types';
+
+export async function listMarketplaceExtensions(
+  params: ExtensionQueryParams = {},
+): Promise<ExtensionAPIResponse> {
+  const query = new URLSearchParams(params as any).toString();
+  return extensionAPI({ method: 'GET', endpoint: `/api/marketplace?${query}` });
+}
+
+export async function installExtension(data: ExtensionInstallRequest): Promise<ExtensionAPIResponse> {
+  return extensionAPI({ method: 'POST', endpoint: '/api/marketplace/install', data });
+}
+
+export async function updateExtension(data: ExtensionUpdateRequest): Promise<ExtensionAPIResponse> {
+  return extensionAPI({ method: 'POST', endpoint: '/api/marketplace/update', data });
+}

--- a/ui_launchers/web_ui/src/services/extensions/pluginService.ts
+++ b/ui_launchers/web_ui/src/services/extensions/pluginService.ts
@@ -1,0 +1,7 @@
+import { extensionAPI } from './extensionAPI';
+import type { ExtensionAPIResponse, ExtensionQueryParams } from './types';
+
+export async function listPlugins(params: ExtensionQueryParams = {}): Promise<ExtensionAPIResponse> {
+  const query = new URLSearchParams(params as any).toString();
+  return extensionAPI({ method: 'GET', endpoint: `/api/plugins?${query}` });
+}

--- a/ui_launchers/web_ui/src/services/extensions/systemExtensionService.ts
+++ b/ui_launchers/web_ui/src/services/extensions/systemExtensionService.ts
@@ -1,0 +1,9 @@
+import { extensionAPI } from './extensionAPI';
+import type { ExtensionAPIResponse, ExtensionQueryParams } from './types';
+
+export async function listSystemExtensions(
+  params: ExtensionQueryParams = {},
+): Promise<ExtensionAPIResponse> {
+  const query = new URLSearchParams(params as any).toString();
+  return extensionAPI({ method: 'GET', endpoint: `/api/extensions?${query}` });
+}


### PR DESCRIPTION
## Summary
- add `useExtensions` and `useExtensionNavigation` hooks
- stub additional extension-related hooks
- add minimal extension API services
- provide tests for new hooks

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*
- `npm test --silent` in `ui_launchers/web_ui` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68848418d1988324a0bffb02bbfc2ad3