### PR TITLE
refactor: add service dependencies

### DIFF
--- a/src/ai_karen_engine/chat/code_execution_service.py
+++ b/src/ai_karen_engine/chat/code_execution_service.py
@@ -216,7 +216,11 @@ class CodeExecutionService:
             }
         
         logger.info(f"Initialized environments for: {list(self._language_configs.keys())}")
-    
+
+    def get_language_configs(self) -> Dict[CodeLanguage, Dict[str, Any]]:
+        """Return configuration details for supported languages."""
+        return dict(self._language_configs)
+
     def _get_python_security_wrapper(self) -> str:
         """Get Python security wrapper code."""
         return '''

--- a/src/ai_karen_engine/chat/dependencies.py
+++ b/src/ai_karen_engine/chat/dependencies.py
@@ -1,0 +1,19 @@
+"""Dependency providers for chat-related services."""
+
+from functools import lru_cache
+
+from ai_karen_engine.chat.code_execution_service import CodeExecutionService
+from ai_karen_engine.chat.tool_integration_service import ToolIntegrationService
+
+
+@lru_cache()
+def get_code_execution_service() -> CodeExecutionService:
+    """Provide a singleton instance of CodeExecutionService."""
+    return CodeExecutionService()
+
+
+@lru_cache()
+def get_tool_integration_service() -> ToolIntegrationService:
+    """Provide a singleton instance of ToolIntegrationService."""
+    return ToolIntegrationService()
+


### PR DESCRIPTION
## Summary
- add dependency providers for code execution and tool integration services
- expose public method on `CodeExecutionService` for language configs
- switch code execution routes to use `Depends` and new providers

## Testing
- `python -m py_compile src/ai_karen_engine/chat/code_execution_service.py src/ai_karen_engine/api_routes/code_execution_routes.py src/ai_karen_engine/chat/dependencies.py`
- `pytest` *(fails: TypeError: Path() takes 0 positional arguments but 1 was given)*

------
https://chatgpt.com/codex/tasks/task_e_6891ff9f7e988324b9b4998c8e1a28ae