### PR TITLE
Import Depends to fix metrics endpoint

### DIFF
--- a/main.py
+++ b/main.py
@@ -13,7 +13,8 @@ import secrets
 import ssl
 from datetime import datetime, timezone
 from pathlib import Path
-from fastapi import FastAPI, HTTPException, Request
+
+from fastapi import Depends, FastAPI, HTTPException, Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse, Response
 


### PR DESCRIPTION
## Summary
- import `Depends` from FastAPI in `main.py`

## Testing
- `pre-commit run --files main.py`
- `pytest` *(fails: ImportError: cannot import name '__version__' from 'ai_karen_engine.pydantic_stub')*
- `PYTHONPATH=src DISPLAY=:0 python - <<'PY'
import main
print('imported main')
PY` *(fails: Xlib.error.DisplayConnectionError: Can't connect to display ":0": [Errno 2] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689263c6b8f483249c7e14eb4002897e