### PR TITLE
Fix broken doc links

### DIFF
--- a/docs/api_usage.md
+++ b/docs/api_usage.md
@@ -1,0 +1,29 @@
+# API Usage Guide
+
+This guide provides quick examples for interacting with Kari's REST API.
+
+## Basic Endpoints
+
+List available routes:
+```bash
+curl http://localhost:8000/
+```
+
+Health check:
+```bash
+curl http://localhost:8000/ping
+```
+
+## Sending Chat Messages
+
+Use the `/chat` endpoint to converse with the assistant:
+```bash
+curl -X POST -H "Content-Type: application/json" \
+     -d '{"text": "hello"}' http://localhost:8000/chat
+```
+
+## Plugin Operations
+
+Plugins can be invoked directly when their manifest exposes a specific route. Refer to `plugin_manifest.json` for the plugin name and parameters.
+
+

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,29 @@
+# Deployment Guide
+
+This document provides a high level overview of how to deploy the Kari AI platform in a production environment.
+
+## Docker Compose
+
+The fastest way to get Kari running is with Docker Compose. The repository includes a `docker-compose.yml` file which starts the API, databases and optional services.
+
+```bash
+# Start the full stack in the background
+docker compose up -d
+```
+
+The API will be available on port **8000** and the default web interface on port **9002**.
+
+## Kubernetes
+
+A lightweight Helm chart is included under `src/charts/kari`. It deploys the API with health probes and Prometheus metrics.
+
+```bash
+helm install my-kari src/charts/kari
+```
+
+Be sure to provision PostgreSQL, Redis and any vector stores before installing the chart.
+
+## Configuration
+
+Runtime settings are controlled via environment variables or the `config.json` file. Review `config/README.md` for parameter descriptions.
+

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,28 @@
+# Troubleshooting Guide
+
+This short guide covers common issues when running Kari in development or production.
+
+## Services Fail to Start
+
+1. Ensure Docker is running and you have enough free memory.
+2. Check each container's logs with `docker compose logs <service>`.
+3. Delete any leftover volumes and retry:
+   ```bash
+   docker compose down -v
+   docker compose up -d
+   ```
+
+## Cannot Access the API
+
+Confirm the backend container is healthy by visiting `http://localhost:8000/ping`.
+If the service is not reachable, verify that port **8000** is exposed and not blocked by a firewall.
+
+## Database Errors
+
+If migrations fail, run:
+```bash
+python scripts/install.sh --migrate
+```
+This will apply the latest Alembic migrations.
+
+For further help, open an issue and include the output of `python scripts/doc_analysis.py`.


### PR DESCRIPTION
## Summary
- add Deployment Guide doc
- add Troubleshooting Guide doc
- add API Usage quick reference
- ensure README links reference existing docs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_6884bc4bb39c8324b11af9eb6692b358