### PR TITLE
Fix NLP config and dynamic model path

### DIFF
--- a/src/ai_karen_engine/config/model_registry.py
+++ b/src/ai_karen_engine/config/model_registry.py
@@ -1,14 +1,16 @@
 import logging
+import os
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
 # === Dynamic Model Providers ===
 
-def list_llama_cpp_models(models_dir="/models"):
+def list_llama_cpp_models(models_dir=None):
     """
     Scan for GGUF/llama.cpp compatible models
     """
+    models_dir = models_dir or os.getenv("KARI_MODEL_DIR", "/models")
     supported_ext = {".gguf", ".bin"}
     models = []
 

--- a/src/ai_karen_engine/services/nlp_service_manager.py
+++ b/src/ai_karen_engine/services/nlp_service_manager.py
@@ -9,7 +9,7 @@ import logging
 from typing import Dict, Any, Optional, List, Union
 
 from ai_karen_engine.services.spacy_service import SpacyService, ParsedMessage
-from ai_karen_engine.services.distilbert_service import DistilBertService, EmbeddingResult
+from ai_karen_engine.services.distilbert_service import DistilBertService
 from ai_karen_engine.services.nlp_health_monitor import NLPHealthMonitor, NLPSystemHealth
 from ai_karen_engine.services.nlp_config import NLPConfig, SpacyConfig, DistilBertConfig
 from ai_karen_engine.config.config_manager import config_manager
@@ -48,7 +48,7 @@ class NLPServiceManager:
         """Load NLP configuration from config manager."""
         try:
             # Get NLP config from main config
-            nlp_config_dict = config_manager.get_config_value("nlp", {})
+            nlp_config_dict = config_manager.get_config_value("nlp", default={})
             
             # Create config objects with defaults
             spacy_config = SpacyConfig(**nlp_config_dict.get("spacy", {}))


### PR DESCRIPTION
## Summary
- fix `list_llama_cpp_models` to respect `KARI_MODEL_DIR` env variable
- correct default argument when fetching NLP configuration

## Testing
- `ruff check src/ai_karen_engine/config/model_registry.py src/ai_karen_engine/services/nlp_service_manager.py`
- `pytest tests/test_model_registry.py::test_load_registry tests/test_model_registry.py::test_get_registry_models_filter tests/test_model_registry.py::test_get_models_reads_registry tests/test_model_registry.py::test_ready_models_default tests/test_model_registry.py::test_get_providers_includes_registry_providers tests/test_model_registry.py::test_get_model_meta` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_6884f02b39d88324bb70804bf95cd2c1