### PR TITLE
Fix duplicate model discovery logs

### DIFF
--- a/src/ai_karen_engine/integrations/model_discovery.py
+++ b/src/ai_karen_engine/integrations/model_discovery.py
@@ -13,6 +13,8 @@ from pathlib import Path
 from typing import List, Dict, Any, Optional, Callable
 
 logger = logging.getLogger("kari.model_discovery")
+# Avoid duplicate log messages bubbling up to Uvicorn
+logger.propagate = False
 
 # ======== Model Registry/Source Abstractions =========
 


### PR DESCRIPTION
## Summary
- prevent model discovery logger from propagating up to Uvicorn

## Testing
- `pip install -r requirements.txt`
- `pytest -k llm_manager -q` *(fails: ModuleNotFoundError and other import errors)*

------
https://chatgpt.com/codex/tasks/task_e_6886b9796a288324b15f79c345edbef8