### PR TITLE
Add plugin/extension sidebar navigation

### DIFF
--- a/ui_launchers/web_ui/src/components/extensions/ExtensionSidebar.tsx
+++ b/ui_launchers/web_ui/src/components/extensions/ExtensionSidebar.tsx
@@ -9,6 +9,7 @@ import {
   SidebarRail,
 } from "@/components/ui/sidebar";
 import ExtensionHeader from "./ExtensionHeader";
+import SidebarNavigation from "./SidebarNavigation";
 import { ExtensionProvider } from "@/extensions";
 import { ErrorBoundary } from "@/components/ui/error-boundary";
 
@@ -26,8 +27,8 @@ function SidebarInner() {
       <SidebarRail />
       <Sidebar variant="sidebar" collapsible="icon" className="border-r z-20">
         <ExtensionHeader />
-      <SidebarContent className="p-2 space-y-2">
-        {/* Navigation items will be added in future tasks */}
+      <SidebarContent className="p-2 space-y-2 overflow-auto">
+        <SidebarNavigation />
       </SidebarContent>
       <SidebarFooter className="p-2 border-t">
         <p className="text-xs text-muted-foreground text-center">

--- a/ui_launchers/web_ui/src/components/extensions/SidebarNavigation.tsx
+++ b/ui_launchers/web_ui/src/components/extensions/SidebarNavigation.tsx
@@ -1,0 +1,73 @@
+"use client";
+import React, { useEffect, useState } from "react";
+import { useExtensionContext, navigationActions } from "@/extensions";
+import { getPluginService, getExtensionService, type PluginCategory, type ExtensionInfo } from "@/services";
+
+export default function SidebarNavigation() {
+  const { state, dispatch } = useExtensionContext();
+  const [pluginCategories, setPluginCategories] = useState<PluginCategory[]>([]);
+  const [extensions, setExtensions] = useState<ExtensionInfo[]>([]);
+
+  useEffect(() => {
+    getPluginService()
+      .getPluginsByCategory()
+      .then(setPluginCategories)
+      .catch(() => {});
+    getExtensionService()
+      .getInstalledExtensions()
+      .then(setExtensions)
+      .catch(() => {});
+  }, []);
+
+  if (state.currentCategory === "Plugins") {
+    return (
+      <div className="space-y-4">
+        {pluginCategories.map((cat) => (
+          <div key={cat.name} className="space-y-1">
+            <p className="text-xs font-semibold text-muted-foreground uppercase">
+              {cat.name}
+            </p>
+            <ul className="pl-2 space-y-1">
+              {cat.plugins.map((p) => (
+                <li key={p.name}>
+                  <button
+                    type="button"
+                    className="text-sm hover:underline"
+                    onClick={() =>
+                      navigationActions
+                        .navigateToPluginProvider(cat.name.toLowerCase(), p.name)
+                        .forEach((action) => dispatch(action))
+                    }
+                  >
+                    {p.name}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <ul className="space-y-1">
+      {extensions.map((ext) => (
+        <li key={ext.name}>
+          <button
+            type="button"
+            className="text-sm hover:underline"
+            onClick={() =>
+              dispatch({
+                type: "PUSH_BREADCRUMB",
+                item: { level: "items", id: ext.name, name: ext.name },
+              })
+            }
+          >
+            {ext.name}
+          </button>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/ui_launchers/web_ui/src/components/extensions/core/index.ts
+++ b/ui_launchers/web_ui/src/components/extensions/core/index.ts
@@ -4,3 +4,4 @@ export { default as ExtensionHeader, type ExtensionHeaderProps } from './Extensi
 export { default as ExtensionStats } from './ExtensionStats';
 export { default as ExtensionBreadcrumb } from './ExtensionBreadcrumb';
 export { default as ExtensionContent, type ExtensionContentProps } from './ExtensionContent';
+export { default as SidebarNavigation } from '../SidebarNavigation';

--- a/ui_launchers/web_ui/src/components/extensions/index.ts
+++ b/ui_launchers/web_ui/src/components/extensions/index.ts
@@ -6,6 +6,7 @@ export { default as ExtensionStats } from './ExtensionStats';
 export { default as ExtensionHeader } from './ExtensionHeader';
 export { default as ExtensionSettingsPanel } from './ExtensionSettingsPanel';
 export { default as ExtensionControls } from './ExtensionControls';
+export { default as SidebarNavigation } from './SidebarNavigation';
 
 // Core components
 export * from './core';


### PR DESCRIPTION
## Summary
- implement new `SidebarNavigation` component listing plugin categories and installed extensions
- render `SidebarNavigation` in the extension sidebar
- export navigation component via extension indexes

## Testing
- `pre-commit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884869d34448324af3a079e9c3c9cd6