### PR TITLE
Improve login feedback

### DIFF
--- a/src/ui_logic/hooks/auth.py
+++ b/src/ui_logic/hooks/auth.py
@@ -116,11 +116,12 @@ def check_permission(user_ctx: dict, required: List[str]) -> bool:
 
 
 # === Auth API Integration ===
-def api_authenticate(username: str, password: str) -> Optional[dict]:
+def api_authenticate(email: str, password: str) -> Optional[dict]:
     """Authenticate user via backend API; returns user_ctx or None."""
     url = f"{API_BASE_URL}/api/auth/login"
     try:
-        resp = requests.post(url, json={"username": username, "password": password})
+        # Backend expects an email field rather than username
+        resp = requests.post(url, json={"email": email, "password": password})
         if resp.status_code == 200:
             return resp.json()
     except Exception:

--- a/ui_launchers/streamlit_ui/helpers/auth.py
+++ b/ui_launchers/streamlit_ui/helpers/auth.py
@@ -8,14 +8,15 @@ import streamlit as st
 API_URL = os.getenv("KARI_API_URL", "http://localhost:8000")
 
 
-def login(username: str, password: str) -> bool:
+def login(email: str, password: str) -> bool:
     """Authenticate against the backend and persist the token."""
     try:
         import httpx  # imported lazily to avoid dependency during tests
 
         resp = httpx.post(
             f"{API_URL}/api/auth/login",
-            json={"username": username, "password": password},
+            # Backend expects an email field
+            json={"email": email, "password": password},
             timeout=5,
         )
         if resp.status_code == 200:

--- a/ui_launchers/web_ui/src/lib/karen-backend.ts
+++ b/ui_launchers/web_ui/src/lib/karen-backend.ts
@@ -757,10 +757,11 @@ class KarenBackendService {
   }
 
   // --- Authentication ---
-  async login(username: string, password: string): Promise<LoginResult> {
+  async login(email: string, password: string): Promise<LoginResult> {
+    // Backend expects an `email` field for authentication
     return await this.makeRequest<LoginResult>('/api/auth/login', {
       method: 'POST',
-      body: JSON.stringify({ username, password })
+      body: JSON.stringify({ email, password })
     })
   }
 

--- a/ui_launchers/web_ui/src/services/authService.ts
+++ b/ui_launchers/web_ui/src/services/authService.ts
@@ -8,18 +8,32 @@ export class AuthService {
   }
 
   async login(credentials: LoginCredentials): Promise<LoginResponse> {
-    const response = await fetch(`${this.baseUrl}/api/auth/login`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify(credentials),
-      credentials: 'include',
-    });
+    let response: Response;
+    try {
+      response = await fetch(`${this.baseUrl}/api/auth/login`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(credentials),
+        credentials: 'include',
+      });
+    } catch (err) {
+      throw new Error('Network error. Please try again.');
+    }
 
     if (!response.ok) {
-      const error = await response.text();
-      throw new Error(`Login failed: ${error}`);
+      let message = 'Invalid credentials';
+      try {
+        const data = await response.json();
+        if (typeof data.detail === 'string') {
+          message = data.detail;
+        }
+      } catch {
+        const text = await response.text();
+        if (text) message = text;
+      }
+      throw new Error(message);
     }
 
     return response.json();


### PR DESCRIPTION
## Summary
- improve error handling in `AuthService.login`
- send `email` field in Python and TypeScript login helpers

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest tests/test_web_ui_auth.py::test_authentication_flow -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_6887d2b9d9348324a80a1bc76ae49698