### PR TITLE
Improve login feedback

### DIFF
--- a/DEV_SHEET.md
+++ b/DEV_SHEET.md
@@ -44,7 +44,7 @@ This document summarizes the official development protocol for Kari AI. It captu
              │
              ▼
 ┌────────────────────────────┐
-│  Admin Skin (Streamlit)    │
+│  Admin Web UI (Next.js)    │
 │  • Dashboard               │
 │  • LLM Manager             │
 │  • Plugin Manager          │
@@ -58,7 +58,7 @@ This document summarizes the official development protocol for Kari AI. It captu
 | Layer            | Primary Lib / Service                | Rationale                           | Alt (optional)             |
 | ---------------- | ------------------------------------ | ----------------------------------- | -------------------------- |
 | Web API          | **FastAPI**                          | ASGI, type-hint, websockets         | —                          |
-| Realtime UI      | **Streamlit**                        | Headless skin, rapid dev            | Next.js if SSG needed      |
+| Realtime UI      | **Web UI (Next.js)**                 | Default interface for all users     | Streamlit for rapid prototyping |
 | Task Queue       | Celery + Redis                       | Battle-tested, supports KRONOS beat | RQ                         |
 | Vector DB        | **Milvus 2.4**                       | billion-scale, metadata filter      | FAISS (local), Chroma      |
 | Cache            | Redis                                | fast kv / pubsub                    | —                          |

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ AI-Karen is a comprehensive, production-ready AI platform designed for enterpris
 * **Multi-Database Architecture** - PostgreSQL, Redis, DuckDB, Milvus, and Elasticsearch integration
 * **Plugin Ecosystem** - 24+ plugins with hot-reload capability and marketplace integration
 * **Extension System** - Modular extensions for analytics, automation, and workflow building
-* **Multiple UI Interfaces** - Web (Next.js), Desktop (Tauri), and Streamlit applications
+* **Multiple UI Interfaces** - Web (Next.js) is the default interface, with Desktop (Tauri) and Streamlit options
 * **AI/ML Integration** - HuggingFace Transformers, OpenAI API, local LLM support via llama-cpp-python
 * **Production Monitoring** - Prometheus metrics, health checks, and comprehensive logging
 * **Authentication & Security** - JWT-based auth, role-based access control, tenant isolation
@@ -133,7 +133,7 @@ curl http://localhost:8000/health
 
 ### 5. Start Frontend (Choose One)
 
-#### Web UI (Next.js)
+#### Web UI (Next.js, default)
 ```bash
 cd ui_launchers/web_ui
 npm install

--- a/src/ui_logic/hooks/auth.py
+++ b/src/ui_logic/hooks/auth.py
@@ -116,11 +116,12 @@ def check_permission(user_ctx: dict, required: List[str]) -> bool:
 
 
 # === Auth API Integration ===
-def api_authenticate(username: str, password: str) -> Optional[dict]:
+def api_authenticate(email: str, password: str) -> Optional[dict]:
     """Authenticate user via backend API; returns user_ctx or None."""
     url = f"{API_BASE_URL}/api/auth/login"
     try:
-        resp = requests.post(url, json={"username": username, "password": password})
+        # Backend expects an email field rather than username
+        resp = requests.post(url, json={"email": email, "password": password})
         if resp.status_code == 200:
             return resp.json()
     except Exception:

--- a/ui_launchers/streamlit_ui/helpers/auth.py
+++ b/ui_launchers/streamlit_ui/helpers/auth.py
@@ -8,14 +8,15 @@ import streamlit as st
 API_URL = os.getenv("KARI_API_URL", "http://localhost:8000")
 
 
-def login(username: str, password: str) -> bool:
+def login(email: str, password: str) -> bool:
     """Authenticate against the backend and persist the token."""
     try:
         import httpx  # imported lazily to avoid dependency during tests
 
         resp = httpx.post(
             f"{API_URL}/api/auth/login",
-            json={"username": username, "password": password},
+            # Backend expects an email field
+            json={"email": email, "password": password},
             timeout=5,
         )
         if resp.status_code == 200:

--- a/ui_launchers/web_ui/src/lib/karen-backend.ts
+++ b/ui_launchers/web_ui/src/lib/karen-backend.ts
@@ -757,10 +757,11 @@ class KarenBackendService {
   }
 
   // --- Authentication ---
-  async login(username: string, password: string): Promise<LoginResult> {
+  async login(email: string, password: string): Promise<LoginResult> {
+    // Backend expects an `email` field for authentication
     return await this.makeRequest<LoginResult>('/api/auth/login', {
       method: 'POST',
-      body: JSON.stringify({ username, password })
+      body: JSON.stringify({ email, password })
     })
   }
 

--- a/ui_launchers/web_ui/src/services/authService.ts
+++ b/ui_launchers/web_ui/src/services/authService.ts
@@ -8,18 +8,32 @@ export class AuthService {
   }
 
   async login(credentials: LoginCredentials): Promise<LoginResponse> {
-    const response = await fetch(`${this.baseUrl}/api/auth/login`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify(credentials),
-      credentials: 'include',
-    });
+    let response: Response;
+    try {
+      response = await fetch(`${this.baseUrl}/api/auth/login`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(credentials),
+        credentials: 'include',
+      });
+    } catch (err) {
+      throw new Error('Network error. Please try again.');
+    }
 
     if (!response.ok) {
-      const error = await response.text();
-      throw new Error(`Login failed: ${error}`);
+      let message = 'Invalid credentials';
+      try {
+        const data = await response.json();
+        if (typeof data.detail === 'string') {
+          message = data.detail;
+        }
+      } catch {
+        const text = await response.text();
+        if (text) message = text;
+      }
+      throw new Error(message);
     }
 
     return response.json();


### PR DESCRIPTION
## Summary
- improve error handling in `AuthService.login`
- send `email` field in Python and TypeScript login helpers
- clarify that Web UI is the default interface in docs

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest tests/test_web_ui_auth.py::test_authentication_flow -q`


------
https://chatgpt.com/codex/tasks/task_e_6887d2b9d9348324a80a1bc76ae49698