### PR TITLE
Restrict plugin management to admin users

### DIFF
--- a/src/ai_karen_engine/api_routes/plugin_routes.py
+++ b/src/ai_karen_engine/api_routes/plugin_routes.py
@@ -27,6 +27,15 @@ from ai_karen_engine.models.web_api_error_responses import (
 
 router = APIRouter(prefix="/api/plugins", tags=["plugins"])
 
+
+def get_current_user() -> Dict[str, Any]:
+    """Retrieve current user context.
+
+    This is a placeholder implementation that always returns an admin user.
+    In production, this should extract the user from the request/session.
+    """
+    return {"user_id": "admin", "roles": ["admin"], "tenant_id": "default"}
+
 logger = get_logger(__name__)
 
 
@@ -290,26 +299,15 @@ async def validate_plugin_parameters(
 @router.post("/{plugin_name}/enable")
 async def enable_plugin(
     plugin_name: str,
-    
-    plugin_service: PluginService = Depends(get_plugin_service)
+    current_user: Dict[str, Any] = Depends(get_current_user),
+    plugin_service: PluginService = Depends(get_plugin_service),
 ):
     """Enable a plugin."""
     try:
-        # TODO: Check if user has admin privileges when auth is implemented
-        # For now, allow all operations for Web UI API
-        # if "admin" not in current_user.get("roles", []):
-        #     error_response = create_generic_error_response(
-        #         error_code=WebAPIErrorCode.AUTHORIZATION_ERROR,
-        #         message="Admin privileges required",
-        #         user_message="You need administrator privileges to perform this action."
-        #     )
-        #     raise HTTPException(
-        #         status_code=get_http_status_for_error_code(WebAPIErrorCode.AUTHORIZATION_ERROR),
-        #         detail=error_response.dict(),
-        #     )
-        
+        if "admin" not in current_user.get("roles", []):
+            raise HTTPException(status_code=403, detail="Admin privileges required")
+
         success = await plugin_service.enable_plugin(plugin_name)
-        
         if not success:
             error_response = create_generic_error_response(
                 error_code=WebAPIErrorCode.NOT_FOUND,
@@ -346,26 +344,15 @@ async def enable_plugin(
 @router.post("/{plugin_name}/disable")
 async def disable_plugin(
     plugin_name: str,
-    
-    plugin_service: PluginService = Depends(get_plugin_service)
+    current_user: Dict[str, Any] = Depends(get_current_user),
+    plugin_service: PluginService = Depends(get_plugin_service),
 ):
     """Disable a plugin."""
     try:
-        # TODO: Check if user has admin privileges when auth is implemented
-        # For now, allow all operations for Web UI API
-        # if "admin" not in current_user.get("roles", []):
-        #     error_response = create_generic_error_response(
-        #         error_code=WebAPIErrorCode.AUTHORIZATION_ERROR,
-        #         message="Admin privileges required",
-        #         user_message="You need administrator privileges to perform this action."
-        #     )
-        #     raise HTTPException(
-        #         status_code=get_http_status_for_error_code(WebAPIErrorCode.AUTHORIZATION_ERROR),
-        #         detail=error_response.dict(),
-        #     )
-        
+        if "admin" not in current_user.get("roles", []):
+            raise HTTPException(status_code=403, detail="Admin privileges required")
+
         success = await plugin_service.disable_plugin(plugin_name)
-        
         if not success:
             error_response = create_generic_error_response(
                 error_code=WebAPIErrorCode.NOT_FOUND,
@@ -469,26 +456,15 @@ async def get_plugin_metrics(
 
 @router.post("/reload")
 async def reload_plugins(
-    
-    plugin_service: PluginService = Depends(get_plugin_service)
+    current_user: Dict[str, Any] = Depends(get_current_user),
+    plugin_service: PluginService = Depends(get_plugin_service),
 ):
     """Reload all plugins from disk."""
     try:
-        # TODO: Check if user has admin privileges when auth is implemented
-        # For now, allow all operations for Web UI API
-        # if "admin" not in current_user.get("roles", []):
-        #     error_response = create_generic_error_response(
-        #         error_code=WebAPIErrorCode.AUTHORIZATION_ERROR,
-        #         message="Admin privileges required",
-        #         user_message="You need administrator privileges to perform this action."
-        #     )
-        #     raise HTTPException(
-        #         status_code=get_http_status_for_error_code(WebAPIErrorCode.AUTHORIZATION_ERROR),
-        #         detail=error_response.dict(),
-        #     )
-        
+        if "admin" not in current_user.get("roles", []):
+            raise HTTPException(status_code=403, detail="Admin privileges required")
+
         count = await plugin_service.reload_plugins()
-        
         return {
             "success": True,
             "message": f"Reloaded {count} plugins successfully",

--- a/tests/test_plugin_routes_permissions.py
+++ b/tests/test_plugin_routes_permissions.py
@@ -1,0 +1,49 @@
+import pytest
+from fastapi import HTTPException
+
+from ai_karen_engine.api_routes.plugin_routes import (
+    enable_plugin,
+    disable_plugin,
+    reload_plugins,
+)
+
+
+class DummyPluginService:
+    async def enable_plugin(self, plugin_name: str) -> bool:  # pragma: no cover - simple stub
+        return True
+
+    async def disable_plugin(self, plugin_name: str) -> bool:  # pragma: no cover - simple stub
+        return True
+
+    async def reload_plugins(self) -> int:  # pragma: no cover - simple stub
+        return 1
+
+
+@pytest.mark.asyncio
+async def test_non_admin_forbidden():
+    service = DummyPluginService()
+    for func, args in [
+        (enable_plugin, ("test",)),
+        (disable_plugin, ("test",)),
+        (reload_plugins, ()),
+    ]:
+        with pytest.raises(HTTPException) as exc:
+            await func(*args, {"roles": ["user"]}, service)
+        assert exc.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_admin_allowed():
+    service = DummyPluginService()
+    result = await enable_plugin("test", {"roles": ["admin"]}, service)
+    assert result == {"success": True, "message": "Plugin test enabled successfully"}
+
+    result = await disable_plugin("test", {"roles": ["admin"]}, service)
+    assert result == {"success": True, "message": "Plugin test disabled successfully"}
+
+    result = await reload_plugins({"roles": ["admin"]}, service)
+    assert result == {
+        "success": True,
+        "message": "Reloaded 1 plugins successfully",
+        "plugins_loaded": 1,
+    }


### PR DESCRIPTION
## Summary
- enforce admin checks when enabling, disabling, or reloading plugins
- provide placeholder `get_current_user` helper
- add unit tests to verify admin-only access

## Testing
- `pytest tests/test_plugin_routes_permissions.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688f375b1e348324916eac6fb65e549e