### PR TITLE
Add DB schema init step

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ RUN pip install -e .
 EXPOSE 8000
 HEALTHCHECK --interval=30s --timeout=5s --start-period=5s \
     CMD curl -f http://localhost:8000/health || exit 1
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["bash", "-c", "python scripts/init_db_schema.py && uvicorn main:app --host 0.0.0.0 --port 8000"]

--- a/scripts/init_db_schema.py
+++ b/scripts/init_db_schema.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Initialize database schema for AI Karen.
+
+This script validates the PostgreSQL schema and applies automatic
+migrations if tables are missing. It should be executed before the
+API server starts.
+"""
+
+import asyncio
+import logging
+
+from ai_karen_engine.database import get_postgres_session
+from ai_karen_engine.database.schema_validator import validate_and_migrate_schema
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("db-init")
+
+
+async def _run() -> None:
+    try:
+        async with get_postgres_session() as session:
+            error = await validate_and_migrate_schema(session)
+            if error:
+                logger.error("Schema validation failed: %s", error.message)
+                raise SystemExit(1)
+    except ImportError as exc:
+        logger.error("Database dependencies missing: %s", exc)
+        raise
+    logger.info("Database schema ready")
+
+
+def main() -> None:
+    asyncio.run(_run())
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- initialize Postgres schema on container start
- add schema init script

## Testing
- `ruff check scripts/init_db_schema.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_6884fda194408324a023a2a4fcd66b24