### PR TITLE
Fix login docs and add /login compatibility route

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,9 +344,14 @@ curl -H "X-Tenant-ID: default" \
 
 ```bash
 # Login with default admin credentials
-curl -X POST http://localhost:8000/login \
+curl -X POST http://localhost:8000/api/auth/login \
   -H "Content-Type: application/json" \
-  -d '{"username": "admin", "password": "admin"}'
+  -d '{"email": "admin@example.com", "password": "admin"}'
+
+# Or login with the demo user
+curl -X POST http://localhost:8000/api/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"email": "user@example.com", "password": "user"}'
 
 # Use token
 curl -H "Authorization: Bearer <token>" \

--- a/src/ai_karen_engine/fastapi.py
+++ b/src/ai_karen_engine/fastapi.py
@@ -24,6 +24,11 @@ from ai_karen_engine.core.memory.manager import init_memory
 from ai_karen_engine.utils.auth import validate_session
 from ai_karen_engine.extensions import initialize_extension_manager
 from ai_karen_engine.plugins.router import get_plugin_router
+from ai_karen_engine.api_routes.auth import (
+    login as auth_login,
+    LoginRequest,
+    LoginResponse,
+)
 
 try:
     from fastapi import FastAPI, APIRouter, Request, Response, status
@@ -271,6 +276,12 @@ def auto_discover_routers(app):
                     logger.error(f"Failed to mount plugin {mod_name}: {e}")
 
 auto_discover_routers(app)
+
+# -- Legacy Login Endpoint for Backward Compatibility --
+@app.post("/login", response_model=LoginResponse, tags=["auth"])
+async def legacy_login(req: LoginRequest, request: Request, response: Response) -> LoginResponse:
+    """Alias to /api/auth/login for older clients."""
+    return await auth_login(req, request, response)
 
 # -- Trace ID + Logging Per Request --
 @app.middleware("http")


### PR DESCRIPTION
## Summary
- document correct login endpoint
- provide example credentials for admin and user accounts
- add `/login` alias route for backward compatibility

## Testing
- `pytest -k login -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_688683db13b88324b66f87d4a95e99f3