### PR TITLE
refactor auth route to use auth_utils dependency

### DIFF
--- a/src/ai_karen_engine/api_routes/auth.py
+++ b/src/ai_karen_engine/api_routes/auth.py
@@ -9,23 +9,18 @@ from typing import Any, Dict, List, Optional
 from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 from pydantic import BaseModel, EmailStr
 
-from ai_karen_engine.core.dependencies import (
-    get_current_tenant_id,
-    get_current_user_context,
-)
+from ai_karen_engine.core.dependencies import get_current_tenant_id
 from ai_karen_engine.core.logging import get_logger
 from ai_karen_engine.security.auth_manager import verify_totp
 from ai_karen_engine.services.auth_service import auth_service
+from ai_karen_engine.services.auth_utils import COOKIE_NAME, get_current_user
 
 logger = get_logger(__name__)
 router = APIRouter(tags=["auth"])
 
 
 # Alias core dependencies for convenience
-get_current_user = get_current_user_context
 get_current_tenant = get_current_tenant_id
-
-COOKIE_NAME = "kari_session"
 
 
 # Request/Response Models
@@ -235,6 +230,7 @@ async def login(
 
 @router.get("/me", response_model=UserResponse)
 async def get_current_user_route(
+    request: Request,
     user_data: Dict[str, Any] = Depends(get_current_user),
 ) -> UserResponse:
     """Get current user information"""


### PR DESCRIPTION
## Summary
- use auth_utils for session cookie and current user lookup
- adjust `/me` route to require Request and leverage new dependency

## Testing
- `pytest tests/test_auth_update_credentials.py::test_login_and_update_credentials -q` *(fails: ImportError: cannot import name '__version__' from 'ai_karen_engine.pydantic_stub')*

------
https://chatgpt.com/codex/tasks/task_e_6892441f40c48324834658c31fd1a213