### PR TITLE
Check CUDA availability in DistilBERT service

### DIFF
--- a/src/ai_karen_engine/services/distilbert_service.py
+++ b/src/ai_karen_engine/services/distilbert_service.py
@@ -111,9 +111,13 @@ class DistilBertService:
     
     def _setup_device(self):
         """Setup compute device (GPU/CPU)."""
-        if self.config.enable_gpu and torch.cuda.is_available():
-            device = torch.device("cuda")
-            logger.info(f"Using GPU: {torch.cuda.get_device_name()}")
+        if self.config.enable_gpu:
+            if torch.cuda.is_available():
+                device = torch.device("cuda")
+                logger.info(f"Using GPU: {torch.cuda.get_device_name()}")
+            else:
+                device = torch.device("cpu")
+                logger.info("CUDA unavailable, using CPU for inference")
         else:
             device = torch.device("cpu")
             logger.info("Using CPU for inference")

--- a/tests/services/test_distilbert_service.py
+++ b/tests/services/test_distilbert_service.py
@@ -1,0 +1,46 @@
+import logging
+import sys
+
+# Ensure real numpy is available (tests may provide a stub)
+sys.modules.pop("numpy", None)
+import numpy as real_numpy  # noqa: E402
+sys.modules["numpy"] = real_numpy
+
+import torch
+import ai_karen_engine.services.distilbert_service as ds
+from ai_karen_engine.services.distilbert_service import DistilBertService, DistilBertConfig
+
+
+def _mock_load_model(self):
+    """Return empty tokenizer and model to bypass heavy initialization."""
+    return None, None
+
+
+def test_setup_device_gpu(monkeypatch, caplog):
+    """Service should use GPU when CUDA is available."""
+    monkeypatch.setattr(ds, "torch", torch)
+    monkeypatch.setattr(ds, "TRANSFORMERS_AVAILABLE", True)
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(torch.cuda, "get_device_name", lambda: "Mock GPU")
+    monkeypatch.setattr(DistilBertService, "_load_model", _mock_load_model)
+
+    caplog.set_level(logging.INFO)
+    service = DistilBertService(DistilBertConfig(enable_gpu=True))
+
+    assert service.device.type == "cuda"
+    assert "Using GPU: Mock GPU" in caplog.text
+
+
+def test_setup_device_cpu_when_cuda_unavailable(monkeypatch, caplog):
+    """Service should fall back to CPU when CUDA is unavailable."""
+    monkeypatch.setattr(ds, "torch", torch)
+    monkeypatch.setattr(ds, "TRANSFORMERS_AVAILABLE", True)
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+    monkeypatch.setattr(DistilBertService, "_load_model", _mock_load_model)
+
+    caplog.set_level(logging.INFO)
+    service = DistilBertService(DistilBertConfig(enable_gpu=True))
+
+    assert service.device.type == "cpu"
+    assert "CUDA unavailable, using CPU for inference" in caplog.text
+


### PR DESCRIPTION
## Summary
- ensure DistilBERT service falls back to CPU when CUDA is unavailable
- add tests covering GPU and CPU environments

## Testing
- `pytest tests/services/test_distilbert_service.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688f0bfd668083249affe87629e12aae