### PR TITLE
Fix missing getAuthService export

### DIFF
--- a/ui_launchers/web_ui/src/services/authService.ts
+++ b/ui_launchers/web_ui/src/services/authService.ts
@@ -1,6 +1,6 @@
 import { LoginCredentials, LoginResponse, User } from '@/types/auth';
 
-class AuthService {
+export class AuthService {
   private baseUrl: string;
 
   constructor() {
@@ -91,3 +91,20 @@ class AuthService {
 }
 
 export const authService = new AuthService();
+
+// Global instance used by hooks that rely on lazy initialization
+let authServiceInstance: AuthService | null = null;
+
+export function getAuthService(): AuthService {
+  if (!authServiceInstance) {
+    authServiceInstance = new AuthService();
+  }
+  return authServiceInstance;
+}
+
+export function initializeAuthService(): AuthService {
+  authServiceInstance = new AuthService();
+  return authServiceInstance;
+}
+
+export { AuthService };

--- a/ui_launchers/web_ui/src/services/extensionService.ts
+++ b/ui_launchers/web_ui/src/services/extensionService.ts
@@ -17,7 +17,7 @@ export interface ExtensionEvent {
   risk: number
 }
 
-class ExtensionService {
+export class ExtensionService {
   private backend = getKarenBackend()
   private polling = false
 

--- a/ui_launchers/web_ui/src/services/index.ts
+++ b/ui_launchers/web_ui/src/services/index.ts
@@ -8,7 +8,7 @@ export { ChatService, getChatService, initializeChatService } from './chatServic
 export { MemoryService, getMemoryService, initializeMemoryService } from './memoryService';
 export { PluginService, getPluginService, initializePluginService } from './pluginService';
 export { ExtensionService, getExtensionService, initializeExtensionService } from './extensionService';
-export { AuthService, getAuthService } from './authService';
+export { AuthService, getAuthService, initializeAuthService } from './authService';
 
 // Export service types
 export type { ConversationSession, ProcessMessageOptions } from './chatService';


### PR DESCRIPTION
## Summary
- export `AuthService` class in auth service and add helper functions `getAuthService` and `initializeAuthService`
- export `ExtensionService` class
- update service index to re-export new helpers

## Testing
- `npm run typecheck` *(fails: many type errors in project)*

------
https://chatgpt.com/codex/tasks/task_e_6886481ec94083249b1b1529d25d7104