### PR TITLE
Implement TOTP validation in login

### DIFF
--- a/tests/test_totp_login.py
+++ b/tests/test_totp_login.py
@@ -1,0 +1,85 @@
+"""Tests for TOTP validation during login."""
+
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from ai_karen_engine.api_routes.auth import (
+    login,
+    LoginRequest,
+    auth_service,
+    HTTPException,
+)
+from ai_karen_engine.fastapi_stub import Request, Response
+
+
+@pytest.fixture
+def two_factor_user():
+    return {
+        "user_id": "test@example.com",
+        "email": "test@example.com",
+        "full_name": "Test User",
+        "roles": ["user"],
+        "tenant_id": "default",
+        "preferences": {},
+        "two_factor_enabled": True,
+        "is_verified": True,
+    }
+
+
+@pytest.fixture
+def session_data():
+    return {
+        "access_token": "access",
+        "refresh_token": "refresh",
+        "session_token": "session",
+        "expires_in": 3600,
+    }
+
+
+@pytest.mark.asyncio
+async def test_login_totp_success(two_factor_user, session_data):
+    req = LoginRequest(
+        email="test@example.com",
+        password="secret",
+        totp_code="123456",
+    )
+    request = Request()
+    response = Response()
+    with patch.object(auth_service, "authenticate_user", AsyncMock(return_value=two_factor_user)), \
+         patch.object(auth_service, "create_session", AsyncMock(return_value=session_data)), \
+         patch("ai_karen_engine.api_routes.auth.verify_totp", return_value=True):
+        result = await login(req, request, response)
+
+    assert result.access_token == "access"
+
+
+@pytest.mark.asyncio
+async def test_login_totp_missing_code(two_factor_user):
+    req = LoginRequest(email="test@example.com", password="secret")
+    request = Request()
+    response = Response()
+    with patch.object(auth_service, "authenticate_user", AsyncMock(return_value=two_factor_user)):
+        with pytest.raises(HTTPException) as exc:
+            await login(req, request, response)
+
+    assert exc.value.status_code == 401
+    assert exc.value.detail == "Two-factor authentication required"
+
+
+@pytest.mark.asyncio
+async def test_login_totp_invalid_code(two_factor_user):
+    req = LoginRequest(
+        email="test@example.com",
+        password="secret",
+        totp_code="000000",
+    )
+    request = Request()
+    response = Response()
+    with patch.object(auth_service, "authenticate_user", AsyncMock(return_value=two_factor_user)), \
+         patch("ai_karen_engine.api_routes.auth.verify_totp", return_value=False):
+        with pytest.raises(HTTPException) as exc:
+            await login(req, request, response)
+
+    assert exc.value.status_code == 401
+    assert exc.value.detail == "Invalid two-factor code"
+


### PR DESCRIPTION
## Summary
- validate TOTP codes during login using user secrets
- add unit tests for successful and failed TOTP login attempts

## Testing
- `pytest tests/test_totp_login.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688f377a29148324aa7740215fecf22c