### PR TITLE
Refactor session cookie handling

### DIFF
--- a/src/ai_karen_engine/api_routes/auth.py
+++ b/src/ai_karen_engine/api_routes/auth.py
@@ -28,6 +28,26 @@ get_current_tenant = get_current_tenant_id
 COOKIE_NAME = "kari_session"
 
 
+def set_session_cookie(
+    response: Response, token: str, max_age: int = 24 * 60 * 60
+) -> None:
+    """Configure the session cookie on the response.
+
+    Args:
+        response: The FastAPI response object.
+        token: Session token to store in the cookie.
+        max_age: Lifetime of the cookie in seconds. Defaults to 24 hours.
+    """
+    response.set_cookie(
+        COOKIE_NAME,
+        token,
+        max_age=max_age,
+        httponly=True,
+        secure=True,
+        samesite="strict",
+    )
+
+
 # Request/Response Models
 class LoginRequest(BaseModel):
     email: EmailStr
@@ -107,15 +127,7 @@ async def register(
         )
 
         # Set secure HttpOnly cookie
-
-        response.set_cookie(
-            COOKIE_NAME,
-            session_data["session_token"],
-            max_age=24 * 60 * 60,  # 24 hours
-            httponly=True,
-            secure=True,
-            samesite="strict",
-        )
+        set_session_cookie(response, session_data["session_token"])
 
         # Convert UserData to dict format
         user_data = {
@@ -200,15 +212,7 @@ async def login(
         )
 
         # Set secure HttpOnly cookie
-
-        response.set_cookie(
-            COOKIE_NAME,
-            session_data["session_token"],
-            max_age=24 * 60 * 60,  # 24 hours
-            httponly=True,
-            secure=True,
-            samesite="strict",
-        )
+        set_session_cookie(response, session_data["session_token"])
 
         logger.info(
             "User logged in",
@@ -316,15 +320,7 @@ async def update_credentials(
         )
 
         # Set new cookie
-
-        response.set_cookie(
-            COOKIE_NAME,
-            session_data["session_token"],
-            max_age=24 * 60 * 60,
-            httponly=True,
-            secure=True,
-            samesite="strict",
-        )
+        set_session_cookie(response, session_data["session_token"])
 
         # Get updated user data
         updated_user = await auth_service.validate_session(


### PR DESCRIPTION
## Summary
- add `set_session_cookie` helper to configure session cookies consistently
- replace inline `response.set_cookie` calls in auth routes with new helper

## Testing
- `pre-commit run --files src/ai_karen_engine/api_routes/auth.py` *(fails: Cannot find implementation or library stub for module named "fastapi")*
- `SKIP=mypy pre-commit run --files src/ai_karen_engine/api_routes/auth.py`
- `pytest tests/test_authentication_flow.py` *(fails: ImportError: cannot import name '__version__' from 'ai_karen_engine.pydantic_stub')*


------
https://chatgpt.com/codex/tasks/task_e_68924ad0e61c832496906dab67ab389b