### PR TITLE
Graceful cleanup for memory manager

### DIFF
--- a/src/ai_karen_engine/core/memory/manager.py
+++ b/src/ai_karen_engine/core/memory/manager.py
@@ -209,6 +209,40 @@ def init_memory() -> None:
 # NeuroVault vector index
 neuro_vault = NeuroVault()
 
+
+async def close() -> None:
+    """Clean up memory manager resources."""
+    global pg_syncer, postgres, redis_client
+
+    if pg_syncer:
+        try:
+            pg_syncer.stop()
+        except Exception as ex:  # pragma: no cover - defensive
+            logger.warning(f"[MemoryManager] Postgres syncer stop failed: {ex}")
+        pg_syncer = None
+
+    if postgres:
+        try:
+            conn = getattr(postgres, "conn", None)
+            if conn:
+                conn.close()
+        except Exception as ex:  # pragma: no cover - defensive
+            logger.warning(f"[MemoryManager] Postgres close failed: {ex}")
+        postgres = None
+
+    if redis_client and hasattr(redis_client, "close"):
+        try:
+            redis_client.close()
+        except Exception as ex:  # pragma: no cover - defensive
+            logger.warning(f"[MemoryManager] Redis close failed: {ex}")
+
+    index = getattr(neuro_vault, "index", None)
+    if index and hasattr(index, "disconnect"):
+        try:
+            await index.disconnect()
+        except Exception as ex:  # pragma: no cover - defensive
+            logger.warning(f"[MemoryManager] NeuroVault disconnect failed: {ex}")
+
 # ====== Context Recall ======
 def recall_context(
     user_ctx: Dict[str, Any], query: str, limit: int = 10, tenant_id: Optional[str] = None
@@ -453,6 +487,8 @@ def update_memory(
         )
     return ok
 __all__ = [
+    "init_memory",
+    "close",
     "recall_context",
     "update_memory",
     "flush_duckdb_to_postgres",

--- a/tests/test_memory_manager_close.py
+++ b/tests/test_memory_manager_close.py
@@ -1,0 +1,54 @@
+import sys
+import types
+import pytest
+
+# Stub out heavy Milvus client dependency before importing manager
+milvus_stub = types.ModuleType("ai_karen_engine.clients.database.milvus_client")
+milvus_stub.recall_vectors = None
+milvus_stub.store_vector = None
+sys.modules.setdefault("ai_karen_engine.clients.database.milvus_client", milvus_stub)
+
+import ai_karen_engine.core.memory.manager as manager
+
+
+@pytest.mark.asyncio
+async def test_close_cleans_resources(monkeypatch):
+    stopped = False
+    pg_closed = False
+    redis_closed = False
+    disconnected = False
+
+    class FakePgSyncer:
+        def stop(self):
+            nonlocal stopped
+            stopped = True
+
+    class FakeConn:
+        def close(self):
+            nonlocal pg_closed
+            pg_closed = True
+
+    class FakePostgres:
+        conn = FakeConn()
+
+    class FakeRedis:
+        def close(self):
+            nonlocal redis_closed
+            redis_closed = True
+
+    class FakeIndex:
+        async def disconnect(self):
+            nonlocal disconnected
+            disconnected = True
+
+    monkeypatch.setattr(manager, "pg_syncer", FakePgSyncer())
+    monkeypatch.setattr(manager, "postgres", FakePostgres())
+    monkeypatch.setattr(manager, "redis_client", FakeRedis())
+    monkeypatch.setattr(manager, "neuro_vault", types.SimpleNamespace(index=FakeIndex()))
+
+    await manager.close()
+
+    assert stopped
+    assert pg_closed
+    assert redis_closed
+    assert disconnected


### PR DESCRIPTION
## Summary
- add async cleanup routine for memory manager
- test memory manager cleanup

## Testing
- `pytest tests/test_memory_manager_close.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688f541b7fb883249a07be62c456720e