### PR TITLE
fix: correct code execution dependencies import

### DIFF
--- a/src/ai_karen_engine/api_routes/code_execution_routes.py
+++ b/src/ai_karen_engine/api_routes/code_execution_routes.py
@@ -31,13 +31,15 @@ from ai_karen_engine.chat.code_execution_service import (
     CodeExecutionService,
     CodeLanguage,
     SecurityLevel,
+)
+from ai_karen_engine.chat.dependencies import (
     get_code_execution_service,
+    get_tool_integration_service,
 )
 from ai_karen_engine.chat.tool_integration_service import (
     ToolExecutionContext,
     ToolExecutionResult,
     ToolIntegrationService,
-    get_tool_integration_service,
 )
 from ai_karen_engine.core.dependencies import get_current_user_context
 from ai_karen_engine.core.logging import get_logger


### PR DESCRIPTION
## Summary
- fix code execution route to import services from dedicated dependency module

## Testing
- `pre-commit run --files src/ai_karen_engine/api_routes/code_execution_routes.py` *(failed: missing imports in mypy)*
- `pytest tests/test_advanced_chat_features.py::TestCodeExecutionFeatures::test_python_code_execution -q` *(failed: ImportError: cannot import name '__version__' from 'ai_karen_engine.pydantic_stub')*

------
https://chatgpt.com/codex/tasks/task_e_689273c5925c8324bb30f55c557cc898