### PR TITLE
Clarify tenant ID dependency alias in auth routes

### DIFF
--- a/src/ai_karen_engine/api_routes/auth.py
+++ b/src/ai_karen_engine/api_routes/auth.py
@@ -21,9 +21,9 @@ logger = get_logger(__name__)
 router = APIRouter(tags=["auth"])
 
 
-# Alias core dependencies for convenience
+# Alias core dependencies for clarity
 get_current_user = get_current_user_context
-get_tenant_id = get_current_tenant_id
+get_current_tenant_id_dependency = get_current_tenant_id
 
 COOKIE_NAME = "kari_session"
 


### PR DESCRIPTION
## Summary
- Rename tenant ID dependency alias to `get_current_tenant_id_dependency` for clarity in auth routes.

## Testing
- `ruff check src/ai_karen_engine/api_routes/auth.py`
- `pytest -q` *(fails: ImportError: cannot import name '__version__' from 'ai_karen_engine.pydantic_stub')*

------
https://chatgpt.com/codex/tasks/task_e_689263ae00548324ac12c13bd1d5dc71