### PR TITLE
feat: add auth checks for user profile routes

### DIFF
--- a/src/ai_karen_engine/api_routes/users.py
+++ b/src/ai_karen_engine/api_routes/users.py
@@ -21,7 +21,13 @@ from ai_karen_engine.core.dependencies import get_current_user_context
 
 router = APIRouter()
 
-db = DuckDBClient()
+# Shared DuckDB client instance for dependency injection
+_db_client = DuckDBClient()
+
+
+def get_db() -> DuckDBClient:
+    """Dependency that provides a DuckDB client instance."""
+    return _db_client
 
 
 class UserProfile(BaseModel):
@@ -35,7 +41,12 @@ class UserProfile(BaseModel):
 async def get_profile(
     user_id: str,
     current_user: Dict[str, Any] = Depends(get_current_user_context),
+    db: DuckDBClient = Depends(get_db),
 ) -> UserProfile:
+    # Only allow access to own profile or for admin roles
+    if current_user.get("user_id") != user_id and "admin" not in current_user.get("roles", []):
+        raise HTTPException(status_code=403, detail="Not authorized to access this profile")
+
     profile = await asyncio.to_thread(db.get_profile, user_id)
     if profile is None:
         raise HTTPException(status_code=404, detail="Profile not found")
@@ -47,7 +58,12 @@ async def save_profile(
     user_id: str,
     profile: UserProfile,
     current_user: Dict[str, Any] = Depends(get_current_user_context),
+    db: DuckDBClient = Depends(get_db),
 ) -> UserProfile:
+    # Only allow modifications to own profile or for admin roles
+    if current_user.get("user_id") != user_id and "admin" not in current_user.get("roles", []):
+        raise HTTPException(status_code=403, detail="Not authorized to modify this profile")
+
     data = profile.dict(exclude={"user_id"})
     await asyncio.to_thread(db.save_profile, user_id, data)
     return UserProfile(user_id=user_id, **data)


### PR DESCRIPTION
## Summary
- add dependency-injected DuckDB client for user profile routes
- restrict profile access and modification to the owner or admin roles

## Testing
- `pytest -q` *(fails: ImportError: cannot import name '__version__' from 'ai_karen_engine.pydantic_stub')*

------
https://chatgpt.com/codex/tasks/task_e_689263ac19dc8324b70341c97e16a729