### PR TITLE
Improve spaCy model fallback logic

### DIFF
--- a/src/ai_karen_engine/clients/nlp/spacy_client.py
+++ b/src/ai_karen_engine/clients/nlp/spacy_client.py
@@ -14,23 +14,33 @@ except Exception:  # pragma: no cover - optional dep
     spacy = None
 
 
-DEFAULT_MODEL = "en_core_web_sm"
+TRF_MODEL = "en_core_web_trf"
+SM_MODEL = "en_core_web_sm"
+DEFAULT_MODEL = TRF_MODEL
 
 
 class SpaCyClient:
     """Expose common spaCy pipeline hooks."""
 
-    def __init__(self, model_name: str = DEFAULT_MODEL) -> None:
+    def __init__(self, model_name: str | None = None) -> None:
         if spacy is None:
             raise RuntimeError("spaCy is required for SpaCyClient")
+
+        chosen_model = model_name or DEFAULT_MODEL
         try:
-            self.nlp = spacy.load(model_name)
+            self.nlp = spacy.load(chosen_model)
+            self.model_name = chosen_model
         except Exception:
-            logger.warning(
-                "[SpaCyClient] ⚠️ Failed to load %s. Falling back to en_core_web_sm.",
-                model_name,
-            )
-            self.nlp = spacy.load("en_core_web_sm")
+            if chosen_model != SM_MODEL:
+                logger.warning(
+                    "[SpaCyClient] ⚠️ Failed to load %s. Falling back to %s.",
+                    chosen_model,
+                    SM_MODEL,
+                )
+                self.nlp = spacy.load(SM_MODEL)
+                self.model_name = SM_MODEL
+            else:
+                raise
 
     def extract_entities(self, text: str) -> List[Dict[str, str]]:
         doc = self.nlp(text)

--- a/src/ai_karen_engine/core/default_models.py
+++ b/src/ai_karen_engine/core/default_models.py
@@ -32,9 +32,7 @@ async def load_default_models() -> None:
             spacy_client = SpaCyClient()
             logger.info(
                 "SpaCy model loaded: %s",
-                SpaCyClient.DEFAULT_MODEL
-                if hasattr(SpaCyClient, "DEFAULT_MODEL")
-                else "default",
+                getattr(spacy_client, "model_name", SpaCyClient.DEFAULT_MODEL),
             )
         except Exception as exc:  # pragma: no cover - runtime only
             logger.error("Failed to load spaCy model: %s", exc)

--- a/tests/test_spacy_client_fallback.py
+++ b/tests/test_spacy_client_fallback.py
@@ -1,0 +1,44 @@
+import pytest
+
+from ai_karen_engine.clients.nlp import spacy_client as sc
+
+class DummyNLP:
+    pass
+
+@pytest.fixture
+
+def fake_spacy(monkeypatch):
+    class FakeSpaCy:
+        def __init__(self):
+            self.calls = []
+        def load(self, name):
+            self.calls.append(name)
+            if name == sc.TRF_MODEL:
+                raise OSError("missing")
+            return DummyNLP()
+    fake = FakeSpaCy()
+    monkeypatch.setattr(sc, "spacy", fake)
+    return fake
+
+
+def test_trf_fallback(fake_spacy):
+    client = sc.SpaCyClient()
+    assert isinstance(client.nlp, DummyNLP)
+    assert client.model_name == sc.SM_MODEL
+    assert fake_spacy.calls == [sc.TRF_MODEL, sc.SM_MODEL]
+
+
+def test_explicit_small(monkeypatch):
+    class FakeSpaCy:
+        def __init__(self):
+            self.calls = []
+        def load(self, name):
+            self.calls.append(name)
+            return DummyNLP()
+    fake = FakeSpaCy()
+    monkeypatch.setattr(sc, "spacy", fake)
+    client = sc.SpaCyClient(model_name=sc.SM_MODEL)
+    assert isinstance(client.nlp, DummyNLP)
+    assert client.model_name == sc.SM_MODEL
+    assert fake.calls == [sc.SM_MODEL]
+


### PR DESCRIPTION
## Summary
- default to transformer `en_core_web_trf` in `SpaCyClient`
- fall back to `en_core_web_sm` if the transformer model is unavailable
- log the actual spaCy model loaded by default models
- test the fallback logic for `SpaCyClient`

## Testing
- `pytest tests/test_spacy_client_fallback.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688bb394cdac8324aebf649ff6d49fc4