### PR TITLE
Add 2FA TOTP and role-based dashboard

### DIFF
--- a/data/users.json
+++ b/data/users.json
@@ -8,7 +8,9 @@
       "language": "en",
       "notifications": true,
       "auto_refresh": true
-    }
+    },
+    "two_factor_enabled": false,
+    "totp_secret": null
   },
   "user@kari.ai": {
     "password": "fc8fc5a0ac094aa8cebf4b73d9fb9a49:c1679d7edf5c3e5c4da03a494b1f06063b2ee3ba192bbfea294fac81ed192003",
@@ -19,6 +21,8 @@
       "language": "en",
       "notifications": true,
       "auto_refresh": false
-    }
+    },
+    "two_factor_enabled": false,
+    "totp_secret": null
   }
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,5 +39,6 @@ sqlalchemy
 alembic
 chardet
 httpx
+pyotp
 tenacity
 pytest-asyncio

--- a/src/ai_karen_engine/api_routes/auth.py
+++ b/src/ai_karen_engine/api_routes/auth.py
@@ -12,6 +12,7 @@ try:
 except Exception:
     from ai_karen_engine.pydantic_stub import BaseModel
 from typing import Any, Dict, List, Optional
+import pyotp
 
 from ai_karen_engine.utils.auth import (
     create_session,
@@ -29,6 +30,10 @@ from ai_karen_engine.security.auth_manager import (
     create_password_reset_token,
     verify_password_reset_token,
     update_password,
+    verify_totp,
+    generate_totp_secret,
+    get_totp_provisioning_uri,
+    enable_two_factor,
 )
 from ai_karen_engine.core.logging import get_logger
 
@@ -49,6 +54,7 @@ RATE_WINDOW = timedelta(minutes=1)
 class LoginRequest(BaseModel):
     email: str
     password: str
+    totp_code: Optional[str] = None
 
 
 class RegisterRequest(BaseModel):
@@ -66,6 +72,7 @@ class LoginResponse(BaseModel):
     roles: List[str]
     tenant_id: str
     preferences: Dict[str, Any]
+    two_factor_enabled: bool = False
 
 
 class TokenResponse(BaseModel):
@@ -79,6 +86,7 @@ class UserResponse(BaseModel):
     roles: List[str]
     tenant_id: str
     preferences: Dict[str, Any]
+    two_factor_enabled: bool = False
 
 
 class UpdateCredentialsRequest(BaseModel):
@@ -120,6 +128,7 @@ async def register(req: RegisterRequest, request: Request, response: Response) -
         roles=user["roles"],
         tenant_id=user.get("tenant_id", "default"),
         preferences=user.get("preferences", {}),
+        two_factor_enabled=user.get("two_factor_enabled", False),
     )
 
 
@@ -142,8 +151,10 @@ async def login(req: LoginRequest, request: Request, response: Response) -> Logi
         )
     if not user.get("is_verified"):
         raise HTTPException(status_code=403, detail="Email not verified")
-    if not user.get("is_verified"):
-        raise HTTPException(status_code=403, detail="Email not verified")
+
+    if user.get("two_factor_enabled"):
+        if not req.totp_code or not verify_totp(req.email, req.totp_code):
+            raise HTTPException(status_code=401, detail="Invalid two-factor code")
 
     tenant_id = user.get("tenant_id") or request.headers.get("X-Tenant-ID", "default")
     token = create_session(
@@ -228,6 +239,7 @@ async def me(request: Request) -> UserResponse:
         roles=list(ctx.get("roles", [])),
         tenant_id=user_data.get("tenant_id", "default"),
         preferences=user_data.get("preferences", {}),
+        two_factor_enabled=user_data.get("two_factor_enabled", False),
     )
 
 
@@ -286,6 +298,7 @@ async def update_creds(
         roles=user.get("roles", []),
         tenant_id=tenant_id,
         preferences=user.get("preferences", {}),
+        two_factor_enabled=user.get("two_factor_enabled", False),
     )
 
 
@@ -330,3 +343,44 @@ async def reset_password(req: PasswordResetConfirm) -> Dict[str, str]:
         raise HTTPException(status_code=400, detail="Invalid token")
     update_password(email, req.new_password)
     return {"detail": "Password updated"}
+
+
+@router.get("/setup_2fa")
+async def setup_two_factor(request: Request) -> Dict[str, str]:
+    token = request.cookies.get(COOKIE_NAME)
+    if not token:
+        raise HTTPException(status_code=401, detail="Not authenticated")
+    ctx = validate_session(token, request.headers.get("user-agent", ""), request.client.host)
+    if not ctx:
+        raise HTTPException(status_code=401, detail="Invalid token")
+    username = ctx["sub"]
+    secret = generate_totp_secret()
+    otpauth_url = get_totp_provisioning_uri(username, secret)
+    _USERS[username]["pending_totp_secret"] = secret
+    save_users()
+    return {"otpauth_url": otpauth_url}
+
+
+class Confirm2FARequest(BaseModel):
+    code: str
+
+
+@router.post("/confirm_2fa")
+async def confirm_two_factor(req: Confirm2FARequest, request: Request) -> Dict[str, str]:
+    token = request.cookies.get(COOKIE_NAME)
+    if not token:
+        raise HTTPException(status_code=401, detail="Not authenticated")
+    ctx = validate_session(token, request.headers.get("user-agent", ""), request.client.host)
+    if not ctx:
+        raise HTTPException(status_code=401, detail="Invalid token")
+    username = ctx["sub"]
+    user = _USERS.get(username)
+    secret = user.get("pending_totp_secret")
+    if not secret:
+        raise HTTPException(status_code=400, detail="No 2FA setup in progress")
+    totp = pyotp.TOTP(secret)
+    if not totp.verify(req.code):
+        raise HTTPException(status_code=400, detail="Invalid code")
+    enable_two_factor(username, secret)
+    user.pop("pending_totp_secret", None)
+    return {"detail": "Two-factor authentication enabled"}

--- a/ui_launchers/web_ui/src/app/login/page.tsx
+++ b/ui_launchers/web_ui/src/app/login/page.tsx
@@ -12,6 +12,7 @@ export default function LoginPage() {
   // In production, inputs should start empty to avoid leaking defaults
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
+  const [totp, setTotp] = useState('')
   const [error, setError] = useState('')
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -22,7 +23,7 @@ export default function LoginPage() {
       return
     }
     try {
-      await login({ email, password })
+      await login({ email, password, totp_code: totp || undefined })
       router.push('/profile')
     } catch (err) {
       setError((err as Error).message)
@@ -39,6 +40,7 @@ export default function LoginPage() {
           <form onSubmit={handleSubmit} className="space-y-4">
             <Input type="email" value={email} onChange={e => setEmail(e.target.value)} placeholder="Email" />
             <Input type="password" value={password} onChange={e => setPassword(e.target.value)} placeholder="Password" />
+            <Input type="text" value={totp} onChange={e => setTotp(e.target.value)} placeholder="2FA code (if enabled)" />
             {error && <p className="text-destructive text-sm">{error}</p>}
             <Button type="submit" className="w-full">Sign In</Button>
             <div className="text-sm text-center space-x-2">

--- a/ui_launchers/web_ui/src/app/page.tsx
+++ b/ui_launchers/web_ui/src/app/page.tsx
@@ -37,6 +37,7 @@ import {
 import { Separator } from '@/components/ui/separator';
 import NotificationsSection from '@/components/sidebar/NotificationsSection';
 import ChatInterface from '@/components/chat/ChatInterface';
+import Dashboard from '@/components/dashboard/Dashboard';
 import { webUIConfig } from '@/lib/config';
 import { AuthProvider } from '@/contexts/AuthContext';
 import { ProtectedRoute } from '@/components/auth/ProtectedRoute';
@@ -44,7 +45,7 @@ import { AuthenticatedHeader } from '@/components/layout/AuthenticatedHeader';
 
 const ExtensionSidebar = dynamic(() => import('@/components/extensions/ExtensionSidebar'));
 
-type ActiveView = 'chat' | 'settings' | 'commsCenter' | 'pluginDatabaseConnector' | 'pluginFacebook' | 'pluginGmail' | 'pluginDateTime' | 'pluginWeather' | 'pluginOverview';
+type ActiveView = 'chat' | 'settings' | 'dashboard' | 'commsCenter' | 'pluginDatabaseConnector' | 'pluginFacebook' | 'pluginGmail' | 'pluginDateTime' | 'pluginWeather' | 'pluginOverview';
 
 export default function HomePage() {
   return (
@@ -101,19 +102,29 @@ function AuthenticatedHomePage() {
               <Separator className="my-1" />
               <AppSidebarContent className="p-2">
                 <SidebarMenu>
-                  <SidebarMenuItem>
-                    <SidebarMenuButton
-                      onClick={() => setActiveMainView('chat')}
-                      isActive={activeMainView === 'chat'}
-                      className="w-full"
-                    >
-                      <MessageSquare />
-                      Chat
-                    </SidebarMenuButton>
-                  </SidebarMenuItem>
-                  <SidebarMenuItem>
-                    <SidebarMenuButton
-                      onClick={() => setActiveMainView('settings')}
+                <SidebarMenuItem>
+                  <SidebarMenuButton
+                    onClick={() => setActiveMainView('chat')}
+                    isActive={activeMainView === 'chat'}
+                    className="w-full"
+                  >
+                    <MessageSquare />
+                    Chat
+                  </SidebarMenuButton>
+                </SidebarMenuItem>
+                <SidebarMenuItem>
+                  <SidebarMenuButton
+                    onClick={() => setActiveMainView('dashboard')}
+                    isActive={activeMainView === 'dashboard'}
+                    className="w-full"
+                  >
+                    <LayoutGrid />
+                    Dashboard
+                  </SidebarMenuButton>
+                </SidebarMenuItem>
+                <SidebarMenuItem>
+                  <SidebarMenuButton
+                    onClick={() => setActiveMainView('settings')}
                       isActive={activeMainView === 'settings'}
                       className="w-full"
                     >
@@ -209,6 +220,7 @@ function AuthenticatedHomePage() {
           <SidebarInset className="flex-1 flex flex-col min-h-0">
             <main className="flex-1 flex flex-col min-h-0 p-4 md:p-6 overflow-y-auto">
               {activeMainView === 'chat' && <ChatInterface />}
+              {activeMainView === 'dashboard' && <Dashboard />}
               {activeMainView === 'settings' && <SettingsDialogComponent />}
               {activeMainView === 'pluginDatabaseConnector' && <DatabaseConnectorPluginPage />}
               {activeMainView === 'pluginFacebook' && <FacebookPluginPage />}

--- a/ui_launchers/web_ui/src/app/profile/page.tsx
+++ b/ui_launchers/web_ui/src/app/profile/page.tsx
@@ -51,6 +51,13 @@ export default function ProfilePage() {
               <Button type="button" variant="secondary" onClick={logout}>Log Out</Button>
             </div>
           </form>
+          <div>
+            {user.two_factor_enabled ? (
+              <a href="/setup-2fa" className="underline">Manage 2FA</a>
+            ) : (
+              <a href="/setup-2fa" className="underline">Enable Two-Factor Authentication</a>
+            )}
+          </div>
         </CardContent>
       </Card>
     </div>

--- a/ui_launchers/web_ui/src/app/setup-2fa/page.tsx
+++ b/ui_launchers/web_ui/src/app/setup-2fa/page.tsx
@@ -1,0 +1,44 @@
+"use client";
+import { useEffect, useState } from 'react';
+import { useAuth } from '@/contexts/AuthContext';
+import { authService } from '@/services/authService';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+
+export default function Setup2FAPage() {
+  const { user, refreshUser } = useAuth();
+  const [qrUrl, setQrUrl] = useState('');
+  const [code, setCode] = useState('');
+  const [message, setMessage] = useState('');
+
+  useEffect(() => {
+    authService.setupTwoFactor().then(res => setQrUrl(res.otpauth_url)).catch(err => setMessage(err.message));
+  }, []);
+
+  const handleConfirm = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      await authService.confirmTwoFactor(code);
+      setMessage('Two-factor authentication enabled');
+      await refreshUser();
+    } catch (err: any) {
+      setMessage(err.message);
+    }
+  };
+
+  if (!user) return null;
+
+  return (
+    <div className="p-6 max-w-md mx-auto space-y-4">
+      <h1 className="text-xl font-semibold">Two-Factor Authentication</h1>
+      {qrUrl && (
+        <img src={`https://api.qrserver.com/v1/create-qr-code/?data=${encodeURIComponent(qrUrl)}`} alt="2FA QR" />
+      )}
+      <form onSubmit={handleConfirm} className="space-y-2">
+        <Input value={code} onChange={e => setCode(e.target.value)} placeholder="Enter code" />
+        <Button type="submit">Confirm</Button>
+      </form>
+      {message && <p className="text-sm">{message}</p>}
+    </div>
+  );
+}

--- a/ui_launchers/web_ui/src/components/dashboard/Dashboard.tsx
+++ b/ui_launchers/web_ui/src/components/dashboard/Dashboard.tsx
@@ -1,0 +1,24 @@
+"use client";
+import { useAuth } from '@/contexts/AuthContext';
+import { HealthDashboard } from '../monitoring/health-dashboard';
+
+export default function Dashboard() {
+  const { user } = useAuth();
+  if (!user) return null;
+  const isAdmin = user.roles.includes('admin') || user.roles.includes('super_admin');
+  return (
+    <div className="space-y-4">
+      {isAdmin ? (
+        <>
+          <h2 className="text-2xl font-semibold">Admin Dashboard</h2>
+          <HealthDashboard />
+        </>
+      ) : (
+        <>
+          <h2 className="text-2xl font-semibold">My Dashboard</h2>
+          <p className="text-muted-foreground">Welcome, {user.email}</p>
+        </>
+      )}
+    </div>
+  );
+}

--- a/ui_launchers/web_ui/src/contexts/AuthContext.tsx
+++ b/ui_launchers/web_ui/src/contexts/AuthContext.tsx
@@ -59,6 +59,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
         email: loginResponse.email,
         roles: loginResponse.roles,
         tenant_id: loginResponse.tenant_id,
+        two_factor_enabled: loginResponse.two_factor_enabled,
         preferences: loginResponse.preferences || {
           personalityTone: 'friendly',
           personalityVerbosity: 'balanced',

--- a/ui_launchers/web_ui/src/services/authService.ts
+++ b/ui_launchers/web_ui/src/services/authService.ts
@@ -25,6 +25,31 @@ export class AuthService {
     return response.json();
   }
 
+  async setupTwoFactor(): Promise<{ otpauth_url: string }> {
+    const response = await fetch(`${this.baseUrl}/api/auth/setup_2fa`, {
+      method: 'GET',
+      credentials: 'include',
+    });
+    if (!response.ok) {
+      const error = await response.text();
+      throw new Error(`Failed to start 2FA setup: ${error}`);
+    }
+    return response.json();
+  }
+
+  async confirmTwoFactor(code: string): Promise<void> {
+    const response = await fetch(`${this.baseUrl}/api/auth/confirm_2fa`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify({ code }),
+    });
+    if (!response.ok) {
+      const error = await response.text();
+      throw new Error(`Failed to enable 2FA: ${error}`);
+    }
+  }
+
   async register(credentials: LoginCredentials): Promise<LoginResponse> {
     const response = await fetch(`${this.baseUrl}/api/auth/register`, {
       method: 'POST',

--- a/ui_launchers/web_ui/src/types/auth.ts
+++ b/ui_launchers/web_ui/src/types/auth.ts
@@ -3,6 +3,7 @@ export interface User {
   email: string;
   roles: string[];
   tenant_id: string;
+  two_factor_enabled: boolean;
   preferences: {
     personalityTone: string;
     personalityVerbosity: string;
@@ -32,6 +33,7 @@ export interface AuthState {
 export interface LoginCredentials {
   email: string;
   password: string;
+  totp_code?: string;
 }
 
 export interface LoginResponse {
@@ -41,6 +43,7 @@ export interface LoginResponse {
   roles: string[];
   tenant_id: string;
   preferences: any;
+  two_factor_enabled: boolean;
 }
 
 export interface AuthContextType {


### PR DESCRIPTION
## Summary
- support pyotp
- extend auth manager with TOTP generation and verification
- enforce 2FA in login API and expose setup/confirm routes
- expose two_factor_enabled status in API responses
- add dashboard view that shows admin vs user layout
- allow login with TOTP code and implement 2FA setup page

## Testing
- `python -m py_compile src/ai_karen_engine/api_routes/auth.py src/ai_karen_engine/security/auth_manager.py`
- `pytest -q` *(fails: ModuleNotFoundError and collection issues)*

------
https://chatgpt.com/codex/tasks/task_e_6886faf1eb408324af207c12d9629d9e