### PR TITLE
Fix CORS environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,9 @@ helm install ai-karen ./charts/kari/ \
 | `ENABLE_SELF_REFACTOR` | Enable self-refactoring | `false` |
 | `LOG_LEVEL` | Logging level | `INFO` |
 | `KARI_CORS_ORIGINS` | Comma-separated list of allowed CORS origins | `*` |
+| `KARI_CORS_METHODS` | Allowed CORS HTTP methods (comma-separated or `*`) | `*` |
+| `KARI_CORS_HEADERS` | Allowed CORS request headers (comma-separated or `*`) | `*` |
+| `KARI_CORS_CREDENTIALS` | Whether to allow credentials in CORS requests | `true` |
 | `KARI_ECO_MODE` | Skip heavy NLP model loading | `false` |
 | `KARI_MEMORY_SURPRISE_THRESHOLD` | Novelty threshold for storing memory | `0.85` |
 | `KARI_DISABLE_MEMORY_SURPRISE_FILTER` | Disable surprise filtering to store all memories | `false` |

--- a/src/ai_karen.egg-info/PKG-INFO
+++ b/src/ai_karen.egg-info/PKG-INFO
@@ -688,6 +688,9 @@ helm install ai-karen ./charts/kari/ \
 | `ENABLE_SELF_REFACTOR` | Enable self-refactoring | `false` |
 | `LOG_LEVEL` | Logging level | `INFO` |
 | `KARI_CORS_ORIGINS` | Comma-separated list of allowed CORS origins | `*` |
+| `KARI_CORS_METHODS` | Allowed CORS HTTP methods (comma-separated or `*`) | `*` |
+| `KARI_CORS_HEADERS` | Allowed CORS request headers (comma-separated or `*`) | `*` |
+| `KARI_CORS_CREDENTIALS` | Whether to allow credentials in CORS requests | `true` |
 | `KARI_ECO_MODE` | Skip heavy NLP model loading | `false` |
 | `KARI_MEMORY_SURPRISE_THRESHOLD` | Novelty threshold for storing memory | `0.85` |
 | `KARI_DISABLE_MEMORY_SURPRISE_FILTER` | Disable surprise filtering to store all memories | `false` |

--- a/src/ai_karen_engine/core/gateway/middleware.py
+++ b/src/ai_karen_engine/core/gateway/middleware.py
@@ -30,10 +30,10 @@ def setup_cors_middleware(app: FastAPI) -> None:
         app: FastAPI application
     """
     # Get CORS configuration from environment
-    allowed_origins = os.getenv("KAREN_CORS_ORIGINS", "*")
-    allowed_methods = os.getenv("KAREN_CORS_METHODS", "*")
-    allowed_headers = os.getenv("KAREN_CORS_HEADERS", "*")
-    allow_credentials = os.getenv("KAREN_CORS_CREDENTIALS", "true").lower() == "true"
+    allowed_origins = os.getenv("KARI_CORS_ORIGINS", "*")
+    allowed_methods = os.getenv("KARI_CORS_METHODS", "*")
+    allowed_headers = os.getenv("KARI_CORS_HEADERS", "*")
+    allow_credentials = os.getenv("KARI_CORS_CREDENTIALS", "true").lower() == "true"
     
     # Parse origins
     if allowed_origins == "*":

--- a/ui_launchers/web_ui/next.config.ts
+++ b/ui_launchers/web_ui/next.config.ts
@@ -47,7 +47,7 @@ const nextConfig: NextConfig = {
         headers: [
           {
             key: 'Access-Control-Allow-Origin',
-            value: process.env.KAREN_CORS_ORIGINS || 'http://localhost:9002',
+            value: process.env.KARI_CORS_ORIGINS || 'http://localhost:9002',
           },
           {
             key: 'Access-Control-Allow-Methods',

--- a/ui_launchers/web_ui/src/lib/config.ts
+++ b/ui_launchers/web_ui/src/lib/config.ts
@@ -94,7 +94,7 @@ export function getWebUIConfig(): WebUIConfig {
     enableHealthChecks: parseBooleanEnv(process.env.KAREN_ENABLE_HEALTH_CHECKS, true),
 
     // CORS configuration
-    corsOrigins: parseArrayEnv(process.env.KAREN_CORS_ORIGINS, ['http://localhost:9002']),
+    corsOrigins: parseArrayEnv(process.env.KARI_CORS_ORIGINS, ['http://localhost:9002']),
 
     // Performance
     enableServiceWorker: parseBooleanEnv(process.env.KAREN_ENABLE_SERVICE_WORKER, false),


### PR DESCRIPTION
## Summary
- use `KARI_CORS_*` env vars in gateway middleware
- update web UI config to use new env name
- document full set of CORS variables

## Testing
- `PYTHONPATH=src pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_688bb942a2148324973c262d5a8a406e