### PR TITLE
feat: centralize route error handling

### DIFF
--- a/src/ai_karen_engine/api_routes/llm_routes.py
+++ b/src/ai_karen_engine/api_routes/llm_routes.py
@@ -23,6 +23,7 @@ except Exception:
 
 from ai_karen_engine.integrations.llm_registry import get_registry
 from ai_karen_engine.core.config_manager import ConfigManager
+from ai_karen_engine.core.error_handler import handle_api_exception
 
 logger = logging.getLogger("kari.llm_routes")
 
@@ -115,14 +116,7 @@ async def list_providers(registry=Depends(get_llm_registry)):
         
     except Exception as ex:
         logger.error(f"Failed to list providers: {ex}")
-        raise HTTPException(
-            status_code=500,
-            detail={
-                "error": "PROVIDER_LIST_ERROR",
-                "message": "Failed to retrieve provider list",
-                "type": "SERVICE_ERROR"
-            }
-        )
+        return handle_api_exception(ex, "Failed to retrieve provider list")
 
 
 @router.get("/providers/{provider_name}", response_model=ProviderInfo)
@@ -158,13 +152,9 @@ async def get_provider_info(
         raise
     except Exception as ex:
         logger.error(f"Failed to get provider info for {provider_name}: {ex}")
-        raise HTTPException(
-            status_code=500,
-            detail={
-                "error": "PROVIDER_INFO_ERROR",
-                "message": f"Failed to get provider information for {provider_name}",
-                "type": "SERVICE_ERROR"
-            }
+        return handle_api_exception(
+            ex,
+            f"Failed to get provider information for {provider_name}",
         )
 
 
@@ -221,14 +211,7 @@ async def list_profiles():
         
     except Exception as ex:
         logger.error(f"Failed to load LLM profiles: {ex}")
-        raise HTTPException(
-            status_code=500,
-            detail={
-                "error": "PROFILES_LOAD_ERROR",
-                "message": "Failed to load LLM profiles",
-                "type": "SERVICE_ERROR"
-            }
-        )
+        return handle_api_exception(ex, "Failed to load LLM profiles")
 
 
 @router.post("/settings")
@@ -266,14 +249,7 @@ async def save_settings(
         
     except Exception as ex:
         logger.error(f"Failed to save LLM settings: {ex}")
-        raise HTTPException(
-            status_code=500,
-            detail={
-                "error": "SETTINGS_SAVE_ERROR",
-                "message": "Failed to save LLM settings",
-                "type": "SERVICE_ERROR"
-            }
-        )
+        return handle_api_exception(ex, "Failed to save LLM settings")
 
 
 @router.post("/health-check", response_model=Dict[str, Dict[str, Any]])
@@ -305,14 +281,7 @@ async def health_check_providers(
         
     except Exception as ex:
         logger.error(f"Failed to perform health check: {ex}")
-        raise HTTPException(
-            status_code=500,
-            detail={
-                "error": "HEALTH_CHECK_ERROR",
-                "message": "Failed to perform provider health check",
-                "type": "SERVICE_ERROR"
-            }
-        )
+        return handle_api_exception(ex, "Failed to perform provider health check")
 
 
 @router.get("/health-check/{provider_name}", response_model=HealthCheckResult)
@@ -341,13 +310,9 @@ async def health_check_provider(
         
     except Exception as ex:
         logger.error(f"Failed to health check provider {provider_name}: {ex}")
-        raise HTTPException(
-            status_code=500,
-            detail={
-                "error": "PROVIDER_HEALTH_CHECK_ERROR",
-                "message": f"Failed to health check provider {provider_name}",
-                "type": "SERVICE_ERROR"
-            }
+        return handle_api_exception(
+            ex,
+            f"Failed to health check provider {provider_name}",
         )
 
 
@@ -365,14 +330,7 @@ async def get_available_providers(registry=Depends(get_llm_registry)):
         
     except Exception as ex:
         logger.error(f"Failed to get available providers: {ex}")
-        raise HTTPException(
-            status_code=500,
-            detail={
-                "error": "AVAILABLE_PROVIDERS_ERROR",
-                "message": "Failed to get available providers",
-                "type": "SERVICE_ERROR"
-            }
-        )
+        return handle_api_exception(ex, "Failed to get available providers")
 
 
 @router.post("/auto-select", response_model=Dict[str, Optional[str]])
@@ -399,14 +357,7 @@ async def auto_select_provider(
         
     except Exception as ex:
         logger.error(f"Failed to auto-select provider: {ex}")
-        raise HTTPException(
-            status_code=500,
-            detail={
-                "error": "AUTO_SELECT_ERROR",
-                "message": "Failed to auto-select provider",
-                "type": "SERVICE_ERROR"
-            }
-        )
+        return handle_api_exception(ex, "Failed to auto-select provider")
 
 
 # Export the router

--- a/src/ai_karen_engine/api_routes/tool_routes.py
+++ b/src/ai_karen_engine/api_routes/tool_routes.py
@@ -26,6 +26,7 @@ from ai_karen_engine.services.tool_service import (
     BaseTool
 )
 from ai_karen_engine.core.dependencies import get_tool_service
+from ai_karen_engine.core.error_handler import handle_api_exception
 # Temporarily disable auth imports for web UI integration
 
 router = APIRouter(prefix="/api/tools", tags=["tools"])
@@ -117,7 +118,7 @@ async def list_tools(
         )
         
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Failed to list tools: {str(e)}")
+        return handle_api_exception(e, "Failed to list tools")
 
 
 @router.get("/{tool_name}", response_model=ToolInfoResponse)
@@ -137,7 +138,7 @@ async def get_tool_info(
     except HTTPException:
         raise
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Failed to get tool info: {str(e)}")
+        return handle_api_exception(e, "Failed to get tool info")
 
 
 @router.post("/{tool_name}/execute", response_model=ToolExecutionResponse)
@@ -180,7 +181,7 @@ async def execute_tool(
         )
         
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Failed to execute tool: {str(e)}")
+        return handle_api_exception(e, "Failed to execute tool")
 
 
 @router.get("/{tool_name}/schema", response_model=ToolSchemaResponse)
@@ -215,7 +216,7 @@ async def get_tool_schema(
     except HTTPException:
         raise
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Failed to get tool schema: {str(e)}")
+        return handle_api_exception(e, "Failed to get tool schema")
 
 
 @router.get("/categories")
@@ -240,7 +241,7 @@ async def get_tool_categories(
         }
         
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Failed to get categories: {str(e)}")
+        return handle_api_exception(e, "Failed to get categories")
 
 
 @router.get("/metrics", response_model=ToolMetricsResponse)
@@ -263,7 +264,7 @@ async def get_tool_metrics(
         )
         
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Failed to get metrics: {str(e)}")
+        return handle_api_exception(e, "Failed to get metrics")
 
 
 @router.post("/register")
@@ -290,7 +291,7 @@ async def register_tool(
     except HTTPException:
         raise
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Failed to register tool: {str(e)}")
+        return handle_api_exception(e, "Failed to register tool")
 
 
 @router.get("/health")
@@ -310,12 +311,7 @@ async def health_check(
                 "tools_available": len(tool_service.list_tools())
             }
     except Exception as e:
-        return {
-            "status": "unhealthy",
-            "service": "tool_service",
-            "timestamp": datetime.utcnow().isoformat(),
-            "error": str(e)
-        }
+        return handle_api_exception(e, "Tool service unhealthy")
 
 
 # Helper functions

--- a/src/ai_karen_engine/core/error_handler.py
+++ b/src/ai_karen_engine/core/error_handler.py
@@ -1,0 +1,20 @@
+from fastapi.responses import JSONResponse
+from ai_karen_engine.core.errors.handlers import get_error_handler
+
+
+def handle_api_exception(error: Exception, user_message: str | None = None) -> JSONResponse:
+    """Convert exceptions to standardized JSON responses for API routes.
+
+    Args:
+        error: The caught exception.
+        user_message: Optional message to override the default error message.
+
+    Returns:
+        JSONResponse: Response containing standardized error information.
+    """
+    handler = get_error_handler()
+    error_response = handler.handle_exception(error)
+    if user_message:
+        error_response.message = user_message
+    status_code = handler.get_http_status_code(error_response.error_code)
+    return JSONResponse(status_code=status_code, content=error_response.dict())


### PR DESCRIPTION
## Summary
- add `handle_api_exception` utility for consistent FastAPI error responses
- refactor tool and llm routes to use shared handler instead of repetitive `except Exception`

## Testing
- `python -m py_compile src/ai_karen_engine/core/error_handler.py src/ai_karen_engine/api_routes/tool_routes.py src/ai_karen_engine/api_routes/llm_routes.py`
- `pytest` *(fails: `pydantic.errors.PydanticImportError: BaseSettings has been moved to the pydantic-settings package`)*

------
https://chatgpt.com/codex/tasks/task_e_6891fe6947dc832487385cb57bd8748e