### PR TITLE
Improve auth flow and profile system

### DIFF
--- a/data/users.json
+++ b/data/users.json
@@ -1,57 +1,24 @@
-[
-  {
-    "id": "admin_001",
-    "username": "admin",
-    "email": "admin@ai-karen.com",
-    "full_name": "System Administrator",
-    "role": "admin",
-    "permissions": [
-      "manage_users",
-      "view_logs",
-      "manage_plugins",
-      "use_chat",
-      "read_dashboard",
-      "view_memory",
-      "view_analytics",
-      "configure_system"
-    ],
-    "created_at": "2025-07-27T13:29:10.717238",
-    "last_login": null,
-    "is_active": true,
+{
+  "admin@example.com": {
+    "password": "f4b35310e1480ca218ef88cb070f022f:2220987db38266dfd26742d473018a9f1a12bf303dd816a8df00b9a344f99126",
+    "roles": ["admin", "dev", "user"],
+    "tenant_id": "default",
     "preferences": {
       "theme": "dark",
       "language": "en",
       "notifications": true,
       "auto_refresh": true
-    },
-    "session_data": {},
-    "password_hash": "f4b35310e1480ca218ef88cb070f022f:2220987db38266dfd26742d473018a9f1a12bf303dd816a8df00b9a344f99126",
-    "api_key": "ak_7JsmtNRVZroV3UAJtw4ivv4aKgSSOCSNJf6N03vhme4",
-    "two_factor_enabled": false
+    }
   },
-  {
-    "id": "user_001",
-    "username": "user",
-    "email": "user@ai-karen.com",
-    "full_name": "Regular User",
-    "role": "user",
-    "permissions": [
-      "use_chat",
-      "read_dashboard",
-      "view_memory"
-    ],
-    "created_at": "2025-07-27T13:29:10.798084",
-    "last_login": null,
-    "is_active": true,
+  "user@example.com": {
+    "password": "d38ac31d74a1e2d0486ab6dc915d871a:02b43f50f625827b3e2beaaa21a679ea72c0262c5452fc5e15f2431e8c2b3c8e",
+    "roles": ["user"],
+    "tenant_id": "default",
     "preferences": {
       "theme": "light",
       "language": "en",
       "notifications": true,
       "auto_refresh": false
-    },
-    "session_data": {},
-    "password_hash": "d38ac31d74a1e2d0486ab6dc915d871a:02b43f50f625827b3e2beaaa21a679ea72c0262c5452fc5e15f2431e8c2b3c8e",
-    "api_key": "ak_M_tuk5ba_izwHhwTPpATXfmh1V4_7vz2f0kVOZimoD8",
-    "two_factor_enabled": false
+    }
   }
-]
+}

--- a/src/ai_karen_engine/api_routes/auth.py
+++ b/src/ai_karen_engine/api_routes/auth.py
@@ -14,6 +14,7 @@ from ai_karen_engine.utils.auth import (
 from ai_karen_engine.security.auth_manager import (
     authenticate,
     update_credentials,
+    create_user,
     _USERS,
 )
 
@@ -33,6 +34,14 @@ RATE_WINDOW = timedelta(minutes=1)
 class LoginRequest(BaseModel):
     email: str
     password: str
+
+
+class RegisterRequest(BaseModel):
+    email: str
+    password: str
+    roles: Optional[List[str]] = None
+    tenant_id: str = "default"
+    preferences: Dict[str, Any] = {}
 
 
 class LoginResponse(BaseModel):
@@ -60,6 +69,41 @@ class UserResponse(BaseModel):
 class UpdateCredentialsRequest(BaseModel):
     new_username: Optional[str] = None
     new_password: Optional[str] = None
+
+
+@router.post("/register", response_model=LoginResponse)
+async def register(req: RegisterRequest, request: Request, response: Response) -> LoginResponse:
+    if req.email in _USERS:
+        raise HTTPException(status_code=400, detail="User already exists")
+    try:
+        create_user(req.email, req.password, roles=req.roles, tenant_id=req.tenant_id, preferences=req.preferences)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+    user = _USERS[req.email]
+    token = create_session(
+        req.email,
+        user["roles"],
+        request.headers.get("user-agent", ""),
+        request.client.host,
+        tenant_id=user.get("tenant_id", "default"),
+    )
+    response.set_cookie(
+        COOKIE_NAME,
+        token,
+        max_age=SESSION_DURATION,
+        httponly=True,
+        secure=True,
+        samesite="strict",
+    )
+    return LoginResponse(
+        token=token,
+        user_id=req.email,
+        email=req.email,
+        roles=user["roles"],
+        tenant_id=user.get("tenant_id", "default"),
+        preferences=user.get("preferences", {}),
+    )
 
 
 @router.post("/login", response_model=LoginResponse)

--- a/src/ai_karen_engine/api_routes/users.py
+++ b/src/ai_karen_engine/api_routes/users.py
@@ -3,7 +3,11 @@ from typing import Dict, Any
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
+from ai_karen_engine.clients.database.duckdb_client import DuckDBClient
+
 router = APIRouter()
+
+db = DuckDBClient()
 
 
 class UserProfile(BaseModel):
@@ -13,12 +17,16 @@ class UserProfile(BaseModel):
     preferences: Dict[str, Any] = {}
 
 
-USER_PROFILES: Dict[str, UserProfile] = {}
-
-
 @router.get("/users/{user_id}/profile", response_model=UserProfile)
 async def get_profile(user_id: str) -> UserProfile:
-    profile = USER_PROFILES.get(user_id)
-    if not profile:
+    profile = db.get_profile(user_id)
+    if profile is None:
         raise HTTPException(status_code=404, detail="Profile not found")
-    return profile
+    return UserProfile(user_id=user_id, **profile)
+
+
+@router.put("/users/{user_id}/profile", response_model=UserProfile)
+async def save_profile(user_id: str, profile: UserProfile) -> UserProfile:
+    data = profile.dict(exclude={"user_id"})
+    db.save_profile(user_id, data)
+    return UserProfile(user_id=user_id, **data)

--- a/src/ai_karen_engine/security/__init__.py
+++ b/src/ai_karen_engine/security/__init__.py
@@ -19,7 +19,7 @@ try:
         IntrusionDetectionSystem,  # noqa: F401
     )
     __all__.extend(['ThreatProtectionSystem', 'IntrusionDetectionSystem'])
-except ImportError:
+except Exception:
     pass
 
 try:
@@ -46,6 +46,6 @@ try:
         SOC2Reporter,  # noqa: F401
         GDPRReporter,  # noqa: F401
     )
-    __all__.extend(['ComplianceReporter', 'SOC2Reporter', 'GDPRReporter'])
-except ImportError:
+    __all__.extend(["ComplianceReporter", "SOC2Reporter", "GDPRReporter"])
+except Exception:
     pass


### PR DESCRIPTION
## Summary
- parse legacy user stores and add create_user
- add user registration endpoint
- connect user profile routes to DuckDB
- allow updating/saving profiles
- handle optional security modules gracefully
- normalize default users.json format

## Testing
- `pytest tests/test_auth_update_credentials.py -q` *(fails: ModuleNotFoundError: aioredis.Redis attribute)*

------
https://chatgpt.com/codex/tasks/task_e_688698641dac83249ea17155aab58d7e