### PR TITLE
Use timezone-aware timestamps

### DIFF
--- a/src/ai_karen_engine/api_routes/auth.py
+++ b/src/ai_karen_engine/api_routes/auth.py
@@ -3,14 +3,15 @@ Production Authentication Routes
 Real database-backed authentication with secure session management
 """
 
-from fastapi import APIRouter, HTTPException, Request, Response, status, Depends
-from datetime import datetime, timedelta
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
+
+from fastapi import APIRouter, HTTPException, Request, Response, status
 from pydantic import BaseModel, EmailStr
 
-from ai_karen_engine.services.auth_service import auth_service
 from ai_karen_engine.core.logging import get_logger
 from ai_karen_engine.security.auth_manager import verify_totp
+from ai_karen_engine.services.auth_service import auth_service
 
 logger = get_logger(__name__)
 router = APIRouter(prefix="/api/auth", tags=["auth"])
@@ -71,14 +72,13 @@ class PasswordResetConfirm(BaseModel):
 
 # Authentication Routes
 
+
 @router.post("/register", response_model=LoginResponse)
 async def register(
-    req: RegisterRequest,
-    request: Request,
-    response: Response
+    req: RegisterRequest, request: Request, response: Response
 ) -> LoginResponse:
     """Register a new user with production database"""
-    
+
     try:
         # Create user
         user = await auth_service.create_user(
@@ -87,17 +87,17 @@ async def register(
             full_name=req.full_name,
             roles=req.roles,
             tenant_id=req.tenant_id,
-            preferences=req.preferences
+            preferences=req.preferences,
         )
-        
+
         # Create session
         session_data = await auth_service.create_session(
             user_id=user.user_id,
             ip_address=request.client.host if request.client else "unknown",
             user_agent=request.headers.get("user-agent", ""),
-            device_fingerprint=None  # Could be implemented later
+            device_fingerprint=None,  # Could be implemented later
         )
-        
+
         # Set secure HttpOnly cookie
         response.set_cookie(
             COOKIE_NAME,
@@ -107,7 +107,7 @@ async def register(
             secure=True,
             samesite="strict",
         )
-        
+
         # Convert UserData to dict format
         user_data = {
             "user_id": user.user_id,
@@ -117,77 +117,81 @@ async def register(
             "tenant_id": user.tenant_id,
             "preferences": user.preferences,
             "two_factor_enabled": user.two_factor_enabled,
-            "is_verified": user.is_verified
+            "is_verified": user.is_verified,
         }
-        
-        logger.info(f"User registered successfully: {req.email}")
-        
+
+        logger.info(
+            "User registered successfully",
+            email=req.email,
+            timestamp=datetime.now(timezone.utc).isoformat(),
+        )
+
         return LoginResponse(
             access_token=session_data["access_token"],
             refresh_token=session_data["refresh_token"],
             expires_in=session_data["expires_in"],
-            user=user_data
+            user=user_data,
         )
-        
+
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:
-        logger.error(f"Registration failed: {e}")
+        logger.error(
+            "Registration failed",
+            error=str(e),
+            timestamp=datetime.now(timezone.utc).isoformat(),
+        )
         raise HTTPException(status_code=500, detail="Registration failed")
 
 
 @router.post("/login", response_model=LoginResponse)
 async def login(
-    req: LoginRequest,
-    request: Request,
-    response: Response
+    req: LoginRequest, request: Request, response: Response
 ) -> LoginResponse:
     """Authenticate user with production database"""
-    
+
     try:
         # Authenticate user
         user_data = await auth_service.authenticate_user(
             email=req.email,
             password=req.password,
             ip_address=request.client.host if request.client else "unknown",
-            user_agent=request.headers.get("user-agent", "")
+            user_agent=request.headers.get("user-agent", ""),
         )
-        
+
         if not user_data:
             raise HTTPException(
-                status_code=status.HTTP_401_UNAUTHORIZED,
-                detail="Invalid credentials"
+                status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials"
             )
-        
+
         # Check if email is verified
         if not user_data["is_verified"]:
             raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail="Email not verified"
+                status_code=status.HTTP_403_FORBIDDEN, detail="Email not verified"
             )
-        
+
         # Handle 2FA if enabled
         if user_data["two_factor_enabled"] and not req.totp_code:
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,
-                detail="Two-factor authentication required"
+                detail="Two-factor authentication required",
             )
-        
+
         if user_data["two_factor_enabled"]:
             if not verify_totp(user_data["user_id"], req.totp_code or ""):
                 raise HTTPException(
                     status_code=status.HTTP_401_UNAUTHORIZED,
                     detail="Invalid two-factor code",
                 )
-        
+
         # Create session
         session_data = await auth_service.create_session(
             user_id=user_data["user_id"],
             ip_address=request.client.host if request.client else "unknown",
             user_agent=request.headers.get("user-agent", ""),
-            device_fingerprint=None
+            device_fingerprint=None,
         )
-        
+
         # Set secure HttpOnly cookie
         response.set_cookie(
             COOKIE_NAME,
@@ -197,122 +201,130 @@ async def login(
             secure=True,
             samesite="strict",
         )
-        
-        logger.info(f"User logged in successfully: {req.email}")
-        
+
+        logger.info(
+            "User logged in successfully",
+            email=req.email,
+            timestamp=datetime.now(timezone.utc).isoformat(),
+        )
+
         return LoginResponse(
             access_token=session_data["access_token"],
             refresh_token=session_data["refresh_token"],
             expires_in=session_data["expires_in"],
-            user=user_data
+            user=user_data,
         )
-        
+
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Login failed: {e}")
+        logger.error(
+            "Login failed",
+            error=str(e),
+            timestamp=datetime.now(timezone.utc).isoformat(),
+        )
         raise HTTPException(status_code=500, detail="Login failed")
 
 
 @router.get("/me", response_model=UserResponse)
 async def get_current_user(request: Request) -> UserResponse:
     """Get current user information"""
-    
+
     # Get session token from cookie or header
     session_token = request.cookies.get(COOKIE_NAME)
     if not session_token:
         auth_header = request.headers.get("authorization")
         if auth_header and auth_header.startswith("Bearer "):
             session_token = auth_header.split(" ")[1]
-    
+
     if not session_token:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Missing authentication token"
+            detail="Missing authentication token",
         )
-    
+
     # Validate session
     user_data = await auth_service.validate_session(
         session_token=session_token,
         ip_address=request.client.host if request.client else "unknown",
-        user_agent=request.headers.get("user-agent", "")
+        user_agent=request.headers.get("user-agent", ""),
     )
-    
+
     if not user_data:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Invalid or expired session"
+            detail="Invalid or expired session",
         )
-    
+
     return UserResponse(**user_data)
 
 
 @router.post("/update_credentials", response_model=LoginResponse)
 async def update_credentials(
-    req: UpdateCredentialsRequest,
-    request: Request,
-    response: Response
+    req: UpdateCredentialsRequest, request: Request, response: Response
 ) -> LoginResponse:
     """Update user credentials"""
-    
+
     # Get current user
     session_token = request.cookies.get(COOKIE_NAME)
     if not session_token:
         raise HTTPException(status_code=401, detail="Missing authentication token")
-    
+
     user_data = await auth_service.validate_session(
         session_token=session_token,
         ip_address=request.client.host if request.client else "unknown",
-        user_agent=request.headers.get("user-agent", "")
+        user_agent=request.headers.get("user-agent", ""),
     )
-    
+
     if not user_data:
         raise HTTPException(status_code=401, detail="Invalid session")
-    
+
     try:
         # Update password if provided
         if req.new_password:
             if not req.current_password:
                 raise HTTPException(status_code=400, detail="Current password required")
-            
+
             # Verify current password first
             auth_result = await auth_service.authenticate_user(
                 email=user_data["email"],
                 password=req.current_password,
                 ip_address=request.client.host if request.client else "unknown",
-                user_agent=request.headers.get("user-agent", "")
+                user_agent=request.headers.get("user-agent", ""),
             )
-            
+
             if not auth_result:
-                raise HTTPException(status_code=400, detail="Current password is incorrect")
-            
+                raise HTTPException(
+                    status_code=400, detail="Current password is incorrect"
+                )
+
             # Update password
             success = await auth_service.update_user_password(
-                user_id=user_data["user_id"],
-                new_password=req.new_password
+                user_id=user_data["user_id"], new_password=req.new_password
             )
-            
+
             if not success:
                 raise HTTPException(status_code=500, detail="Failed to update password")
-        
+
         # Update preferences if provided
         if req.preferences:
             success = await auth_service.update_user_preferences(
-                user_id=user_data["user_id"],
-                preferences=req.preferences
+                user_id=user_data["user_id"], preferences=req.preferences
             )
-            
+
             if not success:
-                raise HTTPException(status_code=500, detail="Failed to update preferences")
-        
+                raise HTTPException(
+                    status_code=500, detail="Failed to update preferences"
+                )
+
         # Create new session (invalidates old one)
         session_data = await auth_service.create_session(
             user_id=user_data["user_id"],
             ip_address=request.client.host if request.client else "unknown",
             user_agent=request.headers.get("user-agent", ""),
-            device_fingerprint=None
+            device_fingerprint=None,
         )
-        
+
         # Set new cookie
         response.set_cookie(
             COOKIE_NAME,
@@ -322,93 +334,112 @@ async def update_credentials(
             secure=True,
             samesite="strict",
         )
-        
+
         # Get updated user data
         updated_user = await auth_service.validate_session(
             session_token=session_data["session_token"],
             ip_address=request.client.host if request.client else "unknown",
-            user_agent=request.headers.get("user-agent", "")
+            user_agent=request.headers.get("user-agent", ""),
         )
-        
-        logger.info(f"Credentials updated for user: {user_data['email']}")
-        
+
+        logger.info(
+            "Credentials updated for user",
+            email=user_data["email"],
+            timestamp=datetime.now(timezone.utc).isoformat(),
+        )
+
         return LoginResponse(
             access_token=session_data["access_token"],
             refresh_token=session_data["refresh_token"],
             expires_in=session_data["expires_in"],
-            user=updated_user
+            user=updated_user,
         )
-        
+
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Failed to update credentials: {e}")
+        logger.error(
+            "Failed to update credentials",
+            error=str(e),
+            timestamp=datetime.now(timezone.utc).isoformat(),
+        )
         raise HTTPException(status_code=500, detail="Failed to update credentials")
 
 
 @router.post("/logout")
 async def logout(request: Request, response: Response) -> Dict[str, str]:
     """Logout user and invalidate session"""
-    
+
     session_token = request.cookies.get(COOKIE_NAME)
     if session_token:
         # Invalidate session
         await auth_service.invalidate_session(session_token)
-    
+
     # Clear cookie
     response.delete_cookie(COOKIE_NAME)
-    
+
     return {"detail": "Logged out successfully"}
 
 
 @router.post("/request_password_reset")
 async def request_password_reset(
-    req: PasswordResetRequest,
-    request: Request
+    req: PasswordResetRequest, request: Request
 ) -> Dict[str, str]:
     """Request password reset token"""
-    
+
     try:
         token = await auth_service.create_password_reset_token(
             email=req.email,
             ip_address=request.client.host if request.client else "unknown",
-            user_agent=request.headers.get("user-agent", "")
+            user_agent=request.headers.get("user-agent", ""),
         )
-        
+
         if not token:
             # Don't reveal if user exists or not
             return {"detail": "If the email exists, a reset link has been sent"}
-        
+
         # In production, you would send this token via email
         # For now, log it (remove this in production!)
-        logger.info(f"Password reset token for {req.email}: {token}")
-        
+        logger.info(
+            "Password reset token generated",
+            email=req.email,
+            token=token,
+            timestamp=datetime.now(timezone.utc).isoformat(),
+        )
+
         return {"detail": "Password reset link sent"}
-        
+
     except Exception as e:
-        logger.error(f"Password reset request failed: {e}")
+        logger.error(
+            "Password reset request failed",
+            error=str(e),
+            timestamp=datetime.now(timezone.utc).isoformat(),
+        )
         raise HTTPException(status_code=500, detail="Failed to process request")
 
 
 @router.post("/reset_password")
 async def reset_password(req: PasswordResetConfirm) -> Dict[str, str]:
     """Reset password using token"""
-    
+
     try:
         success = await auth_service.verify_password_reset_token(
-            token=req.token,
-            new_password=req.new_password
+            token=req.token, new_password=req.new_password
         )
-        
+
         if not success:
             raise HTTPException(status_code=400, detail="Invalid or expired token")
-        
+
         return {"detail": "Password updated successfully"}
-        
+
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Password reset failed: {e}")
+        logger.error(
+            "Password reset failed",
+            error=str(e),
+            timestamp=datetime.now(timezone.utc).isoformat(),
+        )
         raise HTTPException(status_code=500, detail="Password reset failed")
 
 
@@ -416,20 +447,25 @@ async def reset_password(req: PasswordResetConfirm) -> Dict[str, str]:
 @router.get("/health")
 async def auth_health_check():
     """Health check for authentication system"""
-    
+
     try:
         # Test database connection by attempting to query
         # This is a simple check - in production you might want more comprehensive checks
         return {
             "status": "healthy",
-            "timestamp": datetime.utcnow().isoformat(),
-            "service": "auth"
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "service": "auth",
         }
-        
+
     except Exception as e:
-        logger.error(f"Auth health check failed: {e}")
+        logger.error(
+            "Auth health check failed",
+            error=str(e),
+            timestamp=datetime.now(timezone.utc).isoformat(),
+        )
         return {
             "status": "unhealthy",
             "error": str(e),
-            "service": "auth"
+            "service": "auth",
+            "timestamp": datetime.now(timezone.utc).isoformat(),
         }

--- a/src/ai_karen_engine/api_routes/code_execution_routes.py
+++ b/src/ai_karen_engine/api_routes/code_execution_routes.py
@@ -3,17 +3,17 @@ FastAPI routes for code execution and tool integration.
 """
 
 import uuid
-from datetime import datetime
-from typing import List, Optional, Dict, Any
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
 
 try:
-    from fastapi import APIRouter, HTTPException, Depends, Query
+    from fastapi import APIRouter, HTTPException, Query
 except Exception:  # pragma: no cover
     from ai_karen_engine.fastapi_stub import APIRouter, HTTPException
-    def Depends(func):
-        return func
+
     def Query(default=None, **_kw):
         return default
+
 
 try:
     from pydantic import BaseModel, Field
@@ -21,30 +21,24 @@ except Exception:
     from ai_karen_engine.pydantic_stub import BaseModel, Field
 
 from ai_karen_engine.chat.code_execution_service import (
-    CodeExecutionService,
     CodeExecutionRequest,
     CodeExecutionResponse,
-    ToolExecutionRequest,
-    ToolDefinition,
+    CodeExecutionService,
     CodeLanguage,
     SecurityLevel,
-    ExecutionStatus
+    ToolDefinition,
 )
 from ai_karen_engine.chat.tool_integration_service import (
-    ToolIntegrationService,
     ToolExecutionContext,
     ToolExecutionResult,
-    ToolType,
-    ToolStatus
-)
-from ai_karen_engine.models.web_api_error_responses import (
-    WebAPIErrorCode,
-    WebAPIErrorResponse,
-    create_service_error_response,
-    create_validation_error_response,
-    get_http_status_for_error_code,
+    ToolIntegrationService,
 )
 from ai_karen_engine.core.logging import get_logger
+from ai_karen_engine.models.web_api_error_responses import (
+    WebAPIErrorCode,
+    create_service_error_response,
+    get_http_status_for_error_code,
+)
 
 logger = get_logger(__name__)
 
@@ -58,24 +52,33 @@ tool_integration_service = ToolIntegrationService()
 # Request/Response Models
 class ExecuteCodeRequest(BaseModel):
     """Request for code execution."""
+
     code: str = Field(..., description="Code to execute")
     language: CodeLanguage = Field(..., description="Programming language")
     user_id: str = Field(..., description="User ID")
     conversation_id: str = Field(..., description="Conversation ID")
-    security_level: SecurityLevel = Field(SecurityLevel.STRICT, description="Security level")
-    execution_limits: Optional[Dict[str, Any]] = Field(None, description="Custom execution limits")
-    environment_vars: Dict[str, str] = Field(default_factory=dict, description="Environment variables")
+    security_level: SecurityLevel = Field(
+        SecurityLevel.STRICT, description="Security level"
+    )
+    execution_limits: Optional[Dict[str, Any]] = Field(
+        None, description="Custom execution limits"
+    )
+    environment_vars: Dict[str, str] = Field(
+        default_factory=dict, description="Environment variables"
+    )
     input_data: Optional[str] = Field(None, description="Input data for the code")
 
 
 class ExecutionHistoryResponse(BaseModel):
     """Response for execution history."""
+
     executions: List[Dict[str, Any]] = Field(..., description="List of executions")
     total_count: int = Field(..., description="Total number of executions")
 
 
 class ToolExecuteRequest(BaseModel):
     """Request for tool execution."""
+
     tool_name: str = Field(..., description="Name of the tool to execute")
     parameters: Dict[str, Any] = Field(..., description="Tool parameters")
     user_id: str = Field(..., description="User ID")
@@ -84,6 +87,7 @@ class ToolExecuteRequest(BaseModel):
 
 class ToolListResponse(BaseModel):
     """Response for tool listing."""
+
     tools: List[Dict[str, Any]] = Field(..., description="List of available tools")
     categories: Dict[str, List[str]] = Field(..., description="Tool categories")
     total_count: int = Field(..., description="Total number of tools")
@@ -91,8 +95,13 @@ class ToolListResponse(BaseModel):
 
 class ServiceStatsResponse(BaseModel):
     """Response for service statistics."""
-    code_execution_stats: Dict[str, Any] = Field(..., description="Code execution statistics")
-    tool_integration_stats: Dict[str, Any] = Field(..., description="Tool integration statistics")
+
+    code_execution_stats: Dict[str, Any] = Field(
+        ..., description="Code execution statistics"
+    )
+    tool_integration_stats: Dict[str, Any] = Field(
+        ..., description="Tool integration statistics"
+    )
 
 
 @router.post("/execute", response_model=CodeExecutionResponse)
@@ -108,24 +117,30 @@ async def execute_code(request: ExecuteCodeRequest):
             security_level=request.security_level,
             execution_limits=request.execution_limits,
             environment_vars=request.environment_vars,
-            input_data=request.input_data
+            input_data=request.input_data,
         )
-        
+
         # Execute code
         result = await code_execution_service.execute_code(exec_request)
-        
+
         return result
-        
+
     except Exception as e:
-        logger.exception("Code execution failed", error=str(e))
+        logger.exception(
+            "Code execution failed",
+            error=str(e),
+            timestamp=datetime.now(timezone.utc).isoformat(),
+        )
         error_response = create_service_error_response(
             service_name="code_execution",
             error=e,
             error_code=WebAPIErrorCode.INTERNAL_SERVER_ERROR,
-            user_message="Code execution failed. Please try again."
+            user_message="Code execution failed. Please try again.",
         )
         raise HTTPException(
-            status_code=get_http_status_for_error_code(WebAPIErrorCode.INTERNAL_SERVER_ERROR),
+            status_code=get_http_status_for_error_code(
+                WebAPIErrorCode.INTERNAL_SERVER_ERROR
+            ),
             detail=error_response.dict(),
         )
 
@@ -135,27 +150,35 @@ async def get_supported_languages():
     """Get list of supported programming languages."""
     try:
         return {
-            "supported_languages": [lang.value for lang in code_execution_service.supported_languages],
+            "supported_languages": [
+                lang.value for lang in code_execution_service.supported_languages
+            ],
             "language_configs": {
                 lang.value: {
                     "executable": config.get("executable"),
                     "file_extension": config.get("file_extension"),
-                    "docker_image": config.get("docker_image")
+                    "docker_image": config.get("docker_image"),
                 }
                 for lang, config in code_execution_service._language_configs.items()
-            }
+            },
         }
-        
+
     except Exception as e:
-        logger.exception("Failed to get supported languages", error=str(e))
+        logger.exception(
+            "Failed to get supported languages",
+            error=str(e),
+            timestamp=datetime.now(timezone.utc).isoformat(),
+        )
         error_response = create_service_error_response(
             service_name="code_execution",
             error=e,
             error_code=WebAPIErrorCode.INTERNAL_SERVER_ERROR,
-            user_message="Failed to get supported languages. Please try again."
+            user_message="Failed to get supported languages. Please try again.",
         )
         raise HTTPException(
-            status_code=get_http_status_for_error_code(WebAPIErrorCode.INTERNAL_SERVER_ERROR),
+            status_code=get_http_status_for_error_code(
+                WebAPIErrorCode.INTERNAL_SERVER_ERROR
+            ),
             detail=error_response.dict(),
         )
 
@@ -163,28 +186,35 @@ async def get_supported_languages():
 @router.get("/history", response_model=ExecutionHistoryResponse)
 async def get_execution_history(
     user_id: Optional[str] = Query(None, description="Filter by user ID"),
-    limit: int = Query(50, ge=1, le=100, description="Maximum number of executions")
+    limit: int = Query(50, ge=1, le=100, description="Maximum number of executions"),
 ):
     """Get code execution history."""
     try:
         # Get execution history from code execution service
-        code_history = code_execution_service.get_execution_history(user_id or "", limit)
-        
-        return ExecutionHistoryResponse(
-            executions=code_history,
-            total_count=len(code_history)
+        code_history = code_execution_service.get_execution_history(
+            user_id or "", limit
         )
-        
+
+        return ExecutionHistoryResponse(
+            executions=code_history, total_count=len(code_history)
+        )
+
     except Exception as e:
-        logger.exception("Failed to get execution history", error=str(e))
+        logger.exception(
+            "Failed to get execution history",
+            error=str(e),
+            timestamp=datetime.now(timezone.utc).isoformat(),
+        )
         error_response = create_service_error_response(
             service_name="code_execution",
             error=e,
             error_code=WebAPIErrorCode.INTERNAL_SERVER_ERROR,
-            user_message="Failed to get execution history. Please try again."
+            user_message="Failed to get execution history. Please try again.",
         )
         raise HTTPException(
-            status_code=get_http_status_for_error_code(WebAPIErrorCode.INTERNAL_SERVER_ERROR),
+            status_code=get_http_status_for_error_code(
+                WebAPIErrorCode.INTERNAL_SERVER_ERROR
+            ),
             detail=error_response.dict(),
         )
 
@@ -194,36 +224,39 @@ async def cancel_execution(execution_id: str):
     """Cancel an active code execution."""
     try:
         success = await code_execution_service.cancel_execution(execution_id)
-        
+
         if not success:
             error_response = create_service_error_response(
                 service_name="code_execution",
                 error=Exception("Execution not found or already completed"),
                 error_code=WebAPIErrorCode.NOT_FOUND,
-                user_message="The execution could not be found or is already completed."
+                user_message="The execution could not be found or is already completed.",
             )
             raise HTTPException(
                 status_code=get_http_status_for_error_code(WebAPIErrorCode.NOT_FOUND),
                 detail=error_response.dict(),
             )
-        
-        return {
-            "success": True,
-            "message": "Execution cancelled successfully"
-        }
-        
+
+        return {"success": True, "message": "Execution cancelled successfully"}
+
     except HTTPException:
         raise
     except Exception as e:
-        logger.exception("Failed to cancel execution", error=str(e))
+        logger.exception(
+            "Failed to cancel execution",
+            error=str(e),
+            timestamp=datetime.now(timezone.utc).isoformat(),
+        )
         error_response = create_service_error_response(
             service_name="code_execution",
             error=e,
             error_code=WebAPIErrorCode.INTERNAL_SERVER_ERROR,
-            user_message="Failed to cancel execution. Please try again."
+            user_message="Failed to cancel execution. Please try again.",
         )
         raise HTTPException(
-            status_code=get_http_status_for_error_code(WebAPIErrorCode.INTERNAL_SERVER_ERROR),
+            status_code=get_http_status_for_error_code(
+                WebAPIErrorCode.INTERNAL_SERVER_ERROR
+            ),
             detail=error_response.dict(),
         )
 
@@ -237,28 +270,32 @@ async def execute_tool(request: ToolExecuteRequest):
             user_id=request.user_id,
             conversation_id=request.conversation_id,
             execution_id=str(uuid.uuid4()),
-            timestamp=datetime.utcnow()
+            timestamp=datetime.now(timezone.utc),
         )
-        
+
         # Execute tool
         result = await tool_integration_service.execute_tool(
-            request.tool_name,
-            request.parameters,
-            context
+            request.tool_name, request.parameters, context
         )
-        
+
         return result
-        
+
     except Exception as e:
-        logger.exception("Tool execution failed", error=str(e))
+        logger.exception(
+            "Tool execution failed",
+            error=str(e),
+            timestamp=datetime.now(timezone.utc).isoformat(),
+        )
         error_response = create_service_error_response(
             service_name="tool_integration",
             error=e,
             error_code=WebAPIErrorCode.INTERNAL_SERVER_ERROR,
-            user_message="Tool execution failed. Please try again."
+            user_message="Tool execution failed. Please try again.",
         )
         raise HTTPException(
-            status_code=get_http_status_for_error_code(WebAPIErrorCode.INTERNAL_SERVER_ERROR),
+            status_code=get_http_status_for_error_code(
+                WebAPIErrorCode.INTERNAL_SERVER_ERROR
+            ),
             detail=error_response.dict(),
         )
 
@@ -266,7 +303,9 @@ async def execute_tool(request: ToolExecuteRequest):
 @router.get("/tools", response_model=ToolListResponse)
 async def list_tools(
     category: Optional[str] = Query(None, description="Filter by category"),
-    search: Optional[str] = Query(None, description="Search tools by name or description")
+    search: Optional[str] = Query(
+        None, description="Search tools by name or description"
+    ),
 ):
     """List available tools."""
     try:
@@ -274,25 +313,29 @@ async def list_tools(
             tools = tool_integration_service.search_tools(search)
         else:
             tools = tool_integration_service.get_available_tools(category)
-        
+
         categories = tool_integration_service.get_categories()
-        
+
         return ToolListResponse(
-            tools=tools,
-            categories=categories,
-            total_count=len(tools)
+            tools=tools, categories=categories, total_count=len(tools)
         )
-        
+
     except Exception as e:
-        logger.exception("Failed to list tools", error=str(e))
+        logger.exception(
+            "Failed to list tools",
+            error=str(e),
+            timestamp=datetime.now(timezone.utc).isoformat(),
+        )
         error_response = create_service_error_response(
             service_name="tool_integration",
             error=e,
             error_code=WebAPIErrorCode.INTERNAL_SERVER_ERROR,
-            user_message="Failed to list tools. Please try again."
+            user_message="Failed to list tools. Please try again.",
         )
         raise HTTPException(
-            status_code=get_http_status_for_error_code(WebAPIErrorCode.INTERNAL_SERVER_ERROR),
+            status_code=get_http_status_for_error_code(
+                WebAPIErrorCode.INTERNAL_SERVER_ERROR
+            ),
             detail=error_response.dict(),
         )
 
@@ -302,33 +345,39 @@ async def get_tool_info(tool_name: str):
     """Get detailed information about a specific tool."""
     try:
         tool_info = tool_integration_service.get_tool_info(tool_name)
-        
+
         if not tool_info:
             error_response = create_service_error_response(
                 service_name="tool_integration",
                 error=Exception("Tool not found"),
                 error_code=WebAPIErrorCode.NOT_FOUND,
-                user_message="The requested tool could not be found."
+                user_message="The requested tool could not be found.",
             )
             raise HTTPException(
                 status_code=get_http_status_for_error_code(WebAPIErrorCode.NOT_FOUND),
                 detail=error_response.dict(),
             )
-        
+
         return tool_info
-        
+
     except HTTPException:
         raise
     except Exception as e:
-        logger.exception("Failed to get tool info", error=str(e))
+        logger.exception(
+            "Failed to get tool info",
+            error=str(e),
+            timestamp=datetime.now(timezone.utc).isoformat(),
+        )
         error_response = create_service_error_response(
             service_name="tool_integration",
             error=e,
             error_code=WebAPIErrorCode.INTERNAL_SERVER_ERROR,
-            user_message="Failed to get tool information. Please try again."
+            user_message="Failed to get tool information. Please try again.",
         )
         raise HTTPException(
-            status_code=get_http_status_for_error_code(WebAPIErrorCode.INTERNAL_SERVER_ERROR),
+            status_code=get_http_status_for_error_code(
+                WebAPIErrorCode.INTERNAL_SERVER_ERROR
+            ),
             detail=error_response.dict(),
         )
 
@@ -337,31 +386,32 @@ async def get_tool_info(tool_name: str):
 async def get_tool_execution_history(
     user_id: Optional[str] = Query(None, description="Filter by user ID"),
     tool_name: Optional[str] = Query(None, description="Filter by tool name"),
-    limit: int = Query(50, ge=1, le=100, description="Maximum number of executions")
+    limit: int = Query(50, ge=1, le=100, description="Maximum number of executions"),
 ):
     """Get tool execution history."""
     try:
         history = tool_integration_service.get_execution_history(
-            user_id=user_id,
-            tool_name=tool_name,
-            limit=limit
+            user_id=user_id, tool_name=tool_name, limit=limit
         )
-        
-        return ExecutionHistoryResponse(
-            executions=history,
-            total_count=len(history)
-        )
-        
+
+        return ExecutionHistoryResponse(executions=history, total_count=len(history))
+
     except Exception as e:
-        logger.exception("Failed to get tool execution history", error=str(e))
+        logger.exception(
+            "Failed to get tool execution history",
+            error=str(e),
+            timestamp=datetime.now(timezone.utc).isoformat(),
+        )
         error_response = create_service_error_response(
             service_name="tool_integration",
             error=e,
             error_code=WebAPIErrorCode.INTERNAL_SERVER_ERROR,
-            user_message="Failed to get tool execution history. Please try again."
+            user_message="Failed to get tool execution history. Please try again.",
         )
         raise HTTPException(
-            status_code=get_http_status_for_error_code(WebAPIErrorCode.INTERNAL_SERVER_ERROR),
+            status_code=get_http_status_for_error_code(
+                WebAPIErrorCode.INTERNAL_SERVER_ERROR
+            ),
             detail=error_response.dict(),
         )
 
@@ -372,24 +422,30 @@ async def register_custom_tool(tool_definition: ToolDefinition):
     try:
         # Note: In a production system, this would require proper authentication
         # and validation of the tool definition for security
-        
+
         # For now, return a placeholder response
         return {
             "success": False,
             "message": "Custom tool registration is not yet implemented",
-            "tool_name": tool_definition.name
+            "tool_name": tool_definition.name,
         }
-        
+
     except Exception as e:
-        logger.exception("Failed to register custom tool", error=str(e))
+        logger.exception(
+            "Failed to register custom tool",
+            error=str(e),
+            timestamp=datetime.now(timezone.utc).isoformat(),
+        )
         error_response = create_service_error_response(
             service_name="tool_integration",
             error=e,
             error_code=WebAPIErrorCode.INTERNAL_SERVER_ERROR,
-            user_message="Failed to register custom tool. Please try again."
+            user_message="Failed to register custom tool. Please try again.",
         )
         raise HTTPException(
-            status_code=get_http_status_for_error_code(WebAPIErrorCode.INTERNAL_SERVER_ERROR),
+            status_code=get_http_status_for_error_code(
+                WebAPIErrorCode.INTERNAL_SERVER_ERROR
+            ),
             detail=error_response.dict(),
         )
 
@@ -400,22 +456,27 @@ async def get_service_stats():
     try:
         code_stats = code_execution_service.get_service_stats()
         tool_stats = tool_integration_service.get_service_stats()
-        
+
         return ServiceStatsResponse(
-            code_execution_stats=code_stats,
-            tool_integration_stats=tool_stats
+            code_execution_stats=code_stats, tool_integration_stats=tool_stats
         )
-        
+
     except Exception as e:
-        logger.exception("Failed to get service stats", error=str(e))
+        logger.exception(
+            "Failed to get service stats",
+            error=str(e),
+            timestamp=datetime.now(timezone.utc).isoformat(),
+        )
         error_response = create_service_error_response(
             service_name="code_execution",
             error=e,
             error_code=WebAPIErrorCode.INTERNAL_SERVER_ERROR,
-            user_message="Failed to get service statistics. Please try again."
+            user_message="Failed to get service statistics. Please try again.",
         )
         raise HTTPException(
-            status_code=get_http_status_for_error_code(WebAPIErrorCode.INTERNAL_SERVER_ERROR),
+            status_code=get_http_status_for_error_code(
+                WebAPIErrorCode.INTERNAL_SERVER_ERROR
+            ),
             detail=error_response.dict(),
         )
 
@@ -432,7 +493,7 @@ async def get_security_levels():
                     "max_execution_time": 15.0,
                     "max_memory_mb": 256,
                     "allow_network": False,
-                    "allow_file_system": False
+                    "allow_file_system": False,
                 },
                 {
                     "level": SecurityLevel.MODERATE.value,
@@ -440,7 +501,7 @@ async def get_security_levels():
                     "max_execution_time": 30.0,
                     "max_memory_mb": 512,
                     "allow_network": False,
-                    "allow_file_system": True
+                    "allow_file_system": True,
                 },
                 {
                     "level": SecurityLevel.PERMISSIVE.value,
@@ -448,20 +509,26 @@ async def get_security_levels():
                     "max_execution_time": 60.0,
                     "max_memory_mb": 1024,
                     "allow_network": True,
-                    "allow_file_system": True
-                }
+                    "allow_file_system": True,
+                },
             ]
         }
-        
+
     except Exception as e:
-        logger.exception("Failed to get security levels", error=str(e))
+        logger.exception(
+            "Failed to get security levels",
+            error=str(e),
+            timestamp=datetime.now(timezone.utc).isoformat(),
+        )
         error_response = create_service_error_response(
             service_name="code_execution",
             error=e,
             error_code=WebAPIErrorCode.INTERNAL_SERVER_ERROR,
-            user_message="Failed to get security levels. Please try again."
+            user_message="Failed to get security levels. Please try again.",
         )
         raise HTTPException(
-            status_code=get_http_status_for_error_code(WebAPIErrorCode.INTERNAL_SERVER_ERROR),
+            status_code=get_http_status_for_error_code(
+                WebAPIErrorCode.INTERNAL_SERVER_ERROR
+            ),
             detail=error_response.dict(),
         )

--- a/src/ai_karen_engine/api_routes/plugin_routes.py
+++ b/src/ai_karen_engine/api_routes/plugin_routes.py
@@ -1,28 +1,24 @@
-"""
-FastAPI routes for Plugin service integration.
-"""
+"""FastAPI routes for Plugin service integration."""
 
-import uuid
-from datetime import datetime
-from typing import List, Optional, Dict, Any
-from fastapi import APIRouter, HTTPException, Depends, Query, Request
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, Field
 
-from ai_karen_engine.services.plugin_service import PluginService
-# Note: PluginInfo, PluginExecutionRequest, PluginExecutionResult, PluginStatus 
-# classes need to be implemented in the plugin service
 from ai_karen_engine.core.dependencies import get_plugin_service
 from ai_karen_engine.core.logging import get_logger
 from ai_karen_engine.models.web_api_error_responses import (
     WebAPIErrorCode,
-    WebAPIErrorResponse,
-    ValidationErrorDetail,
-    create_service_error_response,
-    create_validation_error_response,
-    create_database_error_response,
     create_generic_error_response,
+    create_service_error_response,
     get_http_status_for_error_code,
 )
+from ai_karen_engine.services.plugin_service import (
+    PluginExecutionRequest,
+    PluginService,
+)
+
 # Temporarily disable auth imports for web UI integration
 
 router = APIRouter(prefix="/api/plugins", tags=["plugins"])
@@ -36,26 +32,34 @@ def get_current_user() -> Dict[str, Any]:
     """
     return {"user_id": "admin", "roles": ["admin"], "tenant_id": "default"}
 
+
 logger = get_logger(__name__)
 
 
 # Request/Response Models
 class ExecutePluginRequest(BaseModel):
     """Request model for plugin execution."""
+
     plugin_name: str = Field(..., description="Name of plugin to execute")
-    parameters: Dict[str, Any] = Field(default_factory=dict, description="Plugin parameters")
+    parameters: Dict[str, Any] = Field(
+        default_factory=dict, description="Plugin parameters"
+    )
     timeout: int = Field(30, ge=1, le=300, description="Execution timeout in seconds")
     session_id: Optional[str] = Field(None, description="Session ID")
 
 
 class ValidatePluginRequest(BaseModel):
     """Request model for plugin validation."""
+
     plugin_name: str = Field(..., description="Name of plugin to validate")
-    parameters: Dict[str, Any] = Field(default_factory=dict, description="Plugin parameters to validate")
+    parameters: Dict[str, Any] = Field(
+        default_factory=dict, description="Plugin parameters to validate"
+    )
 
 
 class PluginInfoResponse(BaseModel):
     """Response model for plugin information."""
+
     name: str
     description: str
     version: str
@@ -73,6 +77,7 @@ class PluginInfoResponse(BaseModel):
 
 class PluginExecutionResponse(BaseModel):
     """Response model for plugin execution."""
+
     success: bool
     result: Optional[Any] = None
     stdout: Optional[str] = None
@@ -86,6 +91,7 @@ class PluginExecutionResponse(BaseModel):
 
 class PluginListResponse(BaseModel):
     """Response model for plugin list."""
+
     plugins: List[PluginInfoResponse]
     total_count: int
     enabled_count: int
@@ -94,6 +100,7 @@ class PluginListResponse(BaseModel):
 
 class PluginMetricsResponse(BaseModel):
     """Response model for plugin metrics."""
+
     total_plugins: int
     enabled_plugins: int
     total_executions: int
@@ -109,55 +116,61 @@ class PluginMetricsResponse(BaseModel):
 async def list_plugins(
     category: Optional[str] = Query(None, description="Filter by category"),
     enabled_only: bool = Query(False, description="Only return enabled plugins"),
-    plugin_service: PluginService = Depends(get_plugin_service)
+    plugin_service: PluginService = Depends(get_plugin_service),
 ):
     """List all available plugins."""
     try:
         plugins = await plugin_service.list_plugins()
-        
+
         # Apply filters
         if category:
             plugins = [p for p in plugins if p.category.lower() == category.lower()]
-        
+
         if enabled_only:
             plugins = [p for p in plugins if p.enabled]
-        
+
         # Convert to response format
         plugin_responses = []
         for plugin in plugins:
-            plugin_responses.append(PluginInfoResponse(
-                name=plugin.name,
-                description=plugin.description,
-                version=plugin.version,
-                category=plugin.category,
-                status=plugin.status.value,
-                parameters=plugin.parameters,
-                author=plugin.author,
-                enabled=plugin.enabled,
-                tags=getattr(plugin, 'tags', []),
-                dependencies=getattr(plugin, 'dependencies', []),
-                last_executed=getattr(plugin, 'last_executed', None),
-                execution_count=getattr(plugin, 'execution_count', 0),
-                success_rate=getattr(plugin, 'success_rate', 0.0)
-            ))
-        
+            plugin_responses.append(
+                PluginInfoResponse(
+                    name=plugin.name,
+                    description=plugin.description,
+                    version=plugin.version,
+                    category=plugin.category,
+                    status=plugin.status.value,
+                    parameters=plugin.parameters,
+                    author=plugin.author,
+                    enabled=plugin.enabled,
+                    tags=getattr(plugin, "tags", []),
+                    dependencies=getattr(plugin, "dependencies", []),
+                    last_executed=getattr(plugin, "last_executed", None),
+                    execution_count=getattr(plugin, "execution_count", 0),
+                    success_rate=getattr(plugin, "success_rate", 0.0),
+                )
+            )
+
         enabled_count = sum(1 for p in plugin_responses if p.enabled)
         disabled_count = len(plugin_responses) - enabled_count
-        
+
         return PluginListResponse(
             plugins=plugin_responses,
             total_count=len(plugin_responses),
             enabled_count=enabled_count,
-            disabled_count=disabled_count
+            disabled_count=disabled_count,
         )
-        
+
     except Exception as e:
-        logger.exception("Failed to list plugins", error=str(e))
+        logger.exception(
+            "Failed to list plugins",
+            error=str(e),
+            timestamp=datetime.now(timezone.utc).isoformat(),
+        )
         error_response = create_service_error_response(
             service_name="plugin",
             error=e,
             error_code=WebAPIErrorCode.PLUGIN_ERROR,
-            user_message="Failed to list plugins. Please try again."
+            user_message="Failed to list plugins. Please try again.",
         )
         raise HTTPException(
             status_code=get_http_status_for_error_code(WebAPIErrorCode.PLUGIN_ERROR),
@@ -167,25 +180,24 @@ async def list_plugins(
 
 @router.get("/{plugin_name}", response_model=PluginInfoResponse)
 async def get_plugin_info(
-    plugin_name: str,
-    plugin_service: PluginService = Depends(get_plugin_service)
+    plugin_name: str, plugin_service: PluginService = Depends(get_plugin_service)
 ):
     """Get detailed information about a specific plugin."""
     try:
         plugin = await plugin_service.get_plugin_info(plugin_name)
-        
+
         if not plugin:
             error_response = create_generic_error_response(
                 error_code=WebAPIErrorCode.NOT_FOUND,
                 message="Plugin not found",
                 user_message="The requested plugin could not be found.",
-                details={"plugin_name": plugin_name}
+                details={"plugin_name": plugin_name},
             )
             raise HTTPException(
                 status_code=get_http_status_for_error_code(WebAPIErrorCode.NOT_FOUND),
                 detail=error_response.dict(),
             )
-        
+
         return PluginInfoResponse(
             name=plugin.name,
             description=plugin.description,
@@ -195,22 +207,26 @@ async def get_plugin_info(
             parameters=plugin.parameters,
             author=plugin.author,
             enabled=plugin.enabled,
-            tags=getattr(plugin, 'tags', []),
-            dependencies=getattr(plugin, 'dependencies', []),
-            last_executed=getattr(plugin, 'last_executed', None),
-            execution_count=getattr(plugin, 'execution_count', 0),
-            success_rate=getattr(plugin, 'success_rate', 0.0)
+            tags=getattr(plugin, "tags", []),
+            dependencies=getattr(plugin, "dependencies", []),
+            last_executed=getattr(plugin, "last_executed", None),
+            execution_count=getattr(plugin, "execution_count", 0),
+            success_rate=getattr(plugin, "success_rate", 0.0),
         )
-        
+
     except HTTPException:
         raise
     except Exception as e:
-        logger.exception("Failed to get plugin info", error=str(e))
+        logger.exception(
+            "Failed to get plugin info",
+            error=str(e),
+            timestamp=datetime.now(timezone.utc).isoformat(),
+        )
         error_response = create_service_error_response(
             service_name="plugin",
             error=e,
             error_code=WebAPIErrorCode.PLUGIN_ERROR,
-            user_message="Failed to get plugin information. Please try again."
+            user_message="Failed to get plugin information. Please try again.",
         )
         raise HTTPException(
             status_code=get_http_status_for_error_code(WebAPIErrorCode.PLUGIN_ERROR),
@@ -222,9 +238,7 @@ async def get_plugin_info(
 async def execute_plugin(
     plugin_name: str,
     request: ExecutePluginRequest,
-    
-    
-    plugin_service: PluginService = Depends(get_plugin_service)
+    plugin_service: PluginService = Depends(get_plugin_service),
 ):
     """Execute a plugin with given parameters."""
     try:
@@ -234,12 +248,12 @@ async def execute_plugin(
             parameters=request.parameters,
             user_id="anonymous",
             session_id=request.session_id,
-            timeout=request.timeout
+            timeout=request.timeout,
         )
-        
+
         # Execute the plugin
         result = await plugin_service.execute_plugin(execution_request)
-        
+
         return PluginExecutionResponse(
             success=result.success,
             result=result.result,
@@ -247,18 +261,22 @@ async def execute_plugin(
             stderr=result.stderr,
             error=result.error,
             execution_time=result.execution_time,
-            timestamp=result.timestamp.isoformat(),
+            timestamp=result.timestamp.astimezone(timezone.utc).isoformat(),
             plugin_name=plugin_name,
-            session_id=request.session_id
+            session_id=request.session_id,
         )
-        
+
     except Exception as e:
-        logger.exception("Failed to execute plugin", error=str(e))
+        logger.exception(
+            "Failed to execute plugin",
+            error=str(e),
+            timestamp=datetime.now(timezone.utc).isoformat(),
+        )
         error_response = create_service_error_response(
             service_name="plugin",
             error=e,
             error_code=WebAPIErrorCode.PLUGIN_ERROR,
-            user_message="Failed to execute plugin. Please try again."
+            user_message="Failed to execute plugin. Please try again.",
         )
         raise HTTPException(
             status_code=get_http_status_for_error_code(WebAPIErrorCode.PLUGIN_ERROR),
@@ -270,25 +288,29 @@ async def execute_plugin(
 async def validate_plugin_parameters(
     plugin_name: str,
     request: ValidatePluginRequest,
-    plugin_service: PluginService = Depends(get_plugin_service)
+    plugin_service: PluginService = Depends(get_plugin_service),
 ):
     """Validate plugin parameters."""
     try:
         is_valid = await plugin_service.validate_plugin(plugin_name, request.parameters)
-        
+
         return {
             "valid": is_valid,
             "plugin_name": plugin_name,
-            "message": "Parameters are valid" if is_valid else "Parameters are invalid"
+            "message": "Parameters are valid" if is_valid else "Parameters are invalid",
         }
-        
+
     except Exception as e:
-        logger.exception("Failed to validate plugin", error=str(e))
+        logger.exception(
+            "Failed to validate plugin",
+            error=str(e),
+            timestamp=datetime.now(timezone.utc).isoformat(),
+        )
         error_response = create_service_error_response(
             service_name="plugin",
             error=e,
             error_code=WebAPIErrorCode.PLUGIN_ERROR,
-            user_message="Failed to validate plugin parameters. Please try again."
+            user_message="Failed to validate plugin parameters. Please try again.",
         )
         raise HTTPException(
             status_code=get_http_status_for_error_code(WebAPIErrorCode.PLUGIN_ERROR),
@@ -313,27 +335,31 @@ async def enable_plugin(
                 error_code=WebAPIErrorCode.NOT_FOUND,
                 message="Plugin not found",
                 user_message="The requested plugin could not be found.",
-                details={"plugin_name": plugin_name}
+                details={"plugin_name": plugin_name},
             )
             raise HTTPException(
                 status_code=get_http_status_for_error_code(WebAPIErrorCode.NOT_FOUND),
                 detail=error_response.dict(),
             )
-        
+
         return {
             "success": True,
-            "message": f"Plugin {plugin_name} enabled successfully"
+            "message": f"Plugin {plugin_name} enabled successfully",
         }
-        
+
     except HTTPException:
         raise
     except Exception as e:
-        logger.exception("Failed to enable plugin", error=str(e))
+        logger.exception(
+            "Failed to enable plugin",
+            error=str(e),
+            timestamp=datetime.now(timezone.utc).isoformat(),
+        )
         error_response = create_service_error_response(
             service_name="plugin",
             error=e,
             error_code=WebAPIErrorCode.PLUGIN_ERROR,
-            user_message="Failed to enable plugin. Please try again."
+            user_message="Failed to enable plugin. Please try again.",
         )
         raise HTTPException(
             status_code=get_http_status_for_error_code(WebAPIErrorCode.PLUGIN_ERROR),
@@ -358,27 +384,31 @@ async def disable_plugin(
                 error_code=WebAPIErrorCode.NOT_FOUND,
                 message="Plugin not found",
                 user_message="The requested plugin could not be found.",
-                details={"plugin_name": plugin_name}
+                details={"plugin_name": plugin_name},
             )
             raise HTTPException(
                 status_code=get_http_status_for_error_code(WebAPIErrorCode.NOT_FOUND),
                 detail=error_response.dict(),
             )
-        
+
         return {
             "success": True,
-            "message": f"Plugin {plugin_name} disabled successfully"
+            "message": f"Plugin {plugin_name} disabled successfully",
         }
-        
+
     except HTTPException:
         raise
     except Exception as e:
-        logger.exception("Failed to disable plugin", error=str(e))
+        logger.exception(
+            "Failed to disable plugin",
+            error=str(e),
+            timestamp=datetime.now(timezone.utc).isoformat(),
+        )
         error_response = create_service_error_response(
             service_name="plugin",
             error=e,
             error_code=WebAPIErrorCode.PLUGIN_ERROR,
-            user_message="Failed to disable plugin. Please try again."
+            user_message="Failed to disable plugin. Please try again.",
         )
         raise HTTPException(
             status_code=get_http_status_for_error_code(WebAPIErrorCode.PLUGIN_ERROR),
@@ -388,31 +418,37 @@ async def disable_plugin(
 
 @router.get("/categories")
 async def get_plugin_categories(
-    plugin_service: PluginService = Depends(get_plugin_service)
+    plugin_service: PluginService = Depends(get_plugin_service),
 ):
     """Get list of plugin categories."""
     try:
         plugins = await plugin_service.list_plugins()
         categories = list(set(plugin.category for plugin in plugins))
         categories.sort()
-        
+
         category_counts = {}
         for plugin in plugins:
-            category_counts[plugin.category] = category_counts.get(plugin.category, 0) + 1
-        
+            category_counts[plugin.category] = (
+                category_counts.get(plugin.category, 0) + 1
+            )
+
         return {
             "categories": categories,
             "category_counts": category_counts,
-            "total_categories": len(categories)
+            "total_categories": len(categories),
         }
-        
+
     except Exception as e:
-        logger.exception("Failed to get categories", error=str(e))
+        logger.exception(
+            "Failed to get categories",
+            error=str(e),
+            timestamp=datetime.now(timezone.utc).isoformat(),
+        )
         error_response = create_service_error_response(
             service_name="plugin",
             error=e,
             error_code=WebAPIErrorCode.PLUGIN_ERROR,
-            user_message="Failed to get plugin categories. Please try again."
+            user_message="Failed to get plugin categories. Please try again.",
         )
         raise HTTPException(
             status_code=get_http_status_for_error_code(WebAPIErrorCode.PLUGIN_ERROR),
@@ -422,12 +458,12 @@ async def get_plugin_categories(
 
 @router.get("/metrics", response_model=PluginMetricsResponse)
 async def get_plugin_metrics(
-    plugin_service: PluginService = Depends(get_plugin_service)
+    plugin_service: PluginService = Depends(get_plugin_service),
 ):
     """Get plugin execution metrics."""
     try:
         metrics = plugin_service.get_metrics()
-        
+
         return PluginMetricsResponse(
             total_plugins=metrics.get("total_plugins", 0),
             enabled_plugins=metrics.get("enabled_plugins", 0),
@@ -437,16 +473,20 @@ async def get_plugin_metrics(
             average_execution_time=metrics.get("average_execution_time", 0.0),
             plugins_by_category=metrics.get("plugins_by_category", {}),
             most_used_plugins=metrics.get("most_used_plugins", []),
-            recent_executions=metrics.get("recent_executions", [])
+            recent_executions=metrics.get("recent_executions", []),
         )
-        
+
     except Exception as e:
-        logger.exception("Failed to get metrics", error=str(e))
+        logger.exception(
+            "Failed to get metrics",
+            error=str(e),
+            timestamp=datetime.now(timezone.utc).isoformat(),
+        )
         error_response = create_service_error_response(
             service_name="plugin",
             error=e,
             error_code=WebAPIErrorCode.PLUGIN_ERROR,
-            user_message="Failed to get plugin metrics. Please try again."
+            user_message="Failed to get plugin metrics. Please try again.",
         )
         raise HTTPException(
             status_code=get_http_status_for_error_code(WebAPIErrorCode.PLUGIN_ERROR),
@@ -468,18 +508,22 @@ async def reload_plugins(
         return {
             "success": True,
             "message": f"Reloaded {count} plugins successfully",
-            "plugins_loaded": count
+            "plugins_loaded": count,
         }
-        
+
     except HTTPException:
         raise
     except Exception as e:
-        logger.exception("Failed to reload plugins", error=str(e))
+        logger.exception(
+            "Failed to reload plugins",
+            error=str(e),
+            timestamp=datetime.now(timezone.utc).isoformat(),
+        )
         error_response = create_service_error_response(
             service_name="plugin",
             error=e,
             error_code=WebAPIErrorCode.PLUGIN_ERROR,
-            user_message="Failed to reload plugins. Please try again."
+            user_message="Failed to reload plugins. Please try again.",
         )
         raise HTTPException(
             status_code=get_http_status_for_error_code(WebAPIErrorCode.PLUGIN_ERROR),
@@ -488,24 +532,27 @@ async def reload_plugins(
 
 
 @router.get("/health")
-async def health_check(
-    plugin_service: PluginService = Depends(get_plugin_service)
-):
+async def health_check(plugin_service: PluginService = Depends(get_plugin_service)):
     """Health check for plugin service."""
     try:
-        if hasattr(plugin_service, 'health_check'):
+        if hasattr(plugin_service, "health_check"):
             health_result = await plugin_service.health_check()
             return health_result
         else:
             return {
                 "status": "healthy",
                 "service": "plugin_service",
-                "timestamp": datetime.utcnow().isoformat()
+                "timestamp": datetime.now(timezone.utc).isoformat(),
             }
     except Exception as e:
+        logger.error(
+            "Plugin service health check failed",
+            error=str(e),
+            timestamp=datetime.now(timezone.utc).isoformat(),
+        )
         return {
             "status": "unhealthy",
             "service": "plugin_service",
-            "timestamp": datetime.utcnow().isoformat(),
-            "error": str(e)
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "error": str(e),
         }


### PR DESCRIPTION
## Summary
- replace `datetime.utcnow()` with `datetime.now(timezone.utc)` across auth, code execution, and plugin routes
- emit ISO8601 timestamps with timezone in API responses and structured logs

## Testing
- `pre-commit run --files src/ai_karen_engine/api_routes/auth.py src/ai_karen_engine/api_routes/code_execution_routes.py src/ai_karen_engine/api_routes/plugin_routes.py` *(fails: mypy missing stubs)*
- `pytest` *(fails: PydanticImportError: BaseSettings moved to pydantic-settings)*

------
https://chatgpt.com/codex/tasks/task_e_6891fe136e648324996b0a25a5631891