### PR TITLE
Add signup and password reset flows

### DIFF
--- a/docs/agent_roadmap.md
+++ b/docs/agent_roadmap.md
@@ -159,9 +159,9 @@ const [memoryCount, setMemoryCount] = useState<number|null>(null);
 |    P0    | ~~Remove prefilled env vars in login → empty inputs~~ | Frontend         | **Complete** |
 |    P0    | ~~Switch to HttpOnly cookie storage~~                 | Frontend/Backend | **Complete** |
 |    P0    | ~~Add rate-limit middleware on `/api/auth/login`~~    | Backend          | **Complete** |
-|    P1    | Signup page + email verification flow             | Full stack       | 1 week  |
-|    P1    | Password reset (magic link) flow                  | Full stack       | 1 week  |
-|    P1    | Client-side validation & error messages           | Frontend         | 2 days  |
+|    P1    | ~~Signup page + email verification flow~~             | Full stack       | **Complete** |
+|    P1    | ~~Password reset (magic link) flow~~                  | Full stack       | **Complete** |
+|    P1    | ~~Client-side validation & error messages~~           | Frontend         | **Complete** |
 |    P2    | 2FA via TOTP setup UI and enforcement             | Full stack       | 2 weeks |
 |    P2    | Role-based dashboard variant                      | Frontend         | 1 week  |
 |    P3    | Avatar upload & theme picker                      | Frontend/Backend | 1 week  |

--- a/ui_launchers/web_ui/src/app/login/page.tsx
+++ b/ui_launchers/web_ui/src/app/login/page.tsx
@@ -17,11 +17,15 @@ export default function LoginPage() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     setError('')
-    const ok = await login(email, password)
-    if (ok) {
+    if (!email || !password) {
+      setError('Email and password are required')
+      return
+    }
+    try {
+      await login({ email, password })
       router.push('/profile')
-    } else {
-      setError('Login failed')
+    } catch (err) {
+      setError((err as Error).message)
     }
   }
 
@@ -37,6 +41,10 @@ export default function LoginPage() {
             <Input type="password" value={password} onChange={e => setPassword(e.target.value)} placeholder="Password" />
             {error && <p className="text-destructive text-sm">{error}</p>}
             <Button type="submit" className="w-full">Sign In</Button>
+            <div className="text-sm text-center space-x-2">
+              <a href="/signup" className="underline">Sign Up</a>
+              <a href="/reset-password" className="underline">Forgot Password?</a>
+            </div>
           </form>
         </CardContent>
       </Card>

--- a/ui_launchers/web_ui/src/app/reset-password/page.tsx
+++ b/ui_launchers/web_ui/src/app/reset-password/page.tsx
@@ -1,0 +1,88 @@
+"use client";
+import { useState, useEffect } from 'react';
+import { useSearchParams, useRouter } from 'next/navigation';
+import { useAuth } from '@/contexts/AuthContext';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+export default function ResetPasswordPage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const token = searchParams.get('token');
+  const { requestPasswordReset, resetPassword } = useAuth();
+
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+  const [message, setMessage] = useState('');
+
+  const handleRequest = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+    setMessage('');
+    if (!email) {
+      setError('Email is required');
+      return;
+    }
+    try {
+      await requestPasswordReset(email);
+      setMessage('Check console for magic link token.');
+    } catch (err) {
+      setError((err as Error).message);
+    }
+  };
+
+  const handleReset = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+    if (!password) {
+      setError('Password required');
+      return;
+    }
+    try {
+      await resetPassword(token || '', password);
+      setMessage('Password updated. You can now log in.');
+    } catch (err) {
+      setError((err as Error).message);
+    }
+  };
+
+  if (token) {
+    return (
+      <div className="flex items-center justify-center h-screen">
+        <Card className="w-full max-w-sm">
+          <CardHeader>
+            <CardTitle>Set New Password</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <form onSubmit={handleReset} className="space-y-4">
+              <Input type="password" value={password} onChange={e => setPassword(e.target.value)} placeholder="New password" />
+              {error && <p className="text-destructive text-sm">{error}</p>}
+              {message && <p className="text-sm text-green-600">{message}</p>}
+              <Button type="submit" className="w-full">Reset Password</Button>
+            </form>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex items-center justify-center h-screen">
+      <Card className="w-full max-w-sm">
+        <CardHeader>
+          <CardTitle>Request Password Reset</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleRequest} className="space-y-4">
+            <Input type="email" value={email} onChange={e => setEmail(e.target.value)} placeholder="Email" />
+            {error && <p className="text-destructive text-sm">{error}</p>}
+            {message && <p className="text-sm text-green-600">{message}</p>}
+            <Button type="submit" className="w-full">Send Reset Link</Button>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/ui_launchers/web_ui/src/app/signup/page.tsx
+++ b/ui_launchers/web_ui/src/app/signup/page.tsx
@@ -1,0 +1,55 @@
+"use client";
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useAuth } from '@/contexts/AuthContext';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+export default function SignupPage() {
+  const router = useRouter();
+  const { register } = useAuth();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+  const [message, setMessage] = useState('');
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+    setMessage('');
+    if (!email || !password) {
+      setError('Email and password are required');
+      return;
+    }
+    if (password.length < 8) {
+      setError('Password must be at least 8 characters');
+      return;
+    }
+    try {
+      await register({ email, password });
+      setMessage('Registration successful. Check your email for verification link.');
+    } catch (err) {
+      setError((err as Error).message);
+    }
+  };
+
+  return (
+    <div className="flex items-center justify-center h-screen">
+      <Card className="w-full max-w-sm">
+        <CardHeader>
+          <CardTitle>Sign Up</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <Input type="email" value={email} onChange={e => setEmail(e.target.value)} placeholder="Email" />
+            <Input type="password" value={password} onChange={e => setPassword(e.target.value)} placeholder="Password" />
+            {error && <p className="text-destructive text-sm">{error}</p>}
+            {message && <p className="text-sm text-green-600">{message}</p>}
+            <Button type="submit" className="w-full">Create Account</Button>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/ui_launchers/web_ui/src/app/verify-email/page.tsx
+++ b/ui_launchers/web_ui/src/app/verify-email/page.tsx
@@ -1,0 +1,24 @@
+"use client";
+import { useEffect, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
+
+export default function VerifyEmailPage() {
+  const searchParams = useSearchParams();
+  const token = searchParams.get('token');
+  const [message, setMessage] = useState('Verifying...');
+
+  useEffect(() => {
+    const verify = async () => {
+      const res = await fetch(`/api/auth/verify_email?token=${token}`);
+      if (res.ok) setMessage('Email verified. You can log in.');
+      else setMessage('Verification failed');
+    };
+    if (token) verify();
+  }, [token]);
+
+  return (
+    <div className="flex items-center justify-center h-screen">
+      <p>{message}</p>
+    </div>
+  );
+}

--- a/ui_launchers/web_ui/src/contexts/AuthContext.tsx
+++ b/ui_launchers/web_ui/src/contexts/AuthContext.tsx
@@ -90,6 +90,21 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     }
   };
 
+  const register = async (credentials: LoginCredentials): Promise<void> => {
+    await authService.register(credentials);
+  };
+
+  const requestPasswordReset = async (email: string): Promise<void> => {
+    await authService.requestPasswordReset(email);
+  };
+
+  const resetPassword = async (
+    token: string,
+    newPassword: string,
+  ): Promise<void> => {
+    await authService.resetPassword(token, newPassword);
+  };
+
   const logout = (): void => {
     authService.logout();
     setAuthState({
@@ -139,6 +154,9 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     isAuthenticated: authState.isAuthenticated,
     isLoading: authState.isLoading,
     login,
+    register,
+    requestPasswordReset,
+    resetPassword,
     logout,
     refreshUser,
     updateUserPreferences,

--- a/ui_launchers/web_ui/src/services/authService.ts
+++ b/ui_launchers/web_ui/src/services/authService.ts
@@ -25,6 +25,24 @@ export class AuthService {
     return response.json();
   }
 
+  async register(credentials: LoginCredentials): Promise<LoginResponse> {
+    const response = await fetch(`${this.baseUrl}/api/auth/register`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(credentials),
+      credentials: 'include',
+    });
+
+    if (!response.ok) {
+      const error = await response.text();
+      throw new Error(`Register failed: ${error}`);
+    }
+
+    return response.json();
+  }
+
   async getCurrentUser(): Promise<User> {
     const response = await fetch(`${this.baseUrl}/api/auth/me`, {
       method: 'GET',
@@ -72,6 +90,22 @@ export class AuthService {
     await fetch(`${this.baseUrl}/api/auth/logout`, {
       method: 'POST',
       credentials: 'include',
+    });
+  }
+
+  async requestPasswordReset(email: string): Promise<void> {
+    await fetch(`${this.baseUrl}/api/auth/request_password_reset`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email }),
+    });
+  }
+
+  async resetPassword(token: string, newPassword: string): Promise<void> {
+    await fetch(`${this.baseUrl}/api/auth/reset_password`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ token, new_password: newPassword }),
     });
   }
 

--- a/ui_launchers/web_ui/src/types/auth.ts
+++ b/ui_launchers/web_ui/src/types/auth.ts
@@ -48,6 +48,9 @@ export interface AuthContextType {
   isAuthenticated: boolean;
   isLoading: boolean;
   login: (credentials: LoginCredentials) => Promise<void>;
+  register: (credentials: LoginCredentials) => Promise<void>;
+  requestPasswordReset: (email: string) => Promise<void>;
+  resetPassword: (token: string, newPassword: string) => Promise<void>;
   logout: () => void;
   refreshUser: () => Promise<void>;
   updateUserPreferences: (preferences: Partial<User['preferences']>) => Promise<void>;


### PR DESCRIPTION
## Summary
- implement email verification and password reset endpoints
- extend auth manager with verification and reset token logic
- add signup page and password reset page in web UI
- add client-side validation and error handling
- update roadmap documentation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: aiohttp)*

------
https://chatgpt.com/codex/tasks/task_e_6886f71380788324a600acdca7fc298f