### PR TITLE
feat: inject auth dependencies into tool routes

### DIFF
--- a/src/ai_karen_engine/api_routes/auth.py
+++ b/src/ai_karen_engine/api_routes/auth.py
@@ -4,7 +4,7 @@ Real database-backed authentication with secure session management
 """
 
 from fastapi import APIRouter, HTTPException, Request, Response, status, Depends
-from datetime import datetime, timedelta
+from datetime import datetime
 from typing import Any, Dict, List, Optional
 from pydantic import BaseModel, EmailStr
 
@@ -243,8 +243,15 @@ async def get_current_user(request: Request) -> UserResponse:
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid or expired session"
         )
-    
+
     return UserResponse(**user_data)
+
+
+async def get_current_tenant(
+    current_user: UserResponse = Depends(get_current_user),
+) -> str:
+    """Dependency to retrieve the current tenant ID."""
+    return current_user.tenant_id
 
 
 @router.post("/update_credentials", response_model=LoginResponse)

--- a/src/ai_karen_engine/api_routes/tool_routes.py
+++ b/src/ai_karen_engine/api_routes/tool_routes.py
@@ -2,7 +2,6 @@
 FastAPI routes for Tool service integration.
 """
 
-import uuid
 from datetime import datetime
 from typing import List, Optional, Dict, Any
 try:
@@ -22,11 +21,10 @@ except Exception:
 from ai_karen_engine.services.tool_service import (
     ToolService,
     ToolInput,
-    ToolOutput,
     BaseTool
 )
 from ai_karen_engine.core.dependencies import get_tool_service
-# Temporarily disable auth imports for web UI integration
+from ai_karen_engine.api_routes.auth import get_current_user, get_current_tenant
 
 router = APIRouter(tags=["tools"])
 
@@ -144,8 +142,8 @@ async def get_tool_info(
 async def execute_tool(
     tool_name: str,
     request: ExecuteToolRequest,
-    
-    
+    current_user: Dict[str, Any] = Depends(get_current_user),
+    tenant_id: str = Depends(get_current_tenant),
     tool_service: ToolService = Depends(get_tool_service)
 ):
     """Execute a tool with given parameters."""
@@ -270,7 +268,8 @@ async def get_tool_metrics(
 async def register_tool(
     tool_name: str,
     tool_class: str,
-    
+    current_user: Dict[str, Any] = Depends(get_current_user),
+    tenant_id: str = Depends(get_current_tenant),
     tool_service: ToolService = Depends(get_tool_service)
 ):
     """Register a new tool (admin only)."""


### PR DESCRIPTION
## Summary
- inject get_current_user and get_current_tenant dependencies into tool execution and registration routes
- expose get_current_tenant dependency in auth routes for tenant-aware requests

## Testing
- `ruff check src/ai_karen_engine/api_routes/tool_routes.py src/ai_karen_engine/api_routes/auth.py`
- `pytest` *(fails: TypeError: Path() takes 0 positional arguments but 1 was given)*


------
https://chatgpt.com/codex/tasks/task_e_68920064c3608324bf4d5bdf05306ec1