### PR TITLE
refactor: require fastapi and pydantic

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ pyautogui
 urwid
 prompt_toolkit
 pydantic
+pydantic-settings
 pytest
 transformers
 sentence-transformers
@@ -18,6 +19,9 @@ scikit-learn==1.5.*
 spacy==3.7.*
 datasets
 jinja2
+passlib
+email-validator
+itsdangerous
 python-multipart
 prometheus_client
 cryptography

--- a/src/ai_karen_engine/api_routes/__init__.py
+++ b/src/ai_karen_engine/api_routes/__init__.py
@@ -2,7 +2,9 @@
 
 try:
     from fastapi import APIRouter
-except Exception:  # pragma: no cover - fallback for minimal envs
-    from ai_karen_engine.fastapi_stub import APIRouter
+except ImportError as e:  # pragma: no cover - runtime dependency
+    raise ImportError(
+        "FastAPI is required for API routes. Install via `pip install fastapi`."
+    ) from e
 
 router = APIRouter()

--- a/src/ai_karen_engine/api_routes/announcements.py
+++ b/src/ai_karen_engine/api_routes/announcements.py
@@ -3,13 +3,17 @@ from typing import List
 
 try:
     from fastapi import APIRouter
-except Exception:  # pragma: no cover
-    from ai_karen_engine.fastapi_stub import APIRouter
+except ImportError as e:  # pragma: no cover - runtime dependency
+    raise ImportError(
+        "FastAPI is required for announcement routes. Install via `pip install fastapi`."
+    ) from e
 
 try:
     from pydantic import BaseModel
-except Exception:
-    from ai_karen_engine.pydantic_stub import BaseModel
+except ImportError as e:  # pragma: no cover - runtime dependency
+    raise ImportError(
+        "Pydantic is required for announcement routes. Install via `pip install pydantic`."
+    ) from e
 
 router = APIRouter()
 

--- a/src/ai_karen_engine/api_routes/code_execution_routes.py
+++ b/src/ai_karen_engine/api_routes/code_execution_routes.py
@@ -8,17 +8,17 @@ from typing import List, Optional, Dict, Any
 
 try:
     from fastapi import APIRouter, HTTPException, Depends, Query
-except Exception:  # pragma: no cover
-    from ai_karen_engine.fastapi_stub import APIRouter, HTTPException
-    def Depends(func):
-        return func
-    def Query(default=None, **_kw):
-        return default
+except ImportError as e:  # pragma: no cover - runtime dependency
+    raise ImportError(
+        "FastAPI is required for code execution routes. Install via `pip install fastapi`."
+    ) from e
 
 try:
     from pydantic import BaseModel, Field
-except Exception:
-    from ai_karen_engine.pydantic_stub import BaseModel, Field
+except ImportError as e:  # pragma: no cover - runtime dependency
+    raise ImportError(
+        "Pydantic is required for code execution routes. Install via `pip install pydantic`."
+    ) from e
 
 from ai_karen_engine.chat.code_execution_service import (
     CodeExecutionService,

--- a/src/ai_karen_engine/api_routes/conversation_routes.py
+++ b/src/ai_karen_engine/api_routes/conversation_routes.py
@@ -5,19 +5,20 @@ FastAPI routes for enhanced conversation management with web UI integration.
 import uuid
 from datetime import datetime
 from typing import List, Optional, Dict, Any, Tuple
+
 try:
     from fastapi import APIRouter, HTTPException, Depends, Query
-except Exception:  # pragma: no cover
-    from ai_karen_engine.fastapi_stub import APIRouter, HTTPException
-    def Depends(func):
-        return func
-    def Query(default=None, **_kw):
-        return default
+except ImportError as e:  # pragma: no cover - runtime dependency
+    raise ImportError(
+        "FastAPI is required for conversation routes. Install via `pip install fastapi`."
+    ) from e
 
 try:
     from pydantic import BaseModel, Field
-except Exception:
-    from ai_karen_engine.pydantic_stub import BaseModel, Field
+except ImportError as e:  # pragma: no cover - runtime dependency
+    raise ImportError(
+        "Pydantic is required for conversation routes. Install via `pip install pydantic`."
+    ) from e
 
 from ai_karen_engine.services.conversation_service import (
     WebUIConversationService,

--- a/src/ai_karen_engine/api_routes/database.py
+++ b/src/ai_karen_engine/api_routes/database.py
@@ -12,25 +12,17 @@ from typing import Dict, List, Optional, Any, Union
 
 try:
     from fastapi import APIRouter, HTTPException, Depends, Query, Path, Body
-except Exception:  # pragma: no cover - stub fallback
-    from ai_karen_engine.fastapi_stub import APIRouter, HTTPException
-    def Depends(func):
-        return func
-    def Query(default=None, **_kw):
-        return default
-    def Path(default=None, **_kw):
-        return default
-    def Body(default=None, **_kw):
-        return default
+except ImportError as e:  # pragma: no cover - runtime dependency
+    raise ImportError(
+        "FastAPI is required for database routes. Install via `pip install fastapi`."
+    ) from e
 
 try:
     from pydantic import BaseModel, Field, validator
-except Exception:
-    from ai_karen_engine.pydantic_stub import BaseModel, Field
-    def validator(*_a, **_kw):
-        def _wrap(func):
-            return func
-        return _wrap
+except ImportError as e:  # pragma: no cover - runtime dependency
+    raise ImportError(
+        "Pydantic is required for database routes. Install via `pip install pydantic`."
+    ) from e
 
 # DB error classes
 from sqlalchemy.exc import ProgrammingError, OperationalError

--- a/src/ai_karen_engine/api_routes/enhanced_file_attachment_routes.py
+++ b/src/ai_karen_engine/api_routes/enhanced_file_attachment_routes.py
@@ -10,31 +10,27 @@ import mimetypes
 import json
 
 try:
-    from fastapi import APIRouter, HTTPException, Depends, UploadFile, File, Form, Query
+    from fastapi import (
+        APIRouter,
+        HTTPException,
+        Depends,
+        UploadFile,
+        File,
+        Form,
+        Query,
+    )
     from fastapi.responses import FileResponse, StreamingResponse, JSONResponse
-except Exception:  # pragma: no cover
-    from ai_karen_engine.fastapi_stub import APIRouter, HTTPException
-    def Depends(func):
-        return func
-    def Query(default=None, **_kw):
-        return default
-    def Form(default=None, **_kw):
-        return default
-    def File(default=None, **_kw):
-        return default
-    class UploadFile:
-        pass
-    class FileResponse:
-        pass
-    class StreamingResponse:
-        pass
-    class JSONResponse:
-        pass
+except ImportError as e:  # pragma: no cover - runtime dependency
+    raise ImportError(
+        "FastAPI is required for file attachment routes. Install via `pip install fastapi`."
+    ) from e
 
 try:
     from pydantic import BaseModel, Field
-except Exception:
-    from ai_karen_engine.pydantic_stub import BaseModel, Field
+except ImportError as e:  # pragma: no cover - runtime dependency
+    raise ImportError(
+        "Pydantic is required for file attachment routes. Install via `pip install pydantic`."
+    ) from e
 
 from ai_karen_engine.chat.hook_enabled_file_service import get_hook_enabled_file_service
 from ai_karen_engine.chat.file_attachment_service import (

--- a/src/ai_karen_engine/api_routes/file_attachment_routes.py
+++ b/src/ai_karen_engine/api_routes/file_attachment_routes.py
@@ -9,29 +9,27 @@ from typing import List, Optional, Dict, Any
 import mimetypes
 
 try:
-    from fastapi import APIRouter, HTTPException, Depends, UploadFile, File, Form, Query
+    from fastapi import (
+        APIRouter,
+        HTTPException,
+        Depends,
+        UploadFile,
+        File,
+        Form,
+        Query,
+    )
     from fastapi.responses import FileResponse, StreamingResponse
-except Exception:  # pragma: no cover
-    from ai_karen_engine.fastapi_stub import APIRouter, HTTPException
-    def Depends(func):
-        return func
-    def Query(default=None, **_kw):
-        return default
-    def Form(default=None, **_kw):
-        return default
-    def File(default=None, **_kw):
-        return default
-    class UploadFile:
-        pass
-    class FileResponse:
-        pass
-    class StreamingResponse:
-        pass
+except ImportError as e:  # pragma: no cover - runtime dependency
+    raise ImportError(
+        "FastAPI is required for file attachment routes. Install via `pip install fastapi`."
+    ) from e
 
 try:
     from pydantic import BaseModel, Field
-except Exception:
-    from ai_karen_engine.pydantic_stub import BaseModel, Field
+except ImportError as e:  # pragma: no cover - runtime dependency
+    raise ImportError(
+        "Pydantic is required for file attachment routes. Install via `pip install pydantic`."
+    ) from e
 
 from ai_karen_engine.chat.file_attachment_service import (
     FileAttachmentService,

--- a/src/ai_karen_engine/api_routes/health.py
+++ b/src/ai_karen_engine/api_routes/health.py
@@ -1,7 +1,9 @@
 try:
     from fastapi import APIRouter
-except Exception:  # pragma: no cover
-    from ai_karen_engine.fastapi_stub import APIRouter
+except ImportError as e:  # pragma: no cover - runtime dependency
+    raise ImportError(
+        "FastAPI is required for health routes. Install via `pip install fastapi`."
+    ) from e
 
 router = APIRouter()
 

--- a/src/ai_karen_engine/api_routes/hook_routes.py
+++ b/src/ai_karen_engine/api_routes/hook_routes.py
@@ -15,32 +15,17 @@ from datetime import datetime
 try:
     from fastapi import APIRouter, HTTPException, Depends, Query, Path
     from fastapi.responses import JSONResponse
-except ImportError:
-    # Stubs for testing
-    class APIRouter:
-        def __init__(self, **kwargs): 
-            self.routes = []
-            self.prefix = kwargs.get('prefix', '')
-            self.tags = kwargs.get('tags', [])
-        def get(self, path: str, **kwargs): return lambda f: f
-        def post(self, path: str, **kwargs): return lambda f: f
-        def delete(self, path: str, **kwargs): return lambda f: f
-        def put(self, path: str, **kwargs): return lambda f: f
-    
-    class HTTPException(Exception):
-        def __init__(self, status_code: int, detail: str): pass
-    
-    class JSONResponse:
-        def __init__(self, content: Dict, **kwargs): pass
-    
-    def Depends(func): return func
-    def Query(default=None, **kwargs): return default
-    def Path(**kwargs): return ""
+except ImportError as e:  # pragma: no cover - runtime dependency
+    raise ImportError(
+        "FastAPI is required for hook routes. Install via `pip install fastapi`."
+    ) from e
 
 try:
     from pydantic import BaseModel, Field
-except ImportError:
-    from ai_karen_engine.pydantic_stub import BaseModel, Field
+except ImportError as e:  # pragma: no cover - runtime dependency
+    raise ImportError(
+        "Pydantic is required for hook routes. Install via `pip install pydantic`."
+    ) from e
 
 from ai_karen_engine.hooks import get_hook_manager, HookTypes, HookContext, HookRegistration
 from ai_karen_engine.utils.auth import validate_session

--- a/src/ai_karen_engine/api_routes/llm_routes.py
+++ b/src/ai_karen_engine/api_routes/llm_routes.py
@@ -11,15 +11,17 @@ from typing import Any, Dict, List, Optional
 
 try:
     from fastapi import APIRouter, HTTPException, Depends
-except Exception:  # pragma: no cover - stub fallback
-    from ai_karen_engine.fastapi_stub import APIRouter, HTTPException
-    def Depends(func):
-        return func
+except ImportError as e:  # pragma: no cover - runtime dependency
+    raise ImportError(
+        "FastAPI is required for LLM routes. Install via `pip install fastapi`."
+    ) from e
 
 try:
     from pydantic import BaseModel, Field
-except Exception:
-    from ai_karen_engine.pydantic_stub import BaseModel, Field
+except ImportError as e:  # pragma: no cover - runtime dependency
+    raise ImportError(
+        "Pydantic is required for LLM routes. Install via `pip install pydantic`."
+    ) from e
 
 from ai_karen_engine.integrations.llm_registry import get_registry
 from ai_karen_engine.core.config_manager import ConfigManager

--- a/src/ai_karen_engine/api_routes/memory_routes.py
+++ b/src/ai_karen_engine/api_routes/memory_routes.py
@@ -5,20 +5,20 @@ FastAPI routes for enhanced memory management with web UI integration.
 import uuid
 from datetime import datetime
 from typing import List, Optional, Dict, Any, Tuple
+
 try:
     from fastapi import APIRouter, HTTPException, Depends, Query, Request
-except Exception:  # pragma: no cover - fallback to stub
-    from ai_karen_engine.fastapi_stub import APIRouter, HTTPException
-    from ai_karen_engine.fastapi_stub import Request
-    def Depends(func):
-        return func
-    def Query(default=None, **_kw):
-        return default
+except ImportError as e:  # pragma: no cover - runtime dependency
+    raise ImportError(
+        "FastAPI is required for memory routes. Install via `pip install fastapi`."
+    ) from e
 
 try:
     from pydantic import BaseModel, Field
-except Exception:
-    from ai_karen_engine.pydantic_stub import BaseModel, Field
+except ImportError as e:  # pragma: no cover - runtime dependency
+    raise ImportError(
+        "Pydantic is required for memory routes. Install via `pip install pydantic`."
+    ) from e
 
 from ai_karen_engine.services.memory_service import (
     WebUIMemoryService,

--- a/src/ai_karen_engine/api_routes/system.py
+++ b/src/ai_karen_engine/api_routes/system.py
@@ -7,11 +7,20 @@ from typing import Any, Dict, List, Optional
 from ai_karen_engine.clients.database.duckdb_client import DuckDBClient
 
 try:
-    from pydantic import BaseModel
-except Exception:  # pragma: no cover - optional dependency
-    from ai_karen_engine.pydantic_stub import BaseModel
+    from fastapi import APIRouter, HTTPException, Request
+except ImportError as e:  # pragma: no cover - runtime dependency
+    raise ImportError(
+        "FastAPI is required for system routes. Install via `pip install fastapi`."
+    ) from e
 
-router = __import__("fastapi").APIRouter()
+try:
+    from pydantic import BaseModel
+except ImportError as e:  # pragma: no cover - runtime dependency
+    raise ImportError(
+        "Pydantic is required for system routes. Install via `pip install pydantic`."
+    ) from e
+
+router = APIRouter()
 
 db = DuckDBClient()
 ANNOUNCE_PATH = Path(__file__).resolve().parents[3] / "data" / "announcements.json"
@@ -49,5 +58,5 @@ def list_announcements(limit: int = 10) -> List[Announcement]:
 def get_profile(user_id: str) -> UserProfile:
     profile = db.get_profile(user_id)
     if profile is None:
-        raise (__import__("fastapi").HTTPException)(status_code=404, detail="Profile not found")
+        raise HTTPException(status_code=404, detail="Profile not found")
     return UserProfile(user_id=user_id, **profile)

--- a/src/ai_karen_engine/api_routes/tool_routes.py
+++ b/src/ai_karen_engine/api_routes/tool_routes.py
@@ -5,19 +5,20 @@ FastAPI routes for Tool service integration.
 import uuid
 from datetime import datetime
 from typing import List, Optional, Dict, Any
+
 try:
     from fastapi import APIRouter, HTTPException, Depends, Query
-except Exception:  # pragma: no cover - stub fallback
-    from ai_karen_engine.fastapi_stub import APIRouter, HTTPException
-    def Depends(func):
-        return func
-    def Query(default=None, **_kw):
-        return default
+except ImportError as e:  # pragma: no cover - runtime dependency
+    raise ImportError(
+        "FastAPI is required for tool routes. Install via `pip install fastapi`."
+    ) from e
 
 try:
     from pydantic import BaseModel, Field
-except Exception:
-    from ai_karen_engine.pydantic_stub import BaseModel, Field
+except ImportError as e:  # pragma: no cover - runtime dependency
+    raise ImportError(
+        "Pydantic is required for tool routes. Install via `pip install pydantic`."
+    ) from e
 
 from ai_karen_engine.services.tool_service import (
     ToolService,

--- a/src/ai_karen_engine/api_routes/users.py
+++ b/src/ai_karen_engine/api_routes/users.py
@@ -2,13 +2,17 @@ from typing import Dict, Any
 
 try:
     from fastapi import APIRouter, HTTPException
-except Exception:  # pragma: no cover
-    from ai_karen_engine.fastapi_stub import APIRouter, HTTPException
+except ImportError as e:  # pragma: no cover - runtime dependency
+    raise ImportError(
+        "FastAPI is required for user routes. Install via `pip install fastapi`."
+    ) from e
 
 try:
     from pydantic import BaseModel
-except Exception:
-    from ai_karen_engine.pydantic_stub import BaseModel
+except ImportError as e:  # pragma: no cover - runtime dependency
+    raise ImportError(
+        "Pydantic is required for user routes. Install via `pip install pydantic`."
+    ) from e
 
 from ai_karen_engine.clients.database.duckdb_client import DuckDBClient
 

--- a/src/ai_karen_engine/api_routes/websocket_routes.py
+++ b/src/ai_karen_engine/api_routes/websocket_routes.py
@@ -13,21 +13,31 @@ import json
 import logging
 from typing import Dict, Any, Optional
 
-from fastapi import APIRouter, WebSocket, WebSocketDisconnect, Request, Depends, Query, HTTPException
+from fastapi import (
+    APIRouter,
+    WebSocket,
+    WebSocketDisconnect,
+    Request,
+    Depends,
+    Query,
+    HTTPException,
+)
 from fastapi.responses import StreamingResponse
 
 try:
     from sse_starlette.sse import EventSourceResponse
-except ImportError:
+except ImportError:  # pragma: no cover - optional dependency
     # Fallback for EventSourceResponse if sse_starlette is not available
-    class EventSourceResponse:
-        def __init__(self, content): 
+    class EventSourceResponse:  # type: ignore[override]
+        def __init__(self, content):
             self.content = content
 
 try:
     from pydantic import BaseModel, Field
-except ImportError:
-    from ai_karen_engine.pydantic_stub import BaseModel, Field
+except ImportError as e:  # pragma: no cover - runtime dependency
+    raise ImportError(
+        "Pydantic is required for websocket routes. Install via `pip install pydantic`."
+    ) from e
 
 from ai_karen_engine.chat.websocket_gateway import WebSocketGateway, WebSocketMessage, MessageType
 from ai_karen_engine.chat.stream_processor import StreamProcessor

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,10 +36,14 @@ sys.modules.setdefault("integrations", importlib.import_module("ai_karen_engine.
 sys.modules.setdefault("integrations.llm_registry", importlib.import_module("ai_karen_engine.integrations.llm_registry"))
 sys.modules.setdefault("integrations.model_discovery", importlib.import_module("ai_karen_engine.integrations.model_discovery"))
 sys.modules.setdefault("integrations.llm_utils", importlib.import_module("ai_karen_engine.integrations.llm_utils"))
-sys.modules.setdefault("fastapi", importlib.import_module("ai_karen_engine.fastapi_stub"))
-sys.modules.setdefault("fastapi_stub", importlib.import_module("ai_karen_engine.fastapi_stub"))
-sys.modules.setdefault("fastapi.testclient", importlib.import_module("ai_karen_engine.fastapi_stub.testclient"))
-sys.modules.setdefault("pydantic", importlib.import_module("ai_karen_engine.pydantic_stub"))
+# Ensure required runtime dependencies are available
+try:  # pragma: no cover - fail early if missing
+    import fastapi  # noqa: F401
+    import pydantic  # noqa: F401
+except Exception as e:  # pragma: no cover
+    raise RuntimeError(
+        "FastAPI and Pydantic must be installed for tests. Install with `pip install fastapi pydantic`."
+    ) from e
 
 os.environ.setdefault("KARI_MODEL_SIGNING_KEY", "test")
 os.environ.setdefault("KARI_DUCKDB_PASSWORD", "test")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -4,17 +4,8 @@ import asyncio
 import pytest
 from fastapi import HTTPException
 
-import ai_karen_engine.fastapi_stub as fastapi_stub
-import ai_karen_engine.pydantic_stub as pydantic_stub
 import ai_karen_engine.utils.auth as auth_utils
 from types import SimpleNamespace
-
-# Expose stubs under their expected top-level names
-sys.modules.setdefault("fastapi_stub", fastapi_stub)
-sys.modules.setdefault("pydantic_stub", pydantic_stub)
-
-sys.modules["fastapi"] = fastapi_stub
-sys.modules["pydantic"] = pydantic_stub
 
 from fastapi.testclient import TestClient  # noqa: E402
 from main import create_app, chat, ChatRequest  # noqa: E402

--- a/tests/test_auth_middleware.py
+++ b/tests/test_auth_middleware.py
@@ -1,20 +1,16 @@
 import asyncio
 from types import SimpleNamespace
 
-import ai_karen_engine.fastapi_stub as fastapi_stub
-import ai_karen_engine.pydantic_stub as pydantic_stub
-import sys
+from types import SimpleNamespace
 
-sys.modules.setdefault("fastapi", fastapi_stub)
-sys.modules.setdefault("pydantic", pydantic_stub)
+from fastapi import Response
 
 from ai_karen_engine.middleware.auth import auth_middleware
 from ai_karen_engine.utils.auth import create_session
-from ai_karen_engine.fastapi_stub import Response
 
 
 async def _call_next(request):
-    return Response({"ok": True})
+    return Response(content="ok")
 
 
 def _build_request(path="/plugins", token: str | None = None):

--- a/tests/test_totp_login.py
+++ b/tests/test_totp_login.py
@@ -3,13 +3,15 @@
 import pytest
 from unittest.mock import AsyncMock, patch
 
+from fastapi import Response
+from types import SimpleNamespace
+
 from ai_karen_engine.api_routes.auth import (
     login,
     LoginRequest,
     auth_service,
     HTTPException,
 )
-from ai_karen_engine.fastapi_stub import Request, Response
 
 
 @pytest.fixture
@@ -43,7 +45,7 @@ async def test_login_totp_success(two_factor_user, session_data):
         password="secret",
         totp_code="123456",
     )
-    request = Request()
+    request = SimpleNamespace(headers={}, client=SimpleNamespace(host="1.1.1.1"), state=SimpleNamespace())
     response = Response()
     with patch.object(auth_service, "authenticate_user", AsyncMock(return_value=two_factor_user)), \
          patch.object(auth_service, "create_session", AsyncMock(return_value=session_data)), \
@@ -56,7 +58,7 @@ async def test_login_totp_success(two_factor_user, session_data):
 @pytest.mark.asyncio
 async def test_login_totp_missing_code(two_factor_user):
     req = LoginRequest(email="test@example.com", password="secret")
-    request = Request()
+    request = SimpleNamespace(headers={}, client=SimpleNamespace(host="1.1.1.1"), state=SimpleNamespace())
     response = Response()
     with patch.object(auth_service, "authenticate_user", AsyncMock(return_value=two_factor_user)):
         with pytest.raises(HTTPException) as exc:
@@ -73,7 +75,7 @@ async def test_login_totp_invalid_code(two_factor_user):
         password="secret",
         totp_code="000000",
     )
-    request = Request()
+    request = SimpleNamespace(headers={}, client=SimpleNamespace(host="1.1.1.1"), state=SimpleNamespace())
     response = Response()
     with patch.object(auth_service, "authenticate_user", AsyncMock(return_value=two_factor_user)), \
          patch("ai_karen_engine.api_routes.auth.verify_totp", return_value=False):


### PR DESCRIPTION
## Summary
- drop legacy stubs and import FastAPI/Pydantic directly with helpful install messages
- ensure tests use real FastAPI & Pydantic and verify required packages
- add missing dependencies for full FastAPI stack

## Testing
- `pytest tests/test_auth_middleware.py tests/test_totp_login.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6891ffe3ddc48324a2ea94659c63a1b8