### PR TITLE
fix(web-ui): move alert import to top of globals

### DIFF
--- a/ui_launchers/web_ui/src/app/globals.css
+++ b/ui_launchers/web_ui/src/app/globals.css
@@ -1,9 +1,9 @@
+/* Karen Alert System Styles */
+@import '../styles/karen-alerts.css';
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-
-/* Karen Alert System Styles */
-@import '../styles/karen-alerts.css';
 
 @layer base {
   :root {


### PR DESCRIPTION
## Summary
- place karen-alert styles import before Tailwind directives in globals.css

## Testing
- `npm test` *(fails: React not defined and other test failures)*
- `npm run lint` *(fails: prompts for ESLint configuration)*
- `npm run typecheck` *(fails: TypeScript compile errors in services)*

------
https://chatgpt.com/codex/tasks/task_e_688daa62faf88324918cb215289e2531