### PR TITLE
Require external secret key configuration

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -27,3 +27,13 @@ Be sure to provision PostgreSQL, Redis and any vector stores before installing t
 
 Runtime settings are controlled via environment variables or the `config.json` file. Review `config/README.md` for parameter descriptions.
 
+### Required `SECRET_KEY`
+
+For security, the server **requires** a secret key for signing tokens. Set it via the `SECRET_KEY` environment variable or in a `.env` file before starting the application:
+
+```bash
+export SECRET_KEY="your-production-secret"
+```
+
+Deployments without this value will fail to start.
+

--- a/main.py
+++ b/main.py
@@ -9,7 +9,6 @@ Kari FastAPI Server - Production Version
 
 import logging
 import logging.config
-import secrets
 import ssl
 from datetime import datetime, timezone
 from pathlib import Path
@@ -50,7 +49,7 @@ from ai_karen_engine.server.startup import create_lifespan
 class Settings(BaseSettings):
     app_name: str = "Kari AI Server"
     environment: str = "development"
-    secret_key: str = Field(default_factory=lambda: secrets.token_urlsafe(64))
+    secret_key: str = Field(..., env="SECRET_KEY")
     algorithm: str = "HS256"
     access_token_expire_minutes: int = 30
     database_url: str = "postgresql://user:password@localhost:5432/kari_prod"


### PR DESCRIPTION
## Summary
- Require SECRET_KEY to be provided via environment or `.env`
- Document SECRET_KEY requirement for deployments

## Testing
- `SECRET_KEY=test-secret pytest` *(fails: ImportError: FastAPI is required for memory routes. Install via `pip install fastapi`.)*

------
https://chatgpt.com/codex/tasks/task_e_689262a6dbd08324b4f8603a11d05bd9