### PR TITLE
refactor: extract flow helpers

### DIFF
--- a/src/ai_karen_engine/api_routes/ai_orchestrator_routes.py
+++ b/src/ai_karen_engine/api_routes/ai_orchestrator_routes.py
@@ -2,7 +2,6 @@
 FastAPI routes for AI Orchestrator service integration.
 """
 
-import uuid
 from datetime import datetime
 from typing import List, Optional, Dict, Any
 from fastapi import APIRouter, HTTPException, Depends, Query, Request
@@ -11,8 +10,6 @@ from pydantic import BaseModel, Field
 from ai_karen_engine.services.ai_orchestrator.ai_orchestrator import (
     AIOrchestrator,
     FlowType,
-    FlowInput,
-    FlowOutput
 )
 from ai_karen_engine.core.dependencies import get_ai_orchestrator_service
 from ai_karen_engine.core.logging import get_logger
@@ -28,6 +25,8 @@ from ai_karen_engine.models.web_api_error_responses import (
 )
 # Temporarily disable auth imports for web UI integration
 # from ..core.auth import get_current_user, get_tenant_id
+
+from ai_karen_engine.utils.flow_helpers import build_flow_input, format_flow_response
 
 router = APIRouter(prefix="/api/ai", tags=["ai-orchestrator"])
 
@@ -104,13 +103,12 @@ async def process_flow(
     """Process an AI flow with the given input."""
     try:
         # Create flow input
-        flow_input = FlowInput(
+        flow_input = build_flow_input(
             prompt=request.prompt,
             conversation_history=request.conversation_history,
             user_settings=request.user_settings,
             context=request.context,
-            user_id="anonymous",
-            session_id=request.session_id
+            session_id=request.session_id,
         )
         
         # Process the flow
@@ -119,17 +117,7 @@ async def process_flow(
         processing_time = (datetime.utcnow() - start_time).total_seconds() * 1000
         
         return FlowResponse(
-            response=result.response,
-            requires_plugin=result.requires_plugin,
-            plugin_to_execute=result.plugin_to_execute,
-            plugin_parameters=result.plugin_parameters,
-            memory_to_store=result.memory_to_store,
-            suggested_actions=result.suggested_actions,
-            ai_data=result.ai_data,
-            proactive_suggestion=result.proactive_suggestion,
-            processing_time_ms=int(processing_time),
-            model_used=result.ai_data.get("model_used") if result.ai_data else None,
-            confidence_score=result.ai_data.get("confidence") if result.ai_data else None
+            **format_flow_response(result, int(processing_time))
         )
         
     except Exception as e:
@@ -156,13 +144,12 @@ async def decide_action(
     """Process decision-making flow."""
     try:
         # Create flow input
-        flow_input = FlowInput(
+        flow_input = build_flow_input(
             prompt=request.prompt,
             conversation_history=request.conversation_history,
             user_settings=request.user_settings,
             context=request.context,
-            user_id="anonymous",
-            session_id=request.session_id
+            session_id=request.session_id,
         )
         
         # Process decide action flow
@@ -171,17 +158,7 @@ async def decide_action(
         processing_time = (datetime.utcnow() - start_time).total_seconds() * 1000
         
         return FlowResponse(
-            response=result.response,
-            requires_plugin=result.requires_plugin,
-            plugin_to_execute=result.plugin_to_execute,
-            plugin_parameters=result.plugin_parameters,
-            memory_to_store=result.memory_to_store,
-            suggested_actions=result.suggested_actions,
-            ai_data=result.ai_data,
-            proactive_suggestion=result.proactive_suggestion,
-            processing_time_ms=int(processing_time),
-            model_used=result.ai_data.get("model_used") if result.ai_data else None,
-            confidence_score=result.ai_data.get("confidence") if result.ai_data else None
+            **format_flow_response(result, int(processing_time))
         )
         
     except Exception as e:
@@ -215,13 +192,12 @@ async def conversation_processing(
             "tenant_id": "default"  # Use default tenant for Web UI API
         })
         
-        flow_input = FlowInput(
+        flow_input = build_flow_input(
             prompt=request.prompt,
             conversation_history=request.conversation_history,
             user_settings=request.user_settings,
             context=context,
-            user_id="anonymous",
-            session_id=request.session_id
+            session_id=request.session_id,
         )
         
         # Process conversation flow
@@ -230,17 +206,7 @@ async def conversation_processing(
         processing_time = (datetime.utcnow() - start_time).total_seconds() * 1000
         
         return FlowResponse(
-            response=result.response,
-            requires_plugin=result.requires_plugin,
-            plugin_to_execute=result.plugin_to_execute,
-            plugin_parameters=result.plugin_parameters,
-            memory_to_store=result.memory_to_store,
-            suggested_actions=result.suggested_actions,
-            ai_data=result.ai_data,
-            proactive_suggestion=result.proactive_suggestion,
-            processing_time_ms=int(processing_time),
-            model_used=result.ai_data.get("model_used") if result.ai_data else None,
-            confidence_score=result.ai_data.get("confidence") if result.ai_data else None
+            **format_flow_response(result, int(processing_time))
         )
         
     except Exception as e:

--- a/src/ai_karen_engine/utils/flow_helpers.py
+++ b/src/ai_karen_engine/utils/flow_helpers.py
@@ -1,0 +1,56 @@
+"""Utility helpers for building flow inputs and formatting flow responses.
+
+These functions encapsulate common patterns used by the API routes
+when interacting with the :class:`AIOrchestrator`.  They centralize the
+construction of :class:`FlowInput` objects and the formatting of
+:class:`FlowOutput` results into response payloads.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from ai_karen_engine.services.ai_orchestrator.ai_orchestrator import (
+    FlowInput,
+    FlowOutput,
+)
+
+
+def build_flow_input(
+    *,
+    prompt: str,
+    conversation_history: List[Dict[str, Any]],
+    user_settings: Dict[str, Any],
+    context: Optional[Dict[str, Any]],
+    session_id: Optional[str],
+    user_id: str = "anonymous",
+) -> FlowInput:
+    """Create a :class:`FlowInput` instance from request data."""
+    return FlowInput(
+        prompt=prompt,
+        conversation_history=conversation_history,
+        user_settings=user_settings,
+        context=context,
+        user_id=user_id,
+        session_id=session_id,
+    )
+
+
+def format_flow_response(result: FlowOutput, processing_time_ms: int) -> Dict[str, Any]:
+    """Convert a :class:`FlowOutput` into a serializable response payload."""
+    return {
+        "response": result.response,
+        "requires_plugin": result.requires_plugin,
+        "plugin_to_execute": result.plugin_to_execute,
+        "plugin_parameters": result.plugin_parameters,
+        "memory_to_store": result.memory_to_store,
+        "suggested_actions": result.suggested_actions,
+        "ai_data": result.ai_data,
+        "proactive_suggestion": result.proactive_suggestion,
+        "processing_time_ms": processing_time_ms,
+        "model_used": result.ai_data.get("model_used") if result.ai_data else None,
+        "confidence_score": result.ai_data.get("confidence") if result.ai_data else None,
+    }
+
+
+__all__ = ["build_flow_input", "format_flow_response"]


### PR DESCRIPTION
## Summary
- add utility helpers `build_flow_input` and `format_flow_response`
- refactor AI orchestrator routes to reuse flow helpers

## Testing
- `pytest` *(fails: Path() takes 0 positional arguments but 1 was given; 32 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6891ff8ae7b88324b16aa89174620931