### PR TITLE
Use timezone-aware timestamps in API routes

### DIFF
--- a/src/ai_karen_engine/api_routes/ai_orchestrator_routes.py
+++ b/src/ai_karen_engine/api_routes/ai_orchestrator_routes.py
@@ -2,7 +2,7 @@
 FastAPI routes for AI Orchestrator service integration.
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import List, Optional, Dict, Any
 from fastapi import APIRouter, HTTPException, Depends
 from pydantic import BaseModel, Field
@@ -106,9 +106,9 @@ async def process_flow(
         )
         
         # Process the flow
-        start_time = datetime.utcnow()
+        start_time = datetime.now(timezone.utc)
         result = await ai_orchestrator.process_flow(request.flow_type, flow_input)
-        processing_time = (datetime.utcnow() - start_time).total_seconds() * 1000
+        processing_time = (datetime.now(timezone.utc) - start_time).total_seconds() * 1000
         
         return FlowResponse(
             **format_flow_response(result, int(processing_time))
@@ -147,9 +147,9 @@ async def decide_action(
         )
         
         # Process decide action flow
-        start_time = datetime.utcnow()
+        start_time = datetime.now(timezone.utc)
         result = await ai_orchestrator.decide_action(flow_input)
-        processing_time = (datetime.utcnow() - start_time).total_seconds() * 1000
+        processing_time = (datetime.now(timezone.utc) - start_time).total_seconds() * 1000
         
         return FlowResponse(
             **format_flow_response(result, int(processing_time))
@@ -195,9 +195,9 @@ async def conversation_processing(
         )
         
         # Process conversation flow
-        start_time = datetime.utcnow()
+        start_time = datetime.now(timezone.utc)
         result = await ai_orchestrator.conversation_processing_flow(flow_input)
-        processing_time = (datetime.utcnow() - start_time).total_seconds() * 1000
+        processing_time = (datetime.now(timezone.utc) - start_time).total_seconds() * 1000
         
         return FlowResponse(
             **format_flow_response(result, int(processing_time))
@@ -297,7 +297,7 @@ async def _generate_starter_prompts(_: Optional[str] = None) -> Dict[str, Any]:
 
     return {
         "prompts": starter_prompts,
-        "timestamp": datetime.utcnow().isoformat(),
+        "timestamp": datetime.now(timezone.utc).isoformat(),
     }
 
 
@@ -355,13 +355,13 @@ async def health_check(
             return {
                 "status": "healthy",
                 "service": "ai_orchestrator",
-                "timestamp": datetime.utcnow().isoformat()
+                "timestamp": datetime.now(timezone.utc).isoformat()
             }
     except Exception as e:
         return {
             "status": "unhealthy",
             "service": "ai_orchestrator",
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
             "error": str(e)
         }
 

--- a/src/ai_karen_engine/api_routes/conversation_routes.py
+++ b/src/ai_karen_engine/api_routes/conversation_routes.py
@@ -2,7 +2,7 @@
 FastAPI routes for enhanced conversation management with web UI integration.
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import List, Optional, Dict, Any
 
 try:
@@ -869,5 +869,5 @@ async def health_check():
     return {
         "status": "healthy",
         "service": "conversation",
-        "timestamp": datetime.utcnow().isoformat()
+        "timestamp": datetime.now(timezone.utc).isoformat()
     }

--- a/src/ai_karen_engine/api_routes/database.py
+++ b/src/ai_karen_engine/api_routes/database.py
@@ -6,7 +6,7 @@ Provides REST endpoints for tenant, memory, and conversation management.
 
 import logging
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Dict, List, Optional, Any
 
 try:
@@ -432,7 +432,7 @@ async def health_check(db_manager: DatabaseIntegrationManager = Depends(get_db_m
             "data": {
                 "status": "unhealthy",
                 "error": str(e),
-                "timestamp": datetime.utcnow().isoformat(),
+                "timestamp": datetime.now(timezone.utc).isoformat(),
             },
         }
 

--- a/src/ai_karen_engine/api_routes/enhanced_file_attachment_routes.py
+++ b/src/ai_karen_engine/api_routes/enhanced_file_attachment_routes.py
@@ -2,7 +2,7 @@
 Enhanced FastAPI routes for file attachment with AG-UI and hook integration.
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import List, Optional, Dict, Any
 import json
 
@@ -174,7 +174,7 @@ async def enhanced_upload_file(
                 "security_scan_result": result.metadata.security_scan_result.value if result.metadata.security_scan_result else None
             },
             "chart_data": {
-                "upload_time": datetime.utcnow().isoformat(),
+                "upload_time": datetime.now(timezone.utc).isoformat(),
                 "file_size_mb": round(result.metadata.file_size / (1024 * 1024), 2),
                 "file_type": result.metadata.file_type.value
             }

--- a/src/ai_karen_engine/api_routes/hook_middleware.py
+++ b/src/ai_karen_engine/api_routes/hook_middleware.py
@@ -12,7 +12,7 @@ import asyncio
 import logging
 import time
 from typing import Callable, Dict, Any, Optional
-from datetime import datetime
+from datetime import datetime, timezone
 
 try:
     from fastapi import Request, Response
@@ -151,7 +151,7 @@ class HookMiddleware(BaseHTTPMiddleware):
                 "headers": dict(request.headers),
                 "path_params": dict(request.path_params),
                 "body": body,
-                "timestamp": datetime.utcnow().isoformat(),
+                "timestamp": datetime.now(timezone.utc).isoformat(),
                 "client_host": getattr(request.client, 'host', None) if request.client else None,
                 "user_agent": request.headers.get("user-agent"),
                 "content_type": request.headers.get("content-type"),
@@ -164,7 +164,7 @@ class HookMiddleware(BaseHTTPMiddleware):
                 "method": request.method,
                 "url": str(request.url),
                 "path": request.url.path,
-                "timestamp": datetime.utcnow().isoformat(),
+                "timestamp": datetime.now(timezone.utc).isoformat(),
                 "extraction_error": str(e)
             }
     
@@ -177,14 +177,14 @@ class HookMiddleware(BaseHTTPMiddleware):
                 "processing_time": processing_time,
                 "content_type": response.headers.get("content-type"),
                 "content_length": response.headers.get("content-length"),
-                "timestamp": datetime.utcnow().isoformat()
+                "timestamp": datetime.now(timezone.utc).isoformat()
             }
         except Exception as e:
             logger.warning(f"Failed to extract response info: {e}")
             return {
                 "status_code": getattr(response, 'status_code', 500),
                 "processing_time": processing_time,
-                "timestamp": datetime.utcnow().isoformat(),
+                "timestamp": datetime.now(timezone.utc).isoformat(),
                 "extraction_error": str(e)
             }
     
@@ -220,7 +220,7 @@ class HookMiddleware(BaseHTTPMiddleware):
             return {
                 "hook_type": hook_type,
                 "summary": summary.__dict__,
-                "executed_at": datetime.utcnow().isoformat()
+                "executed_at": datetime.now(timezone.utc).isoformat()
             }
             
         except asyncio.TimeoutError:
@@ -291,7 +291,7 @@ class HookMiddleware(BaseHTTPMiddleware):
                     "api_endpoint": request_info["path"],
                     "http_method": request_info["method"],
                     "pre_hook_results": pre_hook_results,
-                    "timestamp": datetime.utcnow().isoformat()
+                    "timestamp": datetime.now(timezone.utc).isoformat()
                 },
                 user_context=self._extract_user_context(request_info)
             )

--- a/src/ai_karen_engine/api_routes/hook_routes.py
+++ b/src/ai_karen_engine/api_routes/hook_routes.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from typing import Dict, List, Optional, Any
-from datetime import datetime
+from datetime import datetime, timezone
 
 try:
     from fastapi import APIRouter, HTTPException, Query, Path
@@ -116,7 +116,7 @@ async def register_hook(
                 "hook_type": request.hook_type,
                 "source_type": request.source_type,
                 "source_name": request.source_name,
-                "executed_at": datetime.utcnow().isoformat(),
+                "executed_at": datetime.now(timezone.utc).isoformat(),
                 "data_keys": list(context.data.keys()),
                 "message": f"API hook {request.hook_type} executed successfully"
             }
@@ -145,7 +145,7 @@ async def register_hook(
             source_type=hook_registration.source_type,
             source_name=hook_registration.source_name,
             enabled=hook_registration.enabled,
-            registered_at=datetime.utcnow().isoformat()
+            registered_at=datetime.now(timezone.utc).isoformat()
         )
         
     except Exception as e:
@@ -266,7 +266,7 @@ async def list_hooks(
                 source_type=hook.source_type,
                 source_name=hook.source_name,
                 enabled=hook.enabled,
-                registered_at=datetime.utcnow().isoformat()  # Placeholder - would be actual registration time
+                registered_at=datetime.now(timezone.utc).isoformat()  # Placeholder - would be actual registration time
             ))
         
         return HookListResponse(
@@ -546,7 +546,7 @@ async def hook_system_health():
                 "source_types": summary["source_types"]
             },
             "execution_stats": summary["execution_stats"],
-            "timestamp": datetime.utcnow().isoformat()
+            "timestamp": datetime.now(timezone.utc).isoformat()
         }
         
     except Exception as e:
@@ -554,5 +554,5 @@ async def hook_system_health():
         return {
             "status": "error",
             "error": str(e),
-            "timestamp": datetime.utcnow().isoformat()
+            "timestamp": datetime.now(timezone.utc).isoformat()
         }

--- a/src/ai_karen_engine/api_routes/llm_routes.py
+++ b/src/ai_karen_engine/api_routes/llm_routes.py
@@ -5,7 +5,7 @@ Provides REST API endpoints for managing LLM providers, profiles, and configurat
 """
 
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -255,7 +255,7 @@ async def save_settings(
         return {
             "success": True,
             "message": "LLM settings saved successfully",
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
         }
 
     except Exception as ex:

--- a/src/ai_karen_engine/api_routes/memory_routes.py
+++ b/src/ai_karen_engine/api_routes/memory_routes.py
@@ -2,7 +2,7 @@
 FastAPI routes for enhanced memory management with web UI integration.
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Tuple
 
 try:
@@ -637,5 +637,5 @@ async def health_check():
     return {
         "status": "healthy",
         "service": "memory",
-        "timestamp": datetime.utcnow().isoformat(),
+        "timestamp": datetime.now(timezone.utc).isoformat(),
     }

--- a/src/ai_karen_engine/api_routes/persona_routes.py
+++ b/src/ai_karen_engine/api_routes/persona_routes.py
@@ -3,7 +3,7 @@ Persona API Routes
 REST endpoints for managing personas, style controls, and user preferences
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, status
@@ -451,7 +451,7 @@ async def persona_health_check():
 
         return {
             "status": "healthy",
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
             "service": "persona-service",
             "system_personas_available": system_personas_count,
             "nlp_analyzer_available": hasattr(

--- a/src/ai_karen_engine/api_routes/tool_routes.py
+++ b/src/ai_karen_engine/api_routes/tool_routes.py
@@ -2,7 +2,7 @@
 FastAPI routes for Tool service integration.
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
 try:
@@ -179,7 +179,7 @@ async def execute_tool(
         )
 
         # Execute the tool
-        start_time = datetime.utcnow()
+        start_time = datetime.now(timezone.utc)
         result = await tool_service.execute_tool(tool_input)
 
         return ToolExecutionResponse(
@@ -315,7 +315,7 @@ async def health_check(tool_service: ToolService = Depends(get_tool_service)):
             return {
                 "status": "healthy",
                 "service": "tool_service",
-                "timestamp": datetime.utcnow().isoformat(),
+                "timestamp": datetime.now(timezone.utc).isoformat(),
                 "tools_available": len(tool_service.list_tools()),
             }
     except Exception as e:

--- a/src/ai_karen_engine/api_routes/web_api_compatibility.py
+++ b/src/ai_karen_engine/api_routes/web_api_compatibility.py
@@ -7,7 +7,7 @@ to the correct backend services with proper request/response transformation.
 
 import logging
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Dict, Any, List, Optional
 from fastapi import APIRouter, HTTPException, Depends, Request
 from pydantic import ValidationError
@@ -147,7 +147,7 @@ async def chat_process_compatibility(
             )
 
         # Call AI orchestrator service with timeout and retry logic
-        start_time = datetime.utcnow()
+        start_time = datetime.now(timezone.utc)
         max_retries = 2
         retry_count = 0
 
@@ -230,7 +230,7 @@ async def chat_process_compatibility(
                     logger.error(f"[{request_id}] AI orchestrator error: {e}")
                     raise
 
-        processing_time = (datetime.utcnow() - start_time).total_seconds() * 1000
+        processing_time = (datetime.now(timezone.utc) - start_time).total_seconds() * 1000
         logger.info(
             f"[{request_id}] Chat processing completed in {processing_time:.2f}ms"
         )
@@ -427,7 +427,7 @@ async def memory_query_compatibility(
             )
 
         # Query memories with timeout and retry logic
-        start_time = datetime.utcnow()
+        start_time = datetime.now(timezone.utc)
         max_retries = 2
         retry_count = 0
         memories = []
@@ -499,7 +499,7 @@ async def memory_query_compatibility(
                     logger.error(f"[{request_id}] Memory service error: {e}")
                     raise
 
-        query_time = (datetime.utcnow() - start_time).total_seconds() * 1000
+        query_time = (datetime.now(timezone.utc) - start_time).total_seconds() * 1000
         logger.info(
             f"[{request_id}] Memory query completed in {query_time:.2f}ms, found {len(memories)} memories"
         )
@@ -720,7 +720,7 @@ async def memory_store_compatibility(
                 user_id = None
 
         # Store memory with enhanced error handling
-        start_time = datetime.utcnow()
+        start_time = datetime.now(timezone.utc)
         memory_id = None
 
         try:
@@ -766,7 +766,7 @@ async def memory_store_compatibility(
                             ai_generated=backend_request.ai_generated,
                         )
                         storage_time = (
-                            datetime.utcnow() - start_time
+                            datetime.now(timezone.utc) - start_time
                         ).total_seconds() * 1000
                         backend_response = {
                             "success": memory_id is not None,
@@ -841,7 +841,7 @@ async def memory_store_compatibility(
                 detail=error_response.dict(),
             )
 
-        storage_time = (datetime.utcnow() - start_time).total_seconds() * 1000
+        storage_time = (datetime.now(timezone.utc) - start_time).total_seconds() * 1000
 
         # Transform response to web UI format
         try:
@@ -984,7 +984,7 @@ async def execute_plugin_compatibility(
         logger.info(f"[{request_id}] Executing plugin: {request.plugin_name}")
 
         # Execute plugin
-        start_time = datetime.utcnow()
+        start_time = datetime.now(timezone.utc)
         result = (
             await plugin_service.execute_plugin(
                 request.plugin_name,
@@ -996,7 +996,7 @@ async def execute_plugin_compatibility(
             else {"error": "Plugin service not available"}
         )
 
-        execution_time = (datetime.utcnow() - start_time).total_seconds() * 1000
+        execution_time = (datetime.now(timezone.utc) - start_time).total_seconds() * 1000
 
         # Create response
         response = WebUIPluginExecuteResponse(
@@ -1171,7 +1171,7 @@ async def health_check_compatibility(http_request: Request):
                 get_ai_orchestrator_service()
                 services["ai_orchestrator"] = {
                     "status": "healthy",
-                    "last_check": datetime.utcnow().isoformat(),
+                    "last_check": datetime.now(timezone.utc).isoformat(),
                     "uptime": 100.0,
                     "error_count": 0,
                     "success_count": 1,
@@ -1183,7 +1183,7 @@ async def health_check_compatibility(http_request: Request):
                 )
                 services["ai_orchestrator"] = {
                     "status": "unhealthy",
-                    "last_check": datetime.utcnow().isoformat(),
+                    "last_check": datetime.now(timezone.utc).isoformat(),
                     "uptime": 0.0,
                     "error_count": 1,
                     "success_count": 0,
@@ -1199,7 +1199,7 @@ async def health_check_compatibility(http_request: Request):
                 get_memory_service()
                 services["memory_service"] = {
                     "status": "healthy",
-                    "last_check": datetime.utcnow().isoformat(),
+                    "last_check": datetime.now(timezone.utc).isoformat(),
                     "uptime": 100.0,
                     "error_count": 0,
                     "success_count": 1,
@@ -1211,7 +1211,7 @@ async def health_check_compatibility(http_request: Request):
                 )
                 services["memory_service"] = {
                     "status": "unhealthy",
-                    "last_check": datetime.utcnow().isoformat(),
+                    "last_check": datetime.now(timezone.utc).isoformat(),
                     "uptime": 0.0,
                     "error_count": 1,
                     "success_count": 0,
@@ -1227,7 +1227,7 @@ async def health_check_compatibility(http_request: Request):
                 get_plugin_service()
                 services["plugin_service"] = {
                     "status": "healthy",
-                    "last_check": datetime.utcnow().isoformat(),
+                    "last_check": datetime.now(timezone.utc).isoformat(),
                     "uptime": 100.0,
                     "error_count": 0,
                     "success_count": 1,
@@ -1239,7 +1239,7 @@ async def health_check_compatibility(http_request: Request):
                 )
                 services["plugin_service"] = {
                     "status": "unhealthy",
-                    "last_check": datetime.utcnow().isoformat(),
+                    "last_check": datetime.now(timezone.utc).isoformat(),
                     "uptime": 0.0,
                     "error_count": 1,
                     "success_count": 0,
@@ -1256,7 +1256,7 @@ async def health_check_compatibility(http_request: Request):
                 # Simple connectivity test
                 services["database"] = {
                     "status": "healthy",
-                    "last_check": datetime.utcnow().isoformat(),
+                    "last_check": datetime.now(timezone.utc).isoformat(),
                     "uptime": 100.0,
                     "error_count": 0,
                     "success_count": 1,
@@ -1266,7 +1266,7 @@ async def health_check_compatibility(http_request: Request):
                 logger.error(f"[{request_id}] Database health check failed: {db_error}")
                 services["database"] = {
                     "status": "unhealthy",
-                    "last_check": datetime.utcnow().isoformat(),
+                    "last_check": datetime.now(timezone.utc).isoformat(),
                     "uptime": 0.0,
                     "error_count": 1,
                     "success_count": 0,
@@ -1288,7 +1288,7 @@ async def health_check_compatibility(http_request: Request):
             backend_health = {
                 "status": overall_status,
                 "services": services,
-                "timestamp": datetime.utcnow().isoformat(),
+                "timestamp": datetime.now(timezone.utc).isoformat(),
                 "uptime": 3600.0,  # Default uptime
                 "total_services": len(services),
                 "healthy_services": healthy_count,
@@ -1456,9 +1456,9 @@ async def trigger_health_check(http_request: Request):
             health_monitor = get_health_monitor()
 
             # Trigger immediate health check for all services
-            start_time = datetime.utcnow()
+            start_time = datetime.now(timezone.utc)
             results = await health_monitor.check_all_services()
-            check_duration = (datetime.utcnow() - start_time).total_seconds() * 1000
+            check_duration = (datetime.now(timezone.utc) - start_time).total_seconds() * 1000
 
             # Format results for web UI
             formatted_results = {}
@@ -1477,7 +1477,7 @@ async def trigger_health_check(http_request: Request):
             response = {
                 "message": "Health check completed successfully",
                 "check_duration_ms": round(check_duration, 2),
-                "timestamp": datetime.utcnow().isoformat(),
+                "timestamp": datetime.now(timezone.utc).isoformat(),
                 "overall_status": health_summary["overall_status"],
                 "services_checked": len(results),
                 "results": formatted_results,
@@ -1495,7 +1495,7 @@ async def trigger_health_check(http_request: Request):
             )
 
             # Manual health checks as fallback
-            start_time = datetime.utcnow()
+            start_time = datetime.now(timezone.utc)
             results = {}
 
             # Check critical services manually
@@ -1524,7 +1524,7 @@ async def trigger_health_check(http_request: Request):
                         "status": "healthy",
                         "message": f"{service_name} is available",
                         "response_time": 0.1,
-                        "timestamp": datetime.utcnow().isoformat(),
+                        "timestamp": datetime.now(timezone.utc).isoformat(),
                         "error": None,
                     }
 
@@ -1533,11 +1533,11 @@ async def trigger_health_check(http_request: Request):
                         "status": "unhealthy",
                         "message": f"{service_name} check failed: {str(e)}",
                         "response_time": 0.0,
-                        "timestamp": datetime.utcnow().isoformat(),
+                        "timestamp": datetime.now(timezone.utc).isoformat(),
                         "error": str(e),
                     }
 
-            check_duration = (datetime.utcnow() - start_time).total_seconds() * 1000
+            check_duration = (datetime.now(timezone.utc) - start_time).total_seconds() * 1000
 
             healthy_count = sum(1 for r in results.values() if r["status"] == "healthy")
             unhealthy_count = len(results) - healthy_count
@@ -1550,7 +1550,7 @@ async def trigger_health_check(http_request: Request):
             response = {
                 "message": "Manual health check completed",
                 "check_duration_ms": round(check_duration, 2),
-                "timestamp": datetime.utcnow().isoformat(),
+                "timestamp": datetime.now(timezone.utc).isoformat(),
                 "overall_status": overall_status,
                 "services_checked": len(results),
                 "results": results,


### PR DESCRIPTION
## Summary
- replace `datetime.utcnow()` with `datetime.now(timezone.utc)` across API route modules
- ensure all updated routes import `timezone`

## Testing
- `pytest -q` *(fails: ImportError: cannot import name '__version__' from 'ai_karen_engine.pydantic_stub')*


------
https://chatgpt.com/codex/tasks/task_e_68927a9bafa48324863d963910af0174