### PR TITLE
Persist LLM settings and dynamic timestamp

### DIFF
--- a/src/ai_karen_engine/api_routes/llm_routes.py
+++ b/src/ai_karen_engine/api_routes/llm_routes.py
@@ -5,12 +5,14 @@ Provides REST API endpoints for managing LLM providers, profiles, and configurat
 """
 
 import logging
-import yaml
+from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+import yaml
+
 try:
-    from fastapi import APIRouter, HTTPException, Depends
+    from fastapi import APIRouter, Depends, HTTPException
 except ImportError as e:  # pragma: no cover - runtime dependency
     raise ImportError(
         "FastAPI is required for LLM routes. Install via `pip install fastapi`."
@@ -23,9 +25,9 @@ except ImportError as e:  # pragma: no cover - runtime dependency
         "Pydantic is required for LLM routes. Install via `pip install pydantic`."
     ) from e
 
-from ai_karen_engine.integrations.llm_registry import get_registry
 from ai_karen_engine.core.config_manager import ConfigManager
 from ai_karen_engine.core.error_handler import handle_api_exception
+from ai_karen_engine.integrations.llm_registry import get_registry
 
 logger = logging.getLogger("kari.llm_routes")
 
@@ -35,6 +37,7 @@ router = APIRouter(tags=["llm"])
 # Request/Response Models
 class ProviderInfo(BaseModel):
     """LLM Provider information model."""
+
     name: str
     provider_class: str
     description: str
@@ -49,21 +52,23 @@ class ProviderInfo(BaseModel):
 
 class LLMProfile(BaseModel):
     """LLM Profile configuration model."""
+
     name: str
     providers: Dict[str, str] = Field(
         description="Provider assignments for different tasks",
         example={
             "chat": "ollama",
-            "conversation_processing": "ollama", 
+            "conversation_processing": "ollama",
             "code": "deepseek",
-            "generic": "ollama"
-        }
+            "generic": "ollama",
+        },
     )
     fallback: str = Field(description="Fallback provider name")
 
 
 class LLMSettings(BaseModel):
     """LLM Settings configuration model."""
+
     selected_profile: str
     provider_api_keys: Dict[str, str] = Field(default_factory=dict)
     custom_models: Dict[str, str] = Field(default_factory=dict)
@@ -71,6 +76,7 @@ class LLMSettings(BaseModel):
 
 class HealthCheckResult(BaseModel):
     """Health check result model."""
+
     status: str
     message: Optional[str] = None
     error: Optional[str] = None
@@ -93,63 +99,62 @@ def get_config_manager():
 async def list_providers(registry=Depends(get_llm_registry)):
     """
     Get list of all registered LLM providers with their information.
-    
+
     Returns:
         Dict containing list of provider information
     """
     try:
         provider_names = registry.list_providers()
         providers = []
-        
+
         for name in provider_names:
             provider_info = registry.get_provider_info(name)
             if provider_info:
                 providers.append(ProviderInfo(**provider_info))
             else:
                 # Create basic info if detailed info not available
-                providers.append(ProviderInfo(
-                    name=name,
-                    provider_class="Unknown",
-                    description=f"{name.title()} LLM provider",
-                    health_status="unknown"
-                ))
-        
+                providers.append(
+                    ProviderInfo(
+                        name=name,
+                        provider_class="Unknown",
+                        description=f"{name.title()} LLM provider",
+                        health_status="unknown",
+                    )
+                )
+
         return {"providers": providers}
-        
+
     except Exception as ex:
         logger.error(f"Failed to list providers: {ex}")
         return handle_api_exception(ex, "Failed to retrieve provider list")
 
 
 @router.get("/providers/{provider_name}", response_model=ProviderInfo)
-async def get_provider_info(
-    provider_name: str,
-    registry=Depends(get_llm_registry)
-):
+async def get_provider_info(provider_name: str, registry=Depends(get_llm_registry)):
     """
     Get detailed information about a specific LLM provider.
-    
+
     Args:
         provider_name: Name of the provider to get info for
-        
+
     Returns:
         Provider information
     """
     try:
         provider_info = registry.get_provider_info(provider_name)
-        
+
         if not provider_info:
             raise HTTPException(
                 status_code=404,
                 detail={
                     "error": "PROVIDER_NOT_FOUND",
                     "message": f"Provider '{provider_name}' not found",
-                    "type": "NOT_FOUND_ERROR"
-                }
+                    "type": "NOT_FOUND_ERROR",
+                },
             )
-        
+
         return ProviderInfo(**provider_info)
-        
+
     except HTTPException:
         raise
     except Exception as ex:
@@ -164,14 +169,14 @@ async def get_provider_info(
 async def list_profiles():
     """
     Get list of available LLM profiles.
-    
+
     Returns:
         Dict containing list of LLM profiles
     """
     try:
         # Load profiles from config file
         profiles_path = Path("config/llm_profiles.yml")
-        
+
         if not profiles_path.exists():
             # Return default profiles if config file doesn't exist
             default_profiles = [
@@ -180,10 +185,10 @@ async def list_profiles():
                     providers={
                         "chat": "ollama",
                         "conversation_processing": "ollama",
-                        "code": "deepseek", 
-                        "generic": "ollama"
+                        "code": "deepseek",
+                        "generic": "ollama",
                     },
-                    fallback="openai"
+                    fallback="openai",
                 ),
                 LLMProfile(
                     name="enterprise",
@@ -191,26 +196,28 @@ async def list_profiles():
                         "chat": "openai",
                         "conversation_processing": "openai",
                         "code": "openai",
-                        "generic": "openai"
+                        "generic": "openai",
                     },
-                    fallback="openai"
-                )
+                    fallback="openai",
+                ),
             ]
             return {"profiles": default_profiles}
-        
-        with open(profiles_path, 'r') as f:
+
+        with open(profiles_path, "r") as f:
             config_data = yaml.safe_load(f)
-        
+
         profiles = []
         for profile_name, profile_config in config_data.get("profiles", {}).items():
-            profiles.append(LLMProfile(
-                name=profile_name,
-                providers=profile_config.get("providers", {}),
-                fallback=profile_config.get("fallback", "openai")
-            ))
-        
+            profiles.append(
+                LLMProfile(
+                    name=profile_name,
+                    providers=profile_config.get("providers", {}),
+                    fallback=profile_config.get("fallback", "openai"),
+                )
+            )
+
         return {"profiles": profiles}
-        
+
     except Exception as ex:
         logger.error(f"Failed to load LLM profiles: {ex}")
         return handle_api_exception(ex, "Failed to load LLM profiles")
@@ -218,15 +225,14 @@ async def list_profiles():
 
 @router.post("/settings")
 async def save_settings(
-    settings: LLMSettings,
-    config_manager=Depends(get_config_manager)
+    settings: LLMSettings, config_manager=Depends(get_config_manager)
 ):
     """
     Save LLM provider settings.
-    
+
     Args:
         settings: LLM settings to save
-        
+
     Returns:
         Success confirmation
     """
@@ -235,20 +241,23 @@ async def save_settings(
         # Note: This is a simplified implementation
         # In a production system, you might want to save to a database
         # or persistent configuration store
-        
+
         logger.info(f"Saving LLM settings for profile: {settings.selected_profile}")
-        
-        # For now, we'll just log the settings
-        # In a full implementation, you would persist these settings
-        logger.info(f"Provider API keys configured: {list(settings.provider_api_keys.keys())}")
+
+        # Persist settings using the config manager
+        config_manager.save_llm_settings(settings)
+
+        logger.info(
+            f"Provider API keys configured: {list(settings.provider_api_keys.keys())}"
+        )
         logger.info(f"Custom models configured: {settings.custom_models}")
-        
+
         return {
             "success": True,
             "message": "LLM settings saved successfully",
-            "timestamp": "2024-01-01T00:00:00Z"
+            "timestamp": datetime.utcnow().isoformat(),
         }
-        
+
     except Exception as ex:
         logger.error(f"Failed to save LLM settings: {ex}")
         return handle_api_exception(ex, "Failed to save LLM settings")
@@ -256,16 +265,15 @@ async def save_settings(
 
 @router.post("/health-check", response_model=Dict[str, Dict[str, Any]])
 async def health_check_providers(
-    provider_names: Optional[List[str]] = None,
-    registry=Depends(get_llm_registry)
+    provider_names: Optional[List[str]] = None, registry=Depends(get_llm_registry)
 ):
     """
     Perform health check on LLM providers.
-    
+
     Args:
         provider_names: Optional list of specific providers to check.
                        If None, checks all providers.
-        
+
     Returns:
         Dict containing health check results for each provider
     """
@@ -278,38 +286,35 @@ async def health_check_providers(
             results = {}
             for provider_name in provider_names:
                 results[provider_name] = registry.health_check(provider_name)
-        
+
         return {"results": results}
-        
+
     except Exception as ex:
         logger.error(f"Failed to perform health check: {ex}")
         return handle_api_exception(ex, "Failed to perform provider health check")
 
 
 @router.get("/health-check/{provider_name}", response_model=HealthCheckResult)
-async def health_check_provider(
-    provider_name: str,
-    registry=Depends(get_llm_registry)
-):
+async def health_check_provider(provider_name: str, registry=Depends(get_llm_registry)):
     """
     Perform health check on a specific LLM provider.
-    
+
     Args:
         provider_name: Name of the provider to check
-        
+
     Returns:
         Health check result for the provider
     """
     try:
         result = registry.health_check(provider_name)
-        
+
         return HealthCheckResult(
             status=result.get("status", "unknown"),
             message=result.get("message"),
             error=result.get("error"),
-            timestamp=result.get("timestamp", 0)
+            timestamp=result.get("timestamp", 0),
         )
-        
+
     except Exception as ex:
         logger.error(f"Failed to health check provider {provider_name}: {ex}")
         return handle_api_exception(
@@ -322,14 +327,14 @@ async def health_check_provider(
 async def get_available_providers(registry=Depends(get_llm_registry)):
     """
     Get list of currently available (healthy) LLM providers.
-    
+
     Returns:
         Dict containing list of available provider names
     """
     try:
         available_providers = registry.get_available_providers()
         return {"providers": available_providers}
-        
+
     except Exception as ex:
         logger.error(f"Failed to get available providers: {ex}")
         return handle_api_exception(ex, "Failed to get available providers")
@@ -337,26 +342,22 @@ async def get_available_providers(registry=Depends(get_llm_registry)):
 
 @router.post("/auto-select", response_model=Dict[str, Optional[str]])
 async def auto_select_provider(
-    requirements: Optional[Dict[str, Any]] = None,
-    registry=Depends(get_llm_registry)
+    requirements: Optional[Dict[str, Any]] = None, registry=Depends(get_llm_registry)
 ):
     """
     Automatically select the best available provider based on requirements.
-    
+
     Args:
         requirements: Optional dict with requirements like 'streaming', 'embeddings'
-        
+
     Returns:
         Dict containing the selected provider name
     """
     try:
         selected_provider = registry.auto_select_provider(requirements)
-        
-        return {
-            "provider": selected_provider,
-            "requirements": requirements or {}
-        }
-        
+
+        return {"provider": selected_provider, "requirements": requirements or {}}
+
     except Exception as ex:
         logger.error(f"Failed to auto-select provider: {ex}")
         return handle_api_exception(ex, "Failed to auto-select provider")

--- a/src/ai_karen_engine/core/config_manager.py
+++ b/src/ai_karen_engine/core/config_manager.py
@@ -5,19 +5,20 @@ This module provides centralized configuration management for integrating
 the new Python backend services with the existing AI Karen engine.
 """
 
-import os
 import json
 import logging
-from typing import Dict, Any, Optional, Union, List
-from pathlib import Path
+import os
 from dataclasses import dataclass, field
 from enum import Enum
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Union
 
 logger = logging.getLogger(__name__)
 
 
 class Environment(str, Enum):
     """Environment enumeration."""
+
     DEVELOPMENT = "development"
     STAGING = "staging"
     PRODUCTION = "production"
@@ -27,6 +28,7 @@ class Environment(str, Enum):
 @dataclass
 class DatabaseConfig:
     """Database configuration."""
+
     host: str = "localhost"
     port: int = 5432
     database: str = "ai_karen"
@@ -42,6 +44,7 @@ class DatabaseConfig:
 @dataclass
 class RedisConfig:
     """Redis configuration."""
+
     host: str = "localhost"
     port: int = 6379
     database: int = 0
@@ -55,6 +58,7 @@ class RedisConfig:
 @dataclass
 class VectorDBConfig:
     """Vector database configuration."""
+
     provider: str = "milvus"  # milvus, pinecone, weaviate
     host: str = "localhost"
     port: int = 19530
@@ -68,6 +72,7 @@ class VectorDBConfig:
 @dataclass
 class LLMConfig:
     """LLM configuration."""
+
     provider: str = "openai"  # openai, anthropic, ollama
     model: str = "gpt-3.5-turbo"
     api_key: Optional[str] = None
@@ -81,6 +86,7 @@ class LLMConfig:
 @dataclass
 class ServiceConfig:
     """Service-specific configuration."""
+
     ai_orchestrator: Dict[str, Any] = field(default_factory=dict)
     memory_service: Dict[str, Any] = field(default_factory=dict)
     conversation_service: Dict[str, Any] = field(default_factory=dict)
@@ -92,6 +98,7 @@ class ServiceConfig:
 @dataclass
 class SecurityConfig:
     """Security configuration."""
+
     jwt_secret: str = "your-secret-key"
     jwt_algorithm: str = "HS256"
     jwt_expiration: int = 3600  # seconds
@@ -105,6 +112,7 @@ class SecurityConfig:
 @dataclass
 class MonitoringConfig:
     """Monitoring and observability configuration."""
+
     enable_metrics: bool = True
     enable_tracing: bool = False
     enable_logging: bool = True
@@ -117,17 +125,21 @@ class MonitoringConfig:
 @dataclass
 class WebUIConfig:
     """Web UI integration configuration."""
+
     enable_web_ui_features: bool = True
     session_timeout: int = 3600  # seconds
     max_conversation_history: int = 1000
     enable_proactive_suggestions: bool = True
     enable_memory_integration: bool = True
-    ui_sources: List[str] = field(default_factory=lambda: ["web", "streamlit", "desktop"])
+    ui_sources: List[str] = field(
+        default_factory=lambda: ["web", "streamlit", "desktop"]
+    )
 
 
 @dataclass
 class AIKarenConfig:
     """Main AI Karen configuration."""
+
     environment: Environment = Environment.LOCAL
     debug: bool = False
     database: DatabaseConfig = field(default_factory=DatabaseConfig)
@@ -138,85 +150,87 @@ class AIKarenConfig:
     security: SecurityConfig = field(default_factory=SecurityConfig)
     monitoring: MonitoringConfig = field(default_factory=MonitoringConfig)
     web_ui: WebUIConfig = field(default_factory=WebUIConfig)
-    
+
     # NLP and Embedding Models
-    default_embedding_model: str = "sentence-transformers/distilbert-base-nli-stsb-mean-tokens"
+    default_embedding_model: str = (
+        "sentence-transformers/distilbert-base-nli-stsb-mean-tokens"
+    )
     spacy_model: str = "en_core_web_sm"
-    
+
     # Legacy compatibility
     active_user: str = "default"
     theme: str = "dark"
     llm_model: str = "llama3.2:latest"
-    memory: Dict[str, Any] = field(default_factory=lambda: {
-        "enabled": True,
-        "provider": "local",
-        "embedding_dim": 768,
-        "decay_lambda": 0.1,
-        "query_limit": 100
-    })
+    memory: Dict[str, Any] = field(
+        default_factory=lambda: {
+            "enabled": True,
+            "provider": "local",
+            "embedding_dim": 768,
+            "decay_lambda": 0.1,
+            "query_limit": 100,
+        }
+    )
     event_bus: str = "memory"
-    ui: Dict[str, Any] = field(default_factory=lambda: {
-        "show_debug_info": False
-    })
+    ui: Dict[str, Any] = field(default_factory=lambda: {"show_debug_info": False})
 
 
 class ConfigManager:
     """
     Configuration manager for AI Karen engine integration.
-    
+
     Handles loading, validation, and management of configuration from
     multiple sources including environment variables, config files,
     and runtime updates.
     """
-    
+
     def __init__(self, config_path: Optional[Union[str, Path]] = None):
         self.config_path = Path(config_path) if config_path else Path("config.json")
         self._config: Optional[AIKarenConfig] = None
         self._watchers: List[callable] = []
-    
+
     def load_config(self) -> AIKarenConfig:
         """Load configuration from all sources."""
         if self._config is not None:
             return self._config
-        
+
         # Start with default configuration
         config_dict = {}
-        
+
         # Load from config file if it exists
         if self.config_path.exists():
             try:
-                with open(self.config_path, 'r') as f:
+                with open(self.config_path, "r") as f:
                     file_config = json.load(f)
                 config_dict.update(file_config)
                 logger.info(f"Loaded configuration from {self.config_path}")
             except Exception as e:
                 logger.warning(f"Failed to load config file {self.config_path}: {e}")
-        
+
         # Override with environment variables
         env_config = self._load_from_environment()
         config_dict = self._merge_configs(config_dict, env_config)
-        
+
         # Create configuration object
         self._config = self._create_config_object(config_dict)
-        
+
         # Validate configuration
         self._validate_config(self._config)
-        
+
         logger.info(f"Configuration loaded for environment: {self._config.environment}")
         return self._config
-    
+
     def _load_from_environment(self) -> Dict[str, Any]:
         """Load configuration from environment variables."""
         env_config = {}
-        
+
         # Environment
         if env := os.getenv("KARI_ENV"):
             env_config["environment"] = env
-        
+
         # Debug
         if debug := os.getenv("KARI_DEBUG"):
             env_config["debug"] = debug.lower() in ("true", "1", "yes")
-        
+
         # Database
         db_config = {}
         if host := os.getenv("DB_HOST"):
@@ -231,7 +245,7 @@ class ConfigManager:
             db_config["password"] = password
         if db_config:
             env_config["database"] = db_config
-        
+
         # Redis
         redis_config = {}
         if host := os.getenv("REDIS_HOST"):
@@ -242,7 +256,7 @@ class ConfigManager:
             redis_config["password"] = password
         if redis_config:
             env_config["redis"] = redis_config
-        
+
         # Vector DB
         vector_config = {}
         if provider := os.getenv("VECTOR_DB_PROVIDER"):
@@ -253,7 +267,7 @@ class ConfigManager:
             vector_config["port"] = int(port)
         if vector_config:
             env_config["vector_db"] = vector_config
-        
+
         # LLM
         llm_config = {}
         if provider := os.getenv("LLM_PROVIDER"):
@@ -266,7 +280,7 @@ class ConfigManager:
             llm_config["base_url"] = base_url
         if llm_config:
             env_config["llm"] = llm_config
-        
+
         # Security
         security_config = {}
         if secret := os.getenv("JWT_SECRET"):
@@ -275,131 +289,145 @@ class ConfigManager:
             security_config["cors_origins"] = origins.split(",")
         if security_config:
             env_config["security"] = security_config
-        
+
         # NLP and Embedding Models
         if embedding_model := os.getenv("KARI_EMBED_MODEL"):
             env_config["default_embedding_model"] = embedding_model
         if spacy_model := os.getenv("KARI_SPACY_MODEL"):
             env_config["spacy_model"] = spacy_model
-        
+
         return env_config
-    
-    def _merge_configs(self, base: Dict[str, Any], override: Dict[str, Any]) -> Dict[str, Any]:
+
+    def _merge_configs(
+        self, base: Dict[str, Any], override: Dict[str, Any]
+    ) -> Dict[str, Any]:
         """Merge configuration dictionaries recursively."""
         result = base.copy()
-        
+
         for key, value in override.items():
-            if key in result and isinstance(result[key], dict) and isinstance(value, dict):
+            if (
+                key in result
+                and isinstance(result[key], dict)
+                and isinstance(value, dict)
+            ):
                 result[key] = self._merge_configs(result[key], value)
             else:
                 result[key] = value
-        
+
         return result
-    
+
     def _create_config_object(self, config_dict: Dict[str, Any]) -> AIKarenConfig:
         """Create configuration object from dictionary."""
         # Handle nested configurations
         if "database" in config_dict:
             config_dict["database"] = DatabaseConfig(**config_dict["database"])
-        
+
         if "redis" in config_dict:
             config_dict["redis"] = RedisConfig(**config_dict["redis"])
-        
+
         if "vector_db" in config_dict:
             config_dict["vector_db"] = VectorDBConfig(**config_dict["vector_db"])
-        
+
         if "llm" in config_dict:
             config_dict["llm"] = LLMConfig(**config_dict["llm"])
-        
+
         if "services" in config_dict:
             config_dict["services"] = ServiceConfig(**config_dict["services"])
-        
+
         if "security" in config_dict:
             config_dict["security"] = SecurityConfig(**config_dict["security"])
-        
+
         if "monitoring" in config_dict:
             config_dict["monitoring"] = MonitoringConfig(**config_dict["monitoring"])
-        
+
         if "web_ui" in config_dict:
             config_dict["web_ui"] = WebUIConfig(**config_dict["web_ui"])
-        
+
         # Convert environment string to enum
         if "environment" in config_dict and isinstance(config_dict["environment"], str):
             config_dict["environment"] = Environment(config_dict["environment"])
-        
+
         return AIKarenConfig(**config_dict)
-    
+
     def _validate_config(self, config: AIKarenConfig) -> None:
         """Validate configuration."""
         # Validate required fields based on environment
         if config.environment == Environment.PRODUCTION:
-            if not config.security.jwt_secret or config.security.jwt_secret == "your-secret-key":
+            if (
+                not config.security.jwt_secret
+                or config.security.jwt_secret == "your-secret-key"
+            ):
                 raise ValueError("JWT secret must be set in production")
-            
-            if not config.llm.api_key and config.llm.provider in ["openai", "anthropic"]:
-                raise ValueError(f"API key required for {config.llm.provider} in production")
-        
+
+            if not config.llm.api_key and config.llm.provider in [
+                "openai",
+                "anthropic",
+            ]:
+                raise ValueError(
+                    f"API key required for {config.llm.provider} in production"
+                )
+
         # Validate database configuration
         if not config.database.host:
             raise ValueError("Database host is required")
-        
+
         # Validate vector database configuration
         if config.vector_db.dimension <= 0:
             raise ValueError("Vector database dimension must be positive")
-        
+
         logger.info("Configuration validation passed")
-    
+
     def get_config(self) -> AIKarenConfig:
         """Get the current configuration."""
         if self._config is None:
             return self.load_config()
         return self._config
-    
+
     def reload_config(self) -> AIKarenConfig:
         """Reload configuration from sources."""
         self._config = None
         config = self.load_config()
-        
+
         # Notify watchers
         for watcher in self._watchers:
             try:
                 watcher(config)
             except Exception as e:
                 logger.error(f"Configuration watcher error: {e}")
-        
+
         return config
-    
+
     def add_config_watcher(self, callback: callable) -> None:
         """Add a configuration change watcher."""
         self._watchers.append(callback)
-    
+
     def remove_config_watcher(self, callback: callable) -> None:
         """Remove a configuration change watcher."""
         if callback in self._watchers:
             self._watchers.remove(callback)
-    
+
     def update_config(self, updates: Dict[str, Any]) -> None:
         """Update configuration at runtime."""
         if self._config is None:
             self.load_config()
-        
+
         # Apply updates
         config_dict = self._config_to_dict(self._config)
         updated_dict = self._merge_configs(config_dict, updates)
         self._config = self._create_config_object(updated_dict)
-        
+
         # Validate updated configuration
         self._validate_config(self._config)
-        
+
         # Notify watchers
         for watcher in self._watchers:
             try:
                 watcher(self._config)
             except Exception as e:
                 logger.error(f"Configuration watcher error: {e}")
-        
+
         logger.info("Configuration updated at runtime")
-    
+
     def _config_to_dict(self, config: AIKarenConfig) -> Dict[str, Any]:
         """Convert configuration object to dictionary."""
         # This is a simplified implementation
@@ -407,26 +435,41 @@ class ConfigManager:
         result = {}
         for field_name in config.__dataclass_fields__:
             value = getattr(config, field_name)
-            if hasattr(value, '__dataclass_fields__'):
+            if hasattr(value, "__dataclass_fields__"):
                 result[field_name] = self._config_to_dict(value)
             else:
                 result[field_name] = value
         return result
-    
+
     def save_config(self, path: Optional[Union[str, Path]] = None) -> None:
         """Save current configuration to file."""
         if self._config is None:
             raise ValueError("No configuration loaded")
-        
+
         save_path = Path(path) if path else self.config_path
         config_dict = self._config_to_dict(self._config)
-        
+
         try:
-            with open(save_path, 'w') as f:
+            with open(save_path, "w") as f:
                 json.dump(config_dict, f, indent=2, default=str)
             logger.info(f"Configuration saved to {save_path}")
         except Exception as e:
             logger.error(f"Failed to save configuration: {e}")
+            raise
+
+    def save_llm_settings(
+        self, settings: Any, path: Optional[Union[str, Path]] = None
+    ) -> None:
+        """Persist LLM settings to a dedicated configuration file."""
+        save_path = Path(path) if path else Path("config/llm_settings.json")
+        save_path.parent.mkdir(parents=True, exist_ok=True)
+        data = settings.dict() if hasattr(settings, "dict") else settings
+        try:
+            with open(save_path, "w") as f:
+                json.dump(data, f, indent=2, default=str)
+            logger.info(f"LLM settings saved to {save_path}")
+        except Exception as e:
+            logger.error(f"Failed to save LLM settings: {e}")
             raise
 
 


### PR DESCRIPTION
## Summary
- persist LLM settings via ConfigManager
- return current UTC time when saving LLM settings
- add ConfigManager helper to write LLM settings file

## Testing
- `pre-commit run --files src/ai_karen_engine/api_routes/llm_routes.py src/ai_karen_engine/core/config_manager.py` *(fails: Cannot find implementation or library stub for module named "ai_karen_engine.core.services" and others)*
- `pytest tests/test_db_connection_simple.py` *(fails: ImportError: cannot import name '__version__' from 'ai_karen_engine.pydantic_stub')*


------
https://chatgpt.com/codex/tasks/task_e_68924afcace483248dcac7455c304d16