### PR TITLE
fix: use valid ui source for web conversations

### DIFF
--- a/tests/test_web_ui_auth.py
+++ b/tests/test_web_ui_auth.py
@@ -3,23 +3,22 @@
 Test script for Web UI authentication integration
 """
 
-import requests
 import json
+
+import requests
+
 
 def test_authentication_flow():
     """Test the complete authentication flow"""
     base_url = "http://localhost:8000"
-    
+
     print("🔐 Testing Web UI Authentication Integration")
     print("=" * 50)
-    
+
     # Test 1: Login with admin credentials
     print("\n1. Testing admin login...")
-    login_data = {
-        "email": "admin@kari.ai",
-        "password": "password123"
-    }
-    
+    login_data = {"email": "admin@kari.ai", "password": "password123"}
+
     try:
         response = requests.post(f"{base_url}/api/auth/login", json=login_data)
         if response.status_code == 200:
@@ -30,16 +29,18 @@ def test_authentication_flow():
             print(f"   Email: {login_result['email']}")
             print(f"   Roles: {login_result['roles']}")
             print(f"   Tenant ID: {login_result['tenant_id']}")
-            print(f"   Preferences: {json.dumps(login_result['preferences'], indent=2)}")
-            
-            admin_token = login_result['token']
+            print(
+                f"   Preferences: {json.dumps(login_result['preferences'], indent=2)}"
+            )
+
+            admin_token = login_result["token"]
         else:
             print(f"❌ Admin login failed: {response.status_code} - {response.text}")
             return False
     except Exception as e:
         print(f"❌ Admin login error: {e}")
         return False
-    
+
     # Test 2: Test /me endpoint with admin token
     print("\n2. Testing /me endpoint with admin token...")
     try:
@@ -58,14 +59,11 @@ def test_authentication_flow():
     except Exception as e:
         print(f"❌ /me endpoint error: {e}")
         return False
-    
+
     # Test 3: Login with user credentials
     print("\n3. Testing user login...")
-    user_login_data = {
-        "email": "user@kari.ai",
-        "password": "password123"
-    }
-    
+    user_login_data = {"email": "user@kari.ai", "password": "password123"}
+
     try:
         response = requests.post(f"{base_url}/api/auth/login", json=user_login_data)
         if response.status_code == 200:
@@ -75,34 +73,37 @@ def test_authentication_flow():
             print(f"   Email: {user_result['email']}")
             print(f"   Roles: {user_result['roles']}")
             print(f"   Tenant ID: {user_result['tenant_id']}")
-            
-            user_token = user_result['token']
+
+            user_token = user_result["token"]
         else:
             print(f"❌ User login failed: {response.status_code} - {response.text}")
             return False
     except Exception as e:
         print(f"❌ User login error: {e}")
         return False
-    
+
     # Test 4: Test conversation creation with authenticated user
     print("\n4. Testing conversation creation...")
     try:
         headers = {"Authorization": f"Bearer {user_token}"}
         conversation_data = {
             "session_id": f"test_session_{int(time.time())}",
-            "ui_source": "web_ui",
+            "ui_source": "web",
             "title": "Test Conversation",
             "user_settings": {},
             "ui_context": {
-                "user_id": user_result['user_id'],
-                "created_from": "test_script"
+                "user_id": user_result["user_id"],
+                "created_from": "test_script",
             },
             "tags": ["test"],
-            "priority": "normal"
+            "priority": "normal",
         }
-        
-        response = requests.post(f"{base_url}/api/conversations/create", 
-                               json=conversation_data, headers=headers)
+
+        response = requests.post(
+            f"{base_url}/api/conversations/create",
+            json=conversation_data,
+            headers=headers,
+        )
         if response.status_code == 200:
             conv_result = response.json()
             print("✅ Conversation creation successful!")
@@ -110,19 +111,18 @@ def test_authentication_flow():
             print(f"   Session ID: {conv_result['conversation']['session_id']}")
             print(f"   Title: {conv_result['conversation']['title']}")
         else:
-            print(f"❌ Conversation creation failed: {response.status_code} - {response.text}")
+            print(
+                f"❌ Conversation creation failed: {response.status_code} - {response.text}"
+            )
             return False
     except Exception as e:
         print(f"❌ Conversation creation error: {e}")
         return False
-    
+
     # Test 5: Test invalid credentials
     print("\n5. Testing invalid credentials...")
-    invalid_data = {
-        "email": "invalid@example.com",
-        "password": "wrong"
-    }
-    
+    invalid_data = {"email": "invalid@example.com", "password": "wrong"}
+
     try:
         response = requests.post(f"{base_url}/api/auth/login", json=invalid_data)
         if response.status_code == 401:
@@ -133,7 +133,7 @@ def test_authentication_flow():
     except Exception as e:
         print(f"❌ Invalid credentials test error: {e}")
         return False
-    
+
     print("\n🎉 All authentication tests passed!")
     print("=" * 50)
     print("✅ Web UI authentication integration is working correctly!")
@@ -143,9 +143,11 @@ def test_authentication_flow():
     print("   - Admin: admin@kari.ai / password123")
     print("   - User: user@kari.ai / password123")
     print("3. Test the chat interface with authenticated users")
-    
+
     return True
+
 
 if __name__ == "__main__":
     import time
+
     test_authentication_flow()

--- a/tests/test_web_ui_models.py
+++ b/tests/test_web_ui_models.py
@@ -2,8 +2,9 @@
 Tests for Web UI integration models and shared types.
 """
 
-import pytest
 from datetime import datetime
+
+import pytest
 
 try:
     from pydantic import ValidationError
@@ -12,72 +13,72 @@ except ImportError:
     class ValidationError(Exception):
         pass
 
-from src.ai_karen_engine.models.shared_types import (
-    MessageRole,
-    MemoryDepth,
-    PersonalityTone,
-    PersonalityVerbosity,
-    TemperatureUnit,
-    WeatherServiceOption,
-    FlowType,
-    ToolType,
-    AiData,
-    ChatMessage,
-    NotificationPreferences,
-    KarenSettings,
-    HandleUserMessageResult,
-    FlowInput,
-    FlowOutput,
-    DecideActionInput,
-    DecideActionOutput,
-    KarenEnhancedInput,
-    KarenEnhancedOutput,
-    ToolInput,
-    MemoryContext,
-    PluginInfo,
-)
 
 from src.ai_karen_engine.database.models import TenantConversation, TenantMemoryEntry
+from src.ai_karen_engine.models.shared_types import (
+    AiData,
+    ChatMessage,
+    DecideActionInput,
+    DecideActionOutput,
+    FlowInput,
+    FlowOutput,
+    FlowType,
+    HandleUserMessageResult,
+    KarenEnhancedInput,
+    KarenEnhancedOutput,
+    KarenSettings,
+    MemoryContext,
+    MemoryDepth,
+    MessageRole,
+    NotificationPreferences,
+    PersonalityTone,
+    PersonalityVerbosity,
+    PluginInfo,
+    TemperatureUnit,
+    ToolInput,
+    ToolType,
+    WeatherServiceOption,
+)
 
 
 class TestSharedTypes:
     """Test shared type definitions."""
-    
+
     def test_message_role_enum(self):
         """Test MessageRole enum values."""
         assert MessageRole.USER == "user"
         assert MessageRole.ASSISTANT == "assistant"
         assert MessageRole.SYSTEM == "system"
-    
+
     def test_memory_depth_enum(self):
         """Test MemoryDepth enum values."""
         assert MemoryDepth.SHORT == "short"
         assert MemoryDepth.MEDIUM == "medium"
         assert MemoryDepth.LONG == "long"
-    
+
     def test_personality_tone_enum(self):
         """Test PersonalityTone enum values."""
         assert PersonalityTone.NEUTRAL == "neutral"
         assert PersonalityTone.FRIENDLY == "friendly"
         assert PersonalityTone.FORMAL == "formal"
         assert PersonalityTone.HUMOROUS == "humorous"
-    
+
     def test_ai_data_model(self):
         """Test AiData model."""
         ai_data = AiData(
             keywords=["test", "keyword"],
             knowledge_graph_insights="Some insights",
             confidence=0.85,
-            reasoning="Test reasoning"
+            reasoning="Test reasoning",
         )
         assert ai_data.keywords == ["test", "keyword"]
         assert ai_data.confidence == 0.85
-        
+
         # Test validation (skip for stub implementation)
         # Note: Validation would fail in real pydantic for confidence > 1.0
         # with pytest.raises(ValidationError):
         #     AiData(confidence=1.5)  # Should fail - confidence > 1.0
-    
+
     def test_chat_message_model(self):
         """Test ChatMessage model."""
         message = ChatMessage(
@@ -86,12 +87,12 @@ class TestSharedTypes:
             content="Hello world",
             timestamp=datetime.now(),
             ai_data=AiData(keywords=["hello"]),
-            should_auto_play=True
+            should_auto_play=True,
         )
         assert message.role == MessageRole.USER
         assert message.content == "Hello world"
         assert message.ai_data.keywords == ["hello"]
-    
+
     def test_karen_settings_model(self):
         """Test KarenSettings model."""
         settings = KarenSettings(
@@ -103,12 +104,12 @@ class TestSharedTypes:
             temperature_unit=TemperatureUnit.FAHRENHEIT,
             weather_service=WeatherServiceOption.CUSTOM_API,
             default_weather_location="New York",
-            active_listen_mode=True
+            active_listen_mode=True,
         )
         assert settings.memory_depth == MemoryDepth.LONG
         assert settings.personal_facts == ["I like coffee", "I work in tech"]
         assert settings.temperature_unit == TemperatureUnit.FAHRENHEIT
-    
+
     def test_flow_input_model(self):
         """Test FlowInput model."""
         flow_input = FlowInput(
@@ -118,12 +119,12 @@ class TestSharedTypes:
             user_id="user-123",
             session_id="session-456",
             memory_depth=MemoryDepth.MEDIUM,
-            personality_tone=PersonalityTone.FRIENDLY
+            personality_tone=PersonalityTone.FRIENDLY,
         )
         assert flow_input.prompt == "What's the weather?"
         assert flow_input.user_id == "user-123"
         assert flow_input.memory_depth == MemoryDepth.MEDIUM
-    
+
     def test_flow_output_model(self):
         """Test FlowOutput model."""
         flow_output = FlowOutput(
@@ -133,7 +134,7 @@ class TestSharedTypes:
             plugin_parameters={"location": "New York"},
             ai_data=AiData(confidence=0.9),
             tool_to_call=ToolType.GET_WEATHER,
-            suggested_new_facts=["User asked about weather"]
+            suggested_new_facts=["User asked about weather"],
         )
         assert flow_output.response == "Here's the weather information"
         assert flow_output.requires_plugin is True
@@ -142,7 +143,7 @@ class TestSharedTypes:
 
 class TestDatabaseModels:
     """Test database model extensions."""
-    
+
     def test_tenant_conversation_web_ui_fields(self):
         """Test TenantConversation web UI integration fields."""
         conversation = TenantConversation(
@@ -154,50 +155,50 @@ class TestDatabaseModels:
             user_settings={"memory_depth": "medium"},
             summary="A conversation about weather",
             tags=["weather", "casual"],
-            last_ai_response_id="response-789"
+            last_ai_response_id="response-789",
         )
-        
+
         assert conversation.session_id == "session-456"
         assert conversation.ui_context["theme"] == "dark"
         assert conversation.ai_insights["sentiment"] == "positive"
         assert conversation.tags == ["weather", "casual"]
         assert conversation.summary == "A conversation about weather"
-    
+
     def test_tenant_conversation_tag_methods(self):
         """Test TenantConversation tag manipulation methods."""
         conversation = TenantConversation(user_id="user-123")
-        
+
         # Test adding tags
         conversation.add_tag("weather")
         conversation.add_tag("casual")
         assert "weather" in conversation.tags
         assert "casual" in conversation.tags
-        
+
         # Test adding duplicate tag (should not duplicate)
         conversation.add_tag("weather")
         assert conversation.tags.count("weather") == 1
-        
+
         # Test removing tag
         conversation.remove_tag("casual")
         assert "casual" not in conversation.tags
         assert "weather" in conversation.tags
-    
+
     def test_tenant_conversation_context_methods(self):
         """Test TenantConversation context update methods."""
         conversation = TenantConversation(user_id="user-123")
-        
+
         # Test updating UI context
         conversation.update_ui_context({"theme": "dark"})
         conversation.update_ui_context({"layout": "compact"})
         assert conversation.ui_context["theme"] == "dark"
         assert conversation.ui_context["layout"] == "compact"
-        
+
         # Test updating AI insights
         conversation.update_ai_insights({"sentiment": "positive"})
         conversation.update_ai_insights({"topics": ["weather"]})
         assert conversation.ai_insights["sentiment"] == "positive"
         assert conversation.ai_insights["topics"] == ["weather"]
-    
+
     def test_tenant_memory_entry_web_ui_fields(self):
         """Test TenantMemoryEntry web UI integration fields."""
         memory_entry = TenantMemoryEntry(
@@ -212,90 +213,84 @@ class TestDatabaseModels:
             access_count=5,
             last_accessed=datetime.now(),
             ai_generated=True,
-            user_confirmed=True
+            user_confirmed=True,
         )
-        
+
         assert memory_entry.ui_source == "web"
         assert memory_entry.conversation_id == "conv-789"
         assert memory_entry.memory_type == "preference"
         assert memory_entry.importance_score == 8
         assert memory_entry.ai_generated is True
-    
+
     def test_tenant_memory_entry_tag_methods(self):
         """Test TenantMemoryEntry tag manipulation methods."""
         memory_entry = TenantMemoryEntry(
-            vector_id="vector-123",
-            user_id="user-456",
-            content="Test content"
+            vector_id="vector-123", user_id="user-456", content="Test content"
         )
-        
+
         # Test adding tags
         memory_entry.add_tag("coffee")
         memory_entry.add_tag("preference")
         assert "coffee" in memory_entry.tags
         assert "preference" in memory_entry.tags
-        
+
         # Test removing tag
         memory_entry.remove_tag("coffee")
         assert "coffee" not in memory_entry.tags
         assert "preference" in memory_entry.tags
-    
+
     def test_tenant_memory_entry_access_tracking(self):
         """Test TenantMemoryEntry access tracking."""
         memory_entry = TenantMemoryEntry(
             vector_id="vector-123",
             user_id="user-456",
             content="Test content",
-            access_count=0
+            access_count=0,
         )
-        
+
         # Test incrementing access count
         initial_time = datetime.now()
         memory_entry.increment_access_count()
         assert memory_entry.access_count == 1
         assert memory_entry.last_accessed >= initial_time
-        
+
         # Test multiple increments
         memory_entry.increment_access_count()
         assert memory_entry.access_count == 2
-    
+
     def test_tenant_memory_entry_importance_validation(self):
         """Test TenantMemoryEntry importance score validation."""
         memory_entry = TenantMemoryEntry(
-            vector_id="vector-123",
-            user_id="user-456",
-            content="Test content"
+            vector_id="vector-123", user_id="user-456", content="Test content"
         )
-        
+
         # Test valid importance scores
         memory_entry.set_importance(1)
         assert memory_entry.importance_score == 1
-        
+
         memory_entry.set_importance(10)
         assert memory_entry.importance_score == 10
-        
+
         memory_entry.set_importance(5)
         assert memory_entry.importance_score == 5
-        
+
         # Test invalid importance scores
         with pytest.raises(ValueError):
             memory_entry.set_importance(0)
-        
+
         with pytest.raises(ValueError):
             memory_entry.set_importance(11)
-    
+
     def test_tenant_memory_entry_metadata_update(self):
         """Test TenantMemoryEntry metadata update."""
         memory_entry = TenantMemoryEntry(
-            vector_id="vector-123",
-            user_id="user-456",
-            content="Test content"
+            vector_id="vector-123", user_id="user-456", content="Test content"
         )
-        
+
         # Test updating metadata
-        memory_entry.update_metadata({"source": "web_ui"})
+        memory_entry.update_metadata({"source": "web"})
         memory_entry.update_metadata({"confidence": 0.85})
-        assert memory_entry.memory_metadata["source"] == "web_ui"
+        assert memory_entry.memory_metadata["source"] == "web"
         assert memory_entry.memory_metadata["confidence"] == 0.85
 
 

--- a/ui_launchers/web_ui/src/services/chatService.ts
+++ b/ui_launchers/web_ui/src/services/chatService.ts
@@ -5,11 +5,11 @@
 
 import { getKarenBackend } from '@/lib/karen-backend';
 import { getApiClient } from '@/lib/api-client';
-import type { 
-  ChatMessage, 
-  KarenSettings, 
+import type {
+  ChatMessage,
+  KarenSettings,
   HandleUserMessageResult,
-  AiData 
+  AiData
 } from '@/lib/types';
 
 export interface ConversationSession {
@@ -70,10 +70,10 @@ export class ChatService {
     try {
       // Generate a unique session ID
       const sessionId = `session_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
-      
+
       const response = await this.apiClient.post('/api/conversations/create', {
         session_id: sessionId,
-        ui_source: 'web_ui',
+        ui_source: 'web',
         title: 'New Conversation',
         user_settings: {},
         ui_context: {
@@ -111,7 +111,7 @@ export class ChatService {
       await this.apiClient.post(`/api/conversations/${conversationId}/messages`, {
         role: message.role,
         content: message.content,
-        ui_source: 'web_ui',
+        ui_source: 'web',
         metadata: {
           ai_data: message.aiData,
           should_auto_play: message.shouldAutoPlay,


### PR DESCRIPTION
## Summary
- ensure web UI calls use the `web` source value expected by backend
- update tests to match `web` UI source

## Testing
- `pre-commit run --files tests/test_web_ui_auth.py tests/test_web_ui_models.py ui_launchers/web_ui/src/services/chatService.ts` *(failed: mypy import errors)*
- `pytest tests/test_web_ui_models.py tests/test_web_ui_auth.py` *(failed: pydantic import error)*

------
https://chatgpt.com/codex/tasks/task_e_688e935b0c2c8324810a8ea5448f4dce