### PR TITLE
Fix env loading in settings check

### DIFF
--- a/check_settings.py
+++ b/check_settings.py
@@ -1,13 +1,22 @@
+"""Utility script to display key configuration values."""
+
+# ruff: noqa: E402
+
 from pathlib import Path
 
-from dotenv import load_dotenv
+from dotenv import find_dotenv, load_dotenv  # type: ignore
 
-if Path(".env").exists():
-    load_dotenv(".env")
-if Path(".envK").exists():
-    load_dotenv(".envK")
+# Look for environment files relative to this script rather than the
+# current working directory so it behaves consistently when executed
+# from different locations.
+base_dir = Path(__file__).resolve().parent
 
-from ai_karen_engine.core.chat_memory_config import settings
+for name in (".env", ".envK"):
+    env_path = find_dotenv(name, usecwd=False) or (base_dir / name)
+    if Path(env_path).exists():
+        load_dotenv(env_path)
+
+from ai_karen_engine.core.chat_memory_config import settings  # type: ignore
 
 print("database_url =", repr(settings.database_url))
 print("redis_url    =", repr(settings.redis_url))


### PR DESCRIPTION
## Summary
- ensure `check_settings.py` loads `.env` files relative to repo
- silence ruff and mypy for late imports

## Testing
- `pre-commit run --files check_settings.py`
- `pytest tests/test_ai_orchestrator.py::TestFlowManager::test_flow_manager_initialization -q` *(fails: Error importing huggingface_hub.file_download: No module named 'requests.adapters'; 'requests' is not a package)*

------
https://chatgpt.com/codex/tasks/task_e_688bd58fc5c08324b082d63402f64c28