### PR TITLE
refactor: centralize API route prefixes

### DIFF
--- a/simple_llm_server.py
+++ b/simple_llm_server.py
@@ -26,7 +26,7 @@ app.add_middleware(
 
 # Import and mount LLM routes
 from ai_karen_engine.api_routes.llm_routes import router as llm_router
-app.include_router(llm_router)
+app.include_router(llm_router, prefix="/api/llm")
 
 # Add basic memory and chat endpoints for web UI compatibility
 from fastapi import HTTPException, Request

--- a/src/ai_karen_engine/api_routes/admin.py
+++ b/src/ai_karen_engine/api_routes/admin.py
@@ -11,7 +11,7 @@ from ai_karen_engine.utils.bootstrap import bootstrap_memory_system
 
 logger = logging.getLogger(__name__)
 
-router = APIRouter(prefix="/api/admin", tags=["admin"])
+router = APIRouter(tags=["admin"])
 
 @router.post("/bootstrap_memory")
 async def bootstrap_memory(

--- a/src/ai_karen_engine/api_routes/ag_ui_memory_routes.py
+++ b/src/ai_karen_engine/api_routes/ag_ui_memory_routes.py
@@ -10,7 +10,7 @@ from ai_karen_engine.services.ag_ui_memory_interface import (
 )
 from ai_karen_engine.services.memory_service import WebUIMemoryService
 
-router = APIRouter(prefix="/api/agui/memory", tags=["ag-ui-memory"])
+router = APIRouter(tags=["ag-ui-memory"])
 
 
 @router.post("/query", response_model=AGUIMemoryQueryResponse)

--- a/src/ai_karen_engine/api_routes/ai_orchestrator_routes.py
+++ b/src/ai_karen_engine/api_routes/ai_orchestrator_routes.py
@@ -29,7 +29,7 @@ from ai_karen_engine.models.web_api_error_responses import (
 # Temporarily disable auth imports for web UI integration
 # from ..core.auth import get_current_user, get_tenant_id
 
-router = APIRouter(prefix="/api/ai", tags=["ai-orchestrator"])
+router = APIRouter(tags=["ai-orchestrator"])
 
 logger = get_logger(__name__)
 

--- a/src/ai_karen_engine/api_routes/audit.py
+++ b/src/ai_karen_engine/api_routes/audit.py
@@ -7,7 +7,7 @@ from fastapi import APIRouter, HTTPException, Request
 
 from ai_karen_engine.utils.auth import validate_session
 
-router = APIRouter(prefix="/api/audit", tags=["audit"])
+router = APIRouter(tags=["audit"])
 
 _AUDIT_LOGS: List[dict] = [
     {

--- a/src/ai_karen_engine/api_routes/auth.py
+++ b/src/ai_karen_engine/api_routes/auth.py
@@ -13,7 +13,7 @@ from ai_karen_engine.core.logging import get_logger
 from ai_karen_engine.security.auth_manager import verify_totp
 
 logger = get_logger(__name__)
-router = APIRouter(prefix="/api/auth", tags=["auth"])
+router = APIRouter(tags=["auth"])
 
 # Session cookie configuration
 COOKIE_NAME = "kari_session"

--- a/src/ai_karen_engine/api_routes/chat_memory_routes.py
+++ b/src/ai_karen_engine/api_routes/chat_memory_routes.py
@@ -13,7 +13,7 @@ from ai_karen_engine.services.auth_service import auth_service
 from ai_karen_engine.core.logging import get_logger
 
 logger = get_logger(__name__)
-router = APIRouter(prefix="/api/chats", tags=["chat-memory"])
+router = APIRouter(tags=["chat-memory"])
 
 
 # Request/Response Models

--- a/src/ai_karen_engine/api_routes/code_execution_routes.py
+++ b/src/ai_karen_engine/api_routes/code_execution_routes.py
@@ -48,7 +48,7 @@ from ai_karen_engine.core.logging import get_logger
 
 logger = get_logger(__name__)
 
-router = APIRouter(prefix="/api/code", tags=["code-execution"])
+router = APIRouter(tags=["code-execution"])
 
 # Initialize services
 code_execution_service = CodeExecutionService()

--- a/src/ai_karen_engine/api_routes/conversation_routes.py
+++ b/src/ai_karen_engine/api_routes/conversation_routes.py
@@ -42,7 +42,7 @@ from ai_karen_engine.core.logging import get_logger
 
 logger = get_logger(__name__)
 
-router = APIRouter(prefix="/api/conversations", tags=["conversations"])
+router = APIRouter(tags=["conversations"])
 
 
 # Request/Response Models

--- a/src/ai_karen_engine/api_routes/copilot_routes.py
+++ b/src/ai_karen_engine/api_routes/copilot_routes.py
@@ -66,7 +66,7 @@ class ChatResponse(BaseModel):
     metadata: Dict[str, Any]
 
 # Create router
-router = APIRouter(prefix="/api/copilot", tags=["copilot"])
+router = APIRouter(tags=["copilot"])
 
 def get_copilot_provider() -> CopilotKitProvider:
     """Get CopilotKit provider instance."""

--- a/src/ai_karen_engine/api_routes/database.py
+++ b/src/ai_karen_engine/api_routes/database.py
@@ -42,7 +42,7 @@ from ai_karen_engine.utils.auth import get_current_user, get_tenant_context
 logger = logging.getLogger(__name__)
 DEV_MODE = os.environ.get("DEV_MODE", "false").lower() == "true"
 
-router = APIRouter(prefix="/api/v1/database", tags=["database"])
+router = APIRouter(tags=["database"])
 
 
 # ------------------------------------------------------------------------------

--- a/src/ai_karen_engine/api_routes/enhanced_file_attachment_routes.py
+++ b/src/ai_karen_engine/api_routes/enhanced_file_attachment_routes.py
@@ -62,7 +62,7 @@ from ai_karen_engine.core.logging import get_logger
 
 logger = get_logger(__name__)
 
-router = APIRouter(prefix="/api/files/enhanced", tags=["enhanced-file-attachments"])
+router = APIRouter(tags=["enhanced-file-attachments"])
 
 # Initialize enhanced services
 file_service = get_hook_enabled_file_service()

--- a/src/ai_karen_engine/api_routes/events.py
+++ b/src/ai_karen_engine/api_routes/events.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel
 from ai_karen_engine.event_bus import get_event_bus
 from ai_karen_engine.utils.auth import validate_session
 
-router = APIRouter(prefix="/api/events")
+router = APIRouter()
 
 
 class EventOut(BaseModel):

--- a/src/ai_karen_engine/api_routes/file_attachment_routes.py
+++ b/src/ai_karen_engine/api_routes/file_attachment_routes.py
@@ -59,7 +59,7 @@ from ai_karen_engine.core.logging import get_logger
 
 logger = get_logger(__name__)
 
-router = APIRouter(prefix="/api/files", tags=["file-attachments"])
+router = APIRouter(tags=["file-attachments"])
 
 # Initialize services
 file_service = FileAttachmentService()

--- a/src/ai_karen_engine/api_routes/hook_routes.py
+++ b/src/ai_karen_engine/api_routes/hook_routes.py
@@ -47,7 +47,7 @@ from ai_karen_engine.utils.auth import validate_session
 
 logger = logging.getLogger(__name__)
 
-router = APIRouter(prefix="/api/hooks", tags=["hooks"])
+router = APIRouter(tags=["hooks"])
 
 
 # Request/Response Models

--- a/src/ai_karen_engine/api_routes/llm_routes.py
+++ b/src/ai_karen_engine/api_routes/llm_routes.py
@@ -26,7 +26,7 @@ from ai_karen_engine.core.config_manager import ConfigManager
 
 logger = logging.getLogger("kari.llm_routes")
 
-router = APIRouter(prefix="/api/llm", tags=["llm"])
+router = APIRouter(tags=["llm"])
 
 
 # Request/Response Models

--- a/src/ai_karen_engine/api_routes/memory_ag_ui_routes.py
+++ b/src/ai_karen_engine/api_routes/memory_ag_ui_routes.py
@@ -20,7 +20,7 @@ except ImportError:
 logger = logging.getLogger("kari.api.memory_ag_ui")
 
 # Initialize router
-router = APIRouter(prefix="/api/memory", tags=["memory-ag-ui"])
+router = APIRouter(tags=["memory-ag-ui"])
 
 # Initialize managers
 ag_ui_memory_manager = AGUIMemoryManager()

--- a/src/ai_karen_engine/api_routes/memory_routes.py
+++ b/src/ai_karen_engine/api_routes/memory_routes.py
@@ -42,7 +42,7 @@ from ai_karen_engine.models.web_api_error_responses import (
 # from ..database.client import get_db_client  # Not needed with dependency injection
 # Temporarily disable auth imports for web UI integration
 
-router = APIRouter(prefix="/api/memory", tags=["memory"])
+router = APIRouter(tags=["memory"])
 
 logger = get_logger(__name__)
 

--- a/src/ai_karen_engine/api_routes/persona_routes.py
+++ b/src/ai_karen_engine/api_routes/persona_routes.py
@@ -16,7 +16,7 @@ from ai_karen_engine.models.persona_models import (
 from ai_karen_engine.services.persona_service import get_persona_service
 from ai_karen_engine.utils.auth import get_current_user_context
 
-router = APIRouter(prefix="/api/personas", tags=["personas"])
+router = APIRouter(tags=["personas"])
 
 
 # Request/Response Models

--- a/src/ai_karen_engine/api_routes/plugin_routes.py
+++ b/src/ai_karen_engine/api_routes/plugin_routes.py
@@ -25,7 +25,7 @@ from ai_karen_engine.models.web_api_error_responses import (
 )
 # Temporarily disable auth imports for web UI integration
 
-router = APIRouter(prefix="/api/plugins", tags=["plugins"])
+router = APIRouter(tags=["plugins"])
 
 
 def get_current_user() -> Dict[str, Any]:

--- a/src/ai_karen_engine/api_routes/tool_routes.py
+++ b/src/ai_karen_engine/api_routes/tool_routes.py
@@ -28,7 +28,7 @@ from ai_karen_engine.services.tool_service import (
 from ai_karen_engine.core.dependencies import get_tool_service
 # Temporarily disable auth imports for web UI integration
 
-router = APIRouter(prefix="/api/tools", tags=["tools"])
+router = APIRouter(tags=["tools"])
 
 
 # Request/Response Models

--- a/src/ai_karen_engine/api_routes/web_api_compatibility.py
+++ b/src/ai_karen_engine/api_routes/web_api_compatibility.py
@@ -53,7 +53,7 @@ from ai_karen_engine.integrations.llm_router import LLMProfileRouter
 
 logger = logging.getLogger(__name__)
 
-router = APIRouter(prefix="/api", tags=["web-ui-compatibility"])
+router = APIRouter(tags=["web-ui-compatibility"])
 
 
 def get_request_id(request: Request) -> str:

--- a/src/ai_karen_engine/api_routes/websocket_routes.py
+++ b/src/ai_karen_engine/api_routes/websocket_routes.py
@@ -42,7 +42,7 @@ websocket_gateway: Optional[WebSocketGateway] = None
 stream_processor: Optional[StreamProcessor] = None
 chat_orchestrator: Optional[ChatOrchestrator] = None
 
-router = APIRouter(prefix="/api/ws", tags=["websocket"])
+router = APIRouter(tags=["websocket"])
 
 
 # Request/Response Models

--- a/tests/test_auth_update_credentials.py
+++ b/tests/test_auth_update_credentials.py
@@ -36,7 +36,7 @@ def test_login_and_update_credentials(tmp_path, monkeypatch):
     monkeypatch.setattr(auth_manager, "save_users", lambda: None)
 
     app = FastAPI()
-    app.include_router(auth_routes.router)
+    app.include_router(auth_routes.router, prefix="/api/auth")
     client = TestClient(app)
 
     resp = client.post("/api/auth/login", json={"email": "test@example.com", "password": "pass"})

--- a/tests/test_enhanced_chat_error_handling.py
+++ b/tests/test_enhanced_chat_error_handling.py
@@ -24,7 +24,7 @@ from src.ai_karen_engine.models.shared_types import FlowOutput, AiData
 # Create a test FastAPI app with just the Web UI API router
 if FASTAPI_AVAILABLE:
     test_app = FastAPI()
-    test_app.include_router(router)
+    test_app.include_router(router, prefix="/api")
 else:
     test_app = None
 

--- a/tests/test_hook_api_routes.py
+++ b/tests/test_hook_api_routes.py
@@ -35,7 +35,7 @@ class TestHookAPIRoutes:
     def app(self):
         """Create FastAPI app with hook routes."""
         app = FastAPI()
-        app.include_router(router)
+        app.include_router(router, prefix="/api/hooks")
         return app
     
     @pytest.fixture

--- a/tests/test_intelligent_auth_router.py
+++ b/tests/test_intelligent_auth_router.py
@@ -32,7 +32,7 @@ from ai_karen_engine.security.models import (
 def app():
     """Create FastAPI app with auth router for testing."""
     app = FastAPI()
-    app.include_router(router)
+    app.include_router(router, prefix="/api/auth")
     return app
 
 

--- a/tests/test_web_ui_api_integration.py
+++ b/tests/test_web_ui_api_integration.py
@@ -22,7 +22,7 @@ from src.ai_karen_engine.models.shared_types import FlowOutput, AiData
 # Create a test FastAPI app with just the Web UI API router
 if FASTAPI_AVAILABLE:
     test_app = FastAPI()
-    test_app.include_router(router)
+    test_app.include_router(router, prefix="/api")
 else:
     test_app = None
 


### PR DESCRIPTION
## Summary
- Remove hard-coded prefixes from all API router definitions
- Mount routers with prefixes at include_router call sites and tests
- Demonstrate route registration without duplicate `/api` segments

## Testing
- `PYTHONPATH=src python - <<'PY'
import types, sys, logging
logging.getLogger().setLevel(logging.CRITICAL)
mock_pg=types.SimpleNamespace(click=lambda x,y=None: None, typewrite=lambda text: None, screenshot=lambda path: None)
sys.modules['pyautogui']=mock_pg
sys.modules['mouseinfo']=types.SimpleNamespace()
from main import create_app
app=create_app()
for route in app.routes:
    if route.path.startswith('/api'):
        print(route.path)
PY`
- `PYTHONPATH=src pytest tests/test_auth_update_credentials.py -q` *(fails: FastAPI.__call__() takes 4 positional arguments but 5 were given)*

------
https://chatgpt.com/codex/tasks/task_e_6891fd87dbcc83249959b04acb16c413