### PR TITLE
feat: stream uploads with size checks

### DIFF
--- a/src/ai_karen_engine/api_routes/file_attachment_routes.py
+++ b/src/ai_karen_engine/api_routes/file_attachment_routes.py
@@ -113,8 +113,29 @@ async def upload_file(
                 detail=error_response.dict(),
             )
         
-        # Read file content
-        file_content = await file.read()
+        # Stream file content in chunks to enforce size limits
+        max_size = file_service.max_file_size
+        file_size = 0
+        content_chunks: List[bytes] = []
+        chunk_size = 1024 * 1024  # 1MB
+        file.file.seek(0)
+        while True:
+            chunk = file.file.read(chunk_size)
+            if not chunk:
+                break
+            file_size += len(chunk)
+            if file_size > max_size:
+                error_response = create_validation_error_response(
+                    field="file",
+                    message=f"File size exceeds maximum allowed size of {max_size} bytes",
+                    details={"max_size": max_size}
+                )
+                raise HTTPException(
+                    status_code=get_http_status_for_error_code(WebAPIErrorCode.VALIDATION_ERROR),
+                    detail=error_response.dict(),
+                )
+            content_chunks.append(chunk)
+        file_content = b"".join(content_chunks)
         
         # Create upload request
         upload_request = FileUploadRequest(
@@ -229,7 +250,7 @@ async def download_file(file_id: str):
             )
         
         # Get file metadata for proper response
-        metadata = file_service._file_metadata.get(file_id)
+        metadata = file_service.list_files().get(file_id)
         if not metadata:
             filename = f"file_{file_id}"
             mime_type = "application/octet-stream"
@@ -328,7 +349,7 @@ async def process_multimedia(
             )
         
         # Get file metadata to determine media type
-        metadata = file_service._file_metadata.get(file_id)
+        metadata = file_service.list_files().get(file_id)
         if not metadata:
             error_response = create_service_error_response(
                 service_name="multimedia",
@@ -407,7 +428,7 @@ async def list_files(
         # Get all files from service
         all_files = []
         
-        for file_id, metadata in file_service._file_metadata.items():
+        for file_id, metadata in file_service.list_files().items():
             # Apply filters
             if file_type and metadata.file_type != file_type:
                 continue

--- a/src/ai_karen_engine/chat/file_attachment_service.py
+++ b/src/ai_karen_engine/chat/file_attachment_service.py
@@ -143,8 +143,12 @@ class FileAttachmentService:
         
         # File metadata storage
         self._file_metadata: Dict[str, FileMetadata] = {}
-        
+
         logger.info(f"FileAttachmentService initialized with storage: {self.storage_path}")
+
+    def list_files(self) -> Dict[str, FileMetadata]:
+        """Return a copy of stored file metadata."""
+        return dict(self._file_metadata)
     
     def _get_default_extensions(self) -> List[str]:
         """Get default allowed file extensions."""


### PR DESCRIPTION
## Summary
- stream uploaded files in chunks and validate size limits
- expose a public `list_files` API for file metadata and use it in routes

## Testing
- `pytest` *(fails: Path() takes 0 positional arguments but 1 was given)*

------
https://chatgpt.com/codex/tasks/task_e_6891fe2c35908324aef0456bb6aebf0a