### PR TITLE
feat: make session cookie security configurable

### DIFF
--- a/src/ai_karen_engine/api_routes/auth.py
+++ b/src/ai_karen_engine/api_routes/auth.py
@@ -13,6 +13,7 @@ from ai_karen_engine.core.dependencies import (
     get_current_tenant_id,
     get_current_user_context,
 )
+from ai_karen_engine.core.chat_memory_config import settings
 from ai_karen_engine.core.logging import get_logger
 from ai_karen_engine.security.auth_manager import verify_totp
 from ai_karen_engine.services.auth_service import auth_service
@@ -38,12 +39,17 @@ def set_session_cookie(
         token: Session token to store in the cookie.
         max_age: Lifetime of the cookie in seconds. Defaults to 24 hours.
     """
+    secure_flag = (
+        settings.auth.cookie_secure
+        if settings.auth.cookie_secure is not None
+        else settings.environment.lower() == "production"
+    )
     response.set_cookie(
         COOKIE_NAME,
         token,
         max_age=max_age,
         httponly=True,
-        secure=True,
+        secure=secure_flag,
         samesite="strict",
     )
 

--- a/src/ai_karen_engine/core/chat_memory_config.py
+++ b/src/ai_karen_engine/core/chat_memory_config.py
@@ -10,6 +10,7 @@ Chat Memory & Auth Configuration
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Optional
 
 from pydantic import Field
 from pydantic import __version__ as pydantic_version
@@ -102,6 +103,13 @@ class ProductionAuthSettings(BaseSettings):
     # Rate limiting
     login_rate_limit: int = Field(5, description="Login attempts per minute")
     api_rate_limit: int = Field(100, description="API requests per minute")
+
+    # Cookie security
+    cookie_secure: Optional[bool] = Field(
+        None,
+        description="Send session cookies with the 'secure' flag",
+        json_schema_extra={"env": "COOKIE_SECURE"},
+    )
 
     if V2:
         model_config = SettingsConfigDict(

--- a/src/ai_karen_engine/services/auth_utils.py
+++ b/src/ai_karen_engine/services/auth_utils.py
@@ -2,6 +2,7 @@ from typing import Any, Dict, Optional
 
 from fastapi import HTTPException, Request, Response, status
 
+from ai_karen_engine.core.chat_memory_config import settings
 from ai_karen_engine.services.auth_service import auth_service
 
 # Shared cookie name for authentication sessions
@@ -22,12 +23,17 @@ def set_session_cookie(
     response: Response, session_token: str, max_age: int = 24 * 60 * 60
 ) -> None:
     """Set the authentication session cookie on the response."""
+    secure_flag = (
+        settings.auth.cookie_secure
+        if settings.auth.cookie_secure is not None
+        else settings.environment.lower() == "production"
+    )
     response.set_cookie(
         COOKIE_NAME,
         session_token,
         max_age=max_age,
         httponly=True,
-        secure=True,
+        secure=secure_flag,
         samesite="strict",
     )
 


### PR DESCRIPTION
## Summary
- add `cookie_secure` setting to toggle secure attribute on session cookies
- respect this flag in auth routes and auth utility

## Testing
- `ruff check src/ai_karen_engine/api_routes/auth.py src/ai_karen_engine/services/auth_utils.py src/ai_karen_engine/core/chat_memory_config.py`
- `pytest` *(fails: ImportError: cannot import name '__version__' from 'ai_karen_engine.pydantic_stub')*

------
https://chatgpt.com/codex/tasks/task_e_68927aa4118883248540dc61d2d9ab62