### PR TITLE
Fix web UI forecast widget and scrolling

### DIFF
--- a/ui_launchers/web_ui/src/components/ui/scroll-area.tsx
+++ b/ui_launchers/web_ui/src/components/ui/scroll-area.tsx
@@ -17,7 +17,7 @@ const ScrollArea = React.forwardRef<
 >(({ className, children, viewportRef, ...props }, ref) => (
   <ScrollAreaPrimitive.Root
     ref={ref}
-    className={cn("relative overflow-hidden", className)}
+    className={cn("relative overflow-auto", className)}
     {...props}
   >
     <ScrollAreaPrimitive.Viewport

--- a/ui_launchers/web_ui/src/components/widgets/ForecastWidget.tsx
+++ b/ui_launchers/web_ui/src/components/widgets/ForecastWidget.tsx
@@ -1,15 +1,44 @@
 "use client";
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import { getPluginService } from '@/services/pluginService';
+
+interface WeatherData {
+  summary: string;
+}
 
 export interface ForecastWidgetProps {
   refId: string;
 }
 
 export default function ForecastWidget({ refId }: ForecastWidgetProps) {
+  const [weather, setWeather] = useState<WeatherData | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchWeather = async () => {
+      const pluginService = getPluginService();
+      const location = refId.replace(/_forecast$/, '').replace(/_/g, ' ');
+      const result = await pluginService.executePlugin('weather_query', { location });
+      if (result.success && result.result && typeof result.result === 'object') {
+        setWeather({ summary: result.result.summary || '' });
+      } else {
+        setError(result.error || 'Unable to fetch forecast');
+      }
+    };
+    fetchWeather();
+  }, [refId]);
+
+  if (error) {
+    return <div className="forecast-widget text-sm text-destructive">{error}</div>;
+  }
+
   return (
     <div className="forecast-widget">
-      {/* Forecast data rendered by external component using refId */}
-      <div data-forecast-ref={refId}></div>
+      {weather ? (
+        <p className="text-sm">{weather.summary}</p>
+      ) : (
+        <p className="text-sm text-muted-foreground">Loading forecast...</p>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- make ScrollArea scrollable
- fetch weather data in ForecastWidget using weather plugin

## Testing
- `npm install` *(fails: network not allowed)*

------
https://chatgpt.com/codex/tasks/task_e_6884a2e2000883248d178d176a242cf8