### PR TITLE
feat: add auth dependency for plugin routes

### DIFF
--- a/src/ai_karen_engine/api_routes/plugin_routes.py
+++ b/src/ai_karen_engine/api_routes/plugin_routes.py
@@ -2,39 +2,26 @@
 FastAPI routes for Plugin service integration.
 """
 
-import uuid
 from datetime import datetime
-from typing import List, Optional, Dict, Any
-from fastapi import APIRouter, HTTPException, Depends, Query, Request
+from typing import Any, Dict, List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, Field
 
-from ai_karen_engine.services.plugin_service import PluginService
-# Note: PluginInfo, PluginExecutionRequest, PluginExecutionResult, PluginStatus 
+# Note: PluginInfo, PluginExecutionRequest, PluginExecutionResult, PluginStatus
 # classes need to be implemented in the plugin service
 from ai_karen_engine.core.dependencies import get_plugin_service
 from ai_karen_engine.core.logging import get_logger
 from ai_karen_engine.models.web_api_error_responses import (
     WebAPIErrorCode,
-    WebAPIErrorResponse,
-    ValidationErrorDetail,
-    create_service_error_response,
-    create_validation_error_response,
-    create_database_error_response,
     create_generic_error_response,
+    create_service_error_response,
     get_http_status_for_error_code,
 )
-# Temporarily disable auth imports for web UI integration
+from ai_karen_engine.services.plugin_service import PluginService
+from ai_karen_engine.utils.auth import get_current_user
 
 router = APIRouter(prefix="/api/plugins", tags=["plugins"])
-
-
-def get_current_user() -> Dict[str, Any]:
-    """Retrieve current user context.
-
-    This is a placeholder implementation that always returns an admin user.
-    In production, this should extract the user from the request/session.
-    """
-    return {"user_id": "admin", "roles": ["admin"], "tenant_id": "default"}
 
 logger = get_logger(__name__)
 
@@ -42,20 +29,27 @@ logger = get_logger(__name__)
 # Request/Response Models
 class ExecutePluginRequest(BaseModel):
     """Request model for plugin execution."""
+
     plugin_name: str = Field(..., description="Name of plugin to execute")
-    parameters: Dict[str, Any] = Field(default_factory=dict, description="Plugin parameters")
+    parameters: Dict[str, Any] = Field(
+        default_factory=dict, description="Plugin parameters"
+    )
     timeout: int = Field(30, ge=1, le=300, description="Execution timeout in seconds")
     session_id: Optional[str] = Field(None, description="Session ID")
 
 
 class ValidatePluginRequest(BaseModel):
     """Request model for plugin validation."""
+
     plugin_name: str = Field(..., description="Name of plugin to validate")
-    parameters: Dict[str, Any] = Field(default_factory=dict, description="Plugin parameters to validate")
+    parameters: Dict[str, Any] = Field(
+        default_factory=dict, description="Plugin parameters to validate"
+    )
 
 
 class PluginInfoResponse(BaseModel):
     """Response model for plugin information."""
+
     name: str
     description: str
     version: str
@@ -73,6 +67,7 @@ class PluginInfoResponse(BaseModel):
 
 class PluginExecutionResponse(BaseModel):
     """Response model for plugin execution."""
+
     success: bool
     result: Optional[Any] = None
     stdout: Optional[str] = None
@@ -86,6 +81,7 @@ class PluginExecutionResponse(BaseModel):
 
 class PluginListResponse(BaseModel):
     """Response model for plugin list."""
+
     plugins: List[PluginInfoResponse]
     total_count: int
     enabled_count: int
@@ -94,6 +90,7 @@ class PluginListResponse(BaseModel):
 
 class PluginMetricsResponse(BaseModel):
     """Response model for plugin metrics."""
+
     total_plugins: int
     enabled_plugins: int
     total_executions: int
@@ -109,55 +106,57 @@ class PluginMetricsResponse(BaseModel):
 async def list_plugins(
     category: Optional[str] = Query(None, description="Filter by category"),
     enabled_only: bool = Query(False, description="Only return enabled plugins"),
-    plugin_service: PluginService = Depends(get_plugin_service)
+    plugin_service: PluginService = Depends(get_plugin_service),
 ):
     """List all available plugins."""
     try:
         plugins = await plugin_service.list_plugins()
-        
+
         # Apply filters
         if category:
             plugins = [p for p in plugins if p.category.lower() == category.lower()]
-        
+
         if enabled_only:
             plugins = [p for p in plugins if p.enabled]
-        
+
         # Convert to response format
         plugin_responses = []
         for plugin in plugins:
-            plugin_responses.append(PluginInfoResponse(
-                name=plugin.name,
-                description=plugin.description,
-                version=plugin.version,
-                category=plugin.category,
-                status=plugin.status.value,
-                parameters=plugin.parameters,
-                author=plugin.author,
-                enabled=plugin.enabled,
-                tags=getattr(plugin, 'tags', []),
-                dependencies=getattr(plugin, 'dependencies', []),
-                last_executed=getattr(plugin, 'last_executed', None),
-                execution_count=getattr(plugin, 'execution_count', 0),
-                success_rate=getattr(plugin, 'success_rate', 0.0)
-            ))
-        
+            plugin_responses.append(
+                PluginInfoResponse(
+                    name=plugin.name,
+                    description=plugin.description,
+                    version=plugin.version,
+                    category=plugin.category,
+                    status=plugin.status.value,
+                    parameters=plugin.parameters,
+                    author=plugin.author,
+                    enabled=plugin.enabled,
+                    tags=getattr(plugin, "tags", []),
+                    dependencies=getattr(plugin, "dependencies", []),
+                    last_executed=getattr(plugin, "last_executed", None),
+                    execution_count=getattr(plugin, "execution_count", 0),
+                    success_rate=getattr(plugin, "success_rate", 0.0),
+                )
+            )
+
         enabled_count = sum(1 for p in plugin_responses if p.enabled)
         disabled_count = len(plugin_responses) - enabled_count
-        
+
         return PluginListResponse(
             plugins=plugin_responses,
             total_count=len(plugin_responses),
             enabled_count=enabled_count,
-            disabled_count=disabled_count
+            disabled_count=disabled_count,
         )
-        
+
     except Exception as e:
         logger.exception("Failed to list plugins", error=str(e))
         error_response = create_service_error_response(
             service_name="plugin",
             error=e,
             error_code=WebAPIErrorCode.PLUGIN_ERROR,
-            user_message="Failed to list plugins. Please try again."
+            user_message="Failed to list plugins. Please try again.",
         )
         raise HTTPException(
             status_code=get_http_status_for_error_code(WebAPIErrorCode.PLUGIN_ERROR),
@@ -167,25 +166,24 @@ async def list_plugins(
 
 @router.get("/{plugin_name}", response_model=PluginInfoResponse)
 async def get_plugin_info(
-    plugin_name: str,
-    plugin_service: PluginService = Depends(get_plugin_service)
+    plugin_name: str, plugin_service: PluginService = Depends(get_plugin_service)
 ):
     """Get detailed information about a specific plugin."""
     try:
         plugin = await plugin_service.get_plugin_info(plugin_name)
-        
+
         if not plugin:
             error_response = create_generic_error_response(
                 error_code=WebAPIErrorCode.NOT_FOUND,
                 message="Plugin not found",
                 user_message="The requested plugin could not be found.",
-                details={"plugin_name": plugin_name}
+                details={"plugin_name": plugin_name},
             )
             raise HTTPException(
                 status_code=get_http_status_for_error_code(WebAPIErrorCode.NOT_FOUND),
                 detail=error_response.dict(),
             )
-        
+
         return PluginInfoResponse(
             name=plugin.name,
             description=plugin.description,
@@ -195,13 +193,13 @@ async def get_plugin_info(
             parameters=plugin.parameters,
             author=plugin.author,
             enabled=plugin.enabled,
-            tags=getattr(plugin, 'tags', []),
-            dependencies=getattr(plugin, 'dependencies', []),
-            last_executed=getattr(plugin, 'last_executed', None),
-            execution_count=getattr(plugin, 'execution_count', 0),
-            success_rate=getattr(plugin, 'success_rate', 0.0)
+            tags=getattr(plugin, "tags", []),
+            dependencies=getattr(plugin, "dependencies", []),
+            last_executed=getattr(plugin, "last_executed", None),
+            execution_count=getattr(plugin, "execution_count", 0),
+            success_rate=getattr(plugin, "success_rate", 0.0),
         )
-        
+
     except HTTPException:
         raise
     except Exception as e:
@@ -210,7 +208,7 @@ async def get_plugin_info(
             service_name="plugin",
             error=e,
             error_code=WebAPIErrorCode.PLUGIN_ERROR,
-            user_message="Failed to get plugin information. Please try again."
+            user_message="Failed to get plugin information. Please try again.",
         )
         raise HTTPException(
             status_code=get_http_status_for_error_code(WebAPIErrorCode.PLUGIN_ERROR),
@@ -222,24 +220,19 @@ async def get_plugin_info(
 async def execute_plugin(
     plugin_name: str,
     request: ExecutePluginRequest,
-    
-    
-    plugin_service: PluginService = Depends(get_plugin_service)
+    current_user: Dict[str, Any] = Depends(get_current_user),
+    plugin_service: PluginService = Depends(get_plugin_service),
 ):
     """Execute a plugin with given parameters."""
     try:
-        # Create execution request
-        execution_request = PluginExecutionRequest(
+        result = await plugin_service.execute_plugin(
             plugin_name=plugin_name,
             parameters=request.parameters,
-            user_id="anonymous",
+            timeout_seconds=request.timeout,
+            user_id=current_user.get("user_id"),
             session_id=request.session_id,
-            timeout=request.timeout
         )
-        
-        # Execute the plugin
-        result = await plugin_service.execute_plugin(execution_request)
-        
+
         return PluginExecutionResponse(
             success=result.success,
             result=result.result,
@@ -249,16 +242,16 @@ async def execute_plugin(
             execution_time=result.execution_time,
             timestamp=result.timestamp.isoformat(),
             plugin_name=plugin_name,
-            session_id=request.session_id
+            session_id=request.session_id,
         )
-        
+
     except Exception as e:
         logger.exception("Failed to execute plugin", error=str(e))
         error_response = create_service_error_response(
             service_name="plugin",
             error=e,
             error_code=WebAPIErrorCode.PLUGIN_ERROR,
-            user_message="Failed to execute plugin. Please try again."
+            user_message="Failed to execute plugin. Please try again.",
         )
         raise HTTPException(
             status_code=get_http_status_for_error_code(WebAPIErrorCode.PLUGIN_ERROR),
@@ -270,25 +263,25 @@ async def execute_plugin(
 async def validate_plugin_parameters(
     plugin_name: str,
     request: ValidatePluginRequest,
-    plugin_service: PluginService = Depends(get_plugin_service)
+    plugin_service: PluginService = Depends(get_plugin_service),
 ):
     """Validate plugin parameters."""
     try:
         is_valid = await plugin_service.validate_plugin(plugin_name, request.parameters)
-        
+
         return {
             "valid": is_valid,
             "plugin_name": plugin_name,
-            "message": "Parameters are valid" if is_valid else "Parameters are invalid"
+            "message": "Parameters are valid" if is_valid else "Parameters are invalid",
         }
-        
+
     except Exception as e:
         logger.exception("Failed to validate plugin", error=str(e))
         error_response = create_service_error_response(
             service_name="plugin",
             error=e,
             error_code=WebAPIErrorCode.PLUGIN_ERROR,
-            user_message="Failed to validate plugin parameters. Please try again."
+            user_message="Failed to validate plugin parameters. Please try again.",
         )
         raise HTTPException(
             status_code=get_http_status_for_error_code(WebAPIErrorCode.PLUGIN_ERROR),
@@ -313,18 +306,18 @@ async def enable_plugin(
                 error_code=WebAPIErrorCode.NOT_FOUND,
                 message="Plugin not found",
                 user_message="The requested plugin could not be found.",
-                details={"plugin_name": plugin_name}
+                details={"plugin_name": plugin_name},
             )
             raise HTTPException(
                 status_code=get_http_status_for_error_code(WebAPIErrorCode.NOT_FOUND),
                 detail=error_response.dict(),
             )
-        
+
         return {
             "success": True,
-            "message": f"Plugin {plugin_name} enabled successfully"
+            "message": f"Plugin {plugin_name} enabled successfully",
         }
-        
+
     except HTTPException:
         raise
     except Exception as e:
@@ -333,7 +326,7 @@ async def enable_plugin(
             service_name="plugin",
             error=e,
             error_code=WebAPIErrorCode.PLUGIN_ERROR,
-            user_message="Failed to enable plugin. Please try again."
+            user_message="Failed to enable plugin. Please try again.",
         )
         raise HTTPException(
             status_code=get_http_status_for_error_code(WebAPIErrorCode.PLUGIN_ERROR),
@@ -358,18 +351,18 @@ async def disable_plugin(
                 error_code=WebAPIErrorCode.NOT_FOUND,
                 message="Plugin not found",
                 user_message="The requested plugin could not be found.",
-                details={"plugin_name": plugin_name}
+                details={"plugin_name": plugin_name},
             )
             raise HTTPException(
                 status_code=get_http_status_for_error_code(WebAPIErrorCode.NOT_FOUND),
                 detail=error_response.dict(),
             )
-        
+
         return {
             "success": True,
-            "message": f"Plugin {plugin_name} disabled successfully"
+            "message": f"Plugin {plugin_name} disabled successfully",
         }
-        
+
     except HTTPException:
         raise
     except Exception as e:
@@ -378,7 +371,7 @@ async def disable_plugin(
             service_name="plugin",
             error=e,
             error_code=WebAPIErrorCode.PLUGIN_ERROR,
-            user_message="Failed to disable plugin. Please try again."
+            user_message="Failed to disable plugin. Please try again.",
         )
         raise HTTPException(
             status_code=get_http_status_for_error_code(WebAPIErrorCode.PLUGIN_ERROR),
@@ -388,31 +381,33 @@ async def disable_plugin(
 
 @router.get("/categories")
 async def get_plugin_categories(
-    plugin_service: PluginService = Depends(get_plugin_service)
+    plugin_service: PluginService = Depends(get_plugin_service),
 ):
     """Get list of plugin categories."""
     try:
         plugins = await plugin_service.list_plugins()
         categories = list(set(plugin.category for plugin in plugins))
         categories.sort()
-        
+
         category_counts = {}
         for plugin in plugins:
-            category_counts[plugin.category] = category_counts.get(plugin.category, 0) + 1
-        
+            category_counts[plugin.category] = (
+                category_counts.get(plugin.category, 0) + 1
+            )
+
         return {
             "categories": categories,
             "category_counts": category_counts,
-            "total_categories": len(categories)
+            "total_categories": len(categories),
         }
-        
+
     except Exception as e:
         logger.exception("Failed to get categories", error=str(e))
         error_response = create_service_error_response(
             service_name="plugin",
             error=e,
             error_code=WebAPIErrorCode.PLUGIN_ERROR,
-            user_message="Failed to get plugin categories. Please try again."
+            user_message="Failed to get plugin categories. Please try again.",
         )
         raise HTTPException(
             status_code=get_http_status_for_error_code(WebAPIErrorCode.PLUGIN_ERROR),
@@ -422,12 +417,16 @@ async def get_plugin_categories(
 
 @router.get("/metrics", response_model=PluginMetricsResponse)
 async def get_plugin_metrics(
-    plugin_service: PluginService = Depends(get_plugin_service)
+    current_user: Dict[str, Any] = Depends(get_current_user),
+    plugin_service: PluginService = Depends(get_plugin_service),
 ):
     """Get plugin execution metrics."""
     try:
+        if "admin" not in current_user.get("roles", []):
+            raise HTTPException(status_code=403, detail="Admin privileges required")
+
         metrics = plugin_service.get_metrics()
-        
+
         return PluginMetricsResponse(
             total_plugins=metrics.get("total_plugins", 0),
             enabled_plugins=metrics.get("enabled_plugins", 0),
@@ -437,16 +436,16 @@ async def get_plugin_metrics(
             average_execution_time=metrics.get("average_execution_time", 0.0),
             plugins_by_category=metrics.get("plugins_by_category", {}),
             most_used_plugins=metrics.get("most_used_plugins", []),
-            recent_executions=metrics.get("recent_executions", [])
+            recent_executions=metrics.get("recent_executions", []),
         )
-        
+
     except Exception as e:
         logger.exception("Failed to get metrics", error=str(e))
         error_response = create_service_error_response(
             service_name="plugin",
             error=e,
             error_code=WebAPIErrorCode.PLUGIN_ERROR,
-            user_message="Failed to get plugin metrics. Please try again."
+            user_message="Failed to get plugin metrics. Please try again.",
         )
         raise HTTPException(
             status_code=get_http_status_for_error_code(WebAPIErrorCode.PLUGIN_ERROR),
@@ -468,9 +467,9 @@ async def reload_plugins(
         return {
             "success": True,
             "message": f"Reloaded {count} plugins successfully",
-            "plugins_loaded": count
+            "plugins_loaded": count,
         }
-        
+
     except HTTPException:
         raise
     except Exception as e:
@@ -479,7 +478,7 @@ async def reload_plugins(
             service_name="plugin",
             error=e,
             error_code=WebAPIErrorCode.PLUGIN_ERROR,
-            user_message="Failed to reload plugins. Please try again."
+            user_message="Failed to reload plugins. Please try again.",
         )
         raise HTTPException(
             status_code=get_http_status_for_error_code(WebAPIErrorCode.PLUGIN_ERROR),
@@ -488,24 +487,22 @@ async def reload_plugins(
 
 
 @router.get("/health")
-async def health_check(
-    plugin_service: PluginService = Depends(get_plugin_service)
-):
+async def health_check(plugin_service: PluginService = Depends(get_plugin_service)):
     """Health check for plugin service."""
     try:
-        if hasattr(plugin_service, 'health_check'):
+        if hasattr(plugin_service, "health_check"):
             health_result = await plugin_service.health_check()
             return health_result
         else:
             return {
                 "status": "healthy",
                 "service": "plugin_service",
-                "timestamp": datetime.utcnow().isoformat()
+                "timestamp": datetime.utcnow().isoformat(),
             }
     except Exception as e:
         return {
             "status": "unhealthy",
             "service": "plugin_service",
             "timestamp": datetime.utcnow().isoformat(),
-            "error": str(e)
+            "error": str(e),
         }


### PR DESCRIPTION
## Summary
- implement get_current_user utility to read auth from cookie or JWT
- secure plugin routes with authentication and admin role checks

## Testing
- `pre-commit run --files src/ai_karen_engine/utils/auth.py src/ai_karen_engine/api_routes/plugin_routes.py` *(fails: mypy missing imports)*
- `pytest` *(fails: pydantic BaseSettings moved to pydantic-settings)*

------
https://chatgpt.com/codex/tasks/task_e_6891ff725b748324966d871b0ca3ec92