### PR TITLE
refactor: avoid logging password reset tokens

### DIFF
--- a/src/ai_karen_engine/api_routes/auth.py
+++ b/src/ai_karen_engine/api_routes/auth.py
@@ -379,10 +379,10 @@ async def request_password_reset(
             # Don't reveal if user exists or not
             return {"detail": "If the email exists, a reset link has been sent"}
         
-        # In production, you would send this token via email
-        # For now, log it (remove this in production!)
-        logger.info(f"Password reset token for {req.email}: {token}")
-        
+        # Send token through a secure channel (e.g., email) without logging
+        # Example implementation:
+        # await email_service.send_password_reset_email(req.email, token)
+
         return {"detail": "Password reset link sent"}
         
     except Exception as e:


### PR DESCRIPTION
## Summary
- stop logging password reset tokens in auth route
- add placeholder for sending reset tokens via secure channel

## Testing
- `pytest test_auth_connectivity.py test_authentication_flow.py test_production_auth.py` *(fails: fixture 'base_url' not found; async functions not supported)*

------
https://chatgpt.com/codex/tasks/task_e_6891fe0f652483248e8024555b20d8a7