### PR TITLE
Implement persistent user credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,14 +343,20 @@ curl -H "X-Tenant-ID: default" \
 ### Authentication
 
 ```bash
-# Login
+# Login with default admin credentials
 curl -X POST http://localhost:8000/login \
   -H "Content-Type: application/json" \
-  -d '{"username": "user", "password": "pass"}'
+  -d '{"username": "admin", "password": "admin"}'
 
 # Use token
 curl -H "Authorization: Bearer <token>" \
   http://localhost:8000/chat
+
+# Update your credentials after logging in
+curl -X POST http://localhost:8000/api/auth/update_credentials \
+  -H "Authorization: Bearer <token>" \
+  -H "Content-Type: application/json" \
+  -d '{"new_password": "strongpass"}'
 ```
 
 ### Plugin Management

--- a/data/users.json
+++ b/data/users.json
@@ -1,0 +1,6 @@
+{
+  "admin": {
+    "password": "saltsalt:935d9f7e00cf4605d5a8aec3e230bf41a518234d8ef8b5b8a820d4977d9638c2",
+    "roles": ["admin", "dev", "user"]
+  }
+}

--- a/src/ai_karen_engine/api_routes/auth.py
+++ b/src/ai_karen_engine/api_routes/auth.py
@@ -1,19 +1,19 @@
 from __future__ import annotations
 
-from typing import Dict, Any
 
 from fastapi import APIRouter, HTTPException, Request, status
 from pydantic import BaseModel
 
 from ai_karen_engine.utils.auth import create_session, validate_session
+from ai_karen_engine.security.auth_manager import (
+    authenticate,
+    update_credentials,
+    _USERS,
+)
 
 router = APIRouter(prefix="/api/auth")
 
-# In-memory user store for demo purposes
-_USERS: Dict[str, Dict[str, Any]] = {
-    "admin": {"password": "admin", "roles": ["admin", "dev", "user"]},
-    "user": {"password": "user", "roles": ["user"]},
-}
+# Persistent user store managed by ``auth_manager``
 
 
 class LoginRequest(BaseModel):
@@ -37,10 +37,15 @@ class UserResponse(BaseModel):
     roles: list[str]
 
 
+class UpdateCredentialsRequest(BaseModel):
+    new_username: str | None = None
+    new_password: str | None = None
+
+
 @router.post("/login", response_model=LoginResponse)
 async def login(req: LoginRequest, request: Request) -> LoginResponse:
-    user = _USERS.get(req.username)
-    if not user or user["password"] != req.password:
+    user = authenticate(req.username, req.password)
+    if not user:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials")
     tenant_id = request.headers.get("X-Tenant-ID", "default")
     token = create_session(
@@ -56,8 +61,8 @@ async def login(req: LoginRequest, request: Request) -> LoginResponse:
 @router.post("/token", response_model=TokenResponse)
 async def token(req: LoginRequest, request: Request) -> TokenResponse:
     """Issue an OAuth2-compatible bearer token."""
-    user = _USERS.get(req.username)
-    if not user or user["password"] != req.password:
+    user = authenticate(req.username, req.password)
+    if not user:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials")
     token = create_session(req.username, user["roles"], request.headers.get("user-agent", ""), request.client.host)
     return TokenResponse(access_token=token)
@@ -73,3 +78,25 @@ async def me(request: Request) -> UserResponse:
     if not ctx:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
     return UserResponse(user_id=ctx["sub"], roles=list(ctx.get("roles", [])))
+
+
+@router.post("/update_credentials", response_model=LoginResponse)
+async def update_creds(req: UpdateCredentialsRequest, request: Request) -> LoginResponse:
+    auth = request.headers.get("authorization")
+    if not auth or not auth.lower().startswith("bearer "):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Missing token")
+    token = auth.split(None, 1)[1]
+    ctx = validate_session(token, request.headers.get("user-agent", ""), request.client.host)
+    if not ctx:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
+    username = update_credentials(ctx["sub"], req.new_username, req.new_password)
+    user = _USERS[username]
+    tenant_id = request.headers.get("X-Tenant-ID", "default")
+    new_token = create_session(
+        username,
+        user["roles"],
+        request.headers.get("user-agent", ""),
+        request.client.host,
+        tenant_id,
+    )
+    return LoginResponse(token=new_token, user_id=username, roles=user["roles"])

--- a/src/ai_karen_engine/security/__init__.py
+++ b/src/ai_karen_engine/security/__init__.py
@@ -14,19 +14,38 @@ __all__ = [
 
 # Try to import optional components that require additional dependencies
 try:
-    from ai_karen_engine.security.threat_protection import ThreatProtectionSystem, IntrusionDetectionSystem
+    from ai_karen_engine.security.threat_protection import (
+        ThreatProtectionSystem,  # noqa: F401
+        IntrusionDetectionSystem,  # noqa: F401
+    )
     __all__.extend(['ThreatProtectionSystem', 'IntrusionDetectionSystem'])
 except ImportError:
     pass
 
 try:
-    from ai_karen_engine.security.incident_response import SecurityIncidentManager, IncidentResponsePlan
+    from ai_karen_engine.security.auth_manager import (
+        authenticate,  # noqa: F401
+        update_credentials,  # noqa: F401
+    )
+    __all__.extend(['authenticate', 'update_credentials'])
+except ImportError:
+    pass
+
+try:
+    from ai_karen_engine.security.incident_response import (
+        SecurityIncidentManager,  # noqa: F401
+        IncidentResponsePlan,  # noqa: F401
+    )
     __all__.extend(['SecurityIncidentManager', 'IncidentResponsePlan'])
 except ImportError:
     pass
 
 try:
-    from ai_karen_engine.security.compliance import ComplianceReporter, SOC2Reporter, GDPRReporter
+    from ai_karen_engine.security.compliance import (
+        ComplianceReporter,  # noqa: F401
+        SOC2Reporter,  # noqa: F401
+        GDPRReporter,  # noqa: F401
+    )
     __all__.extend(['ComplianceReporter', 'SOC2Reporter', 'GDPRReporter'])
 except ImportError:
     pass

--- a/src/ai_karen_engine/security/auth_manager.py
+++ b/src/ai_karen_engine/security/auth_manager.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import json
+import os
+import secrets
+import hashlib
+from pathlib import Path
+from typing import Dict, Any, Optional
+
+# Path to persistent user store
+USER_STORE_PATH = Path(__file__).resolve().parents[3] / "data" / "users.json"
+
+
+def _hash_password(password: str, *, salt: Optional[str] = None) -> str:
+    """Return a salted PBKDF2 hash."""
+    salt = salt or secrets.token_hex(16)
+    pwd_hash = hashlib.pbkdf2_hmac("sha256", password.encode(), salt.encode(), 100000)
+    return f"{salt}:{pwd_hash.hex()}"
+
+
+def _verify_password(password: str, stored: str) -> bool:
+    try:
+        salt, hex_hash = stored.split(":")
+    except ValueError:
+        return False
+    check = hashlib.pbkdf2_hmac("sha256", password.encode(), salt.encode(), 100000)
+    return check.hex() == hex_hash
+
+
+def _init_default_admin() -> Dict[str, Dict[str, Any]]:
+    """Create default admin credentials if store missing."""
+    username = os.getenv("KARI_ADMIN_USERNAME", "admin")
+    password = os.getenv("KARI_ADMIN_PASSWORD", "admin")
+    return {
+        username: {
+            "password": _hash_password(password),
+            "roles": ["admin", "dev", "user"],
+        }
+    }
+
+
+def load_users() -> Dict[str, Dict[str, Any]]:
+    if USER_STORE_PATH.exists():
+        try:
+            return json.loads(USER_STORE_PATH.read_text())
+        except Exception:
+            pass
+    users = _init_default_admin()
+    USER_STORE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    USER_STORE_PATH.write_text(json.dumps(users, indent=2))
+    return users
+
+
+_USERS: Dict[str, Dict[str, Any]] = load_users()
+
+
+def save_users() -> None:
+    USER_STORE_PATH.write_text(json.dumps(_USERS, indent=2))
+
+
+def authenticate(username: str, password: str) -> Optional[Dict[str, Any]]:
+    user = _USERS.get(username)
+    if not user:
+        return None
+    if _verify_password(password, user.get("password", "")):
+        return user
+    return None
+
+
+def update_credentials(
+    current_username: str,
+    new_username: Optional[str] = None,
+    new_password: Optional[str] = None,
+) -> str:
+    if current_username not in _USERS:
+        raise KeyError("User not found")
+    data = _USERS.pop(current_username)
+    username = new_username or current_username
+    if username in _USERS and username != current_username:
+        raise KeyError("Username already exists")
+    if new_password:
+        data["password"] = _hash_password(new_password)
+    _USERS[username] = data
+    save_users()
+    return username
+
+
+__all__ = ["authenticate", "update_credentials", "_USERS"]


### PR DESCRIPTION
## Summary
- add new `auth_manager` for hashed credential storage
- use auth manager in login routes
- allow updating credentials
- document default admin login and how to change credentials

## Testing
- `ruff check src/ai_karen_engine/api_routes/auth.py`
- `ruff check src/ai_karen_engine/security/auth_manager.py`
- `ruff check src/ai_karen_engine/security/__init__.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68862884d074832495acc95bdb1fd50f