### PR TITLE
feat: add API error handling decorator

### DIFF
--- a/src/ai_karen_engine/api_routes/hook_routes.py
+++ b/src/ai_karen_engine/api_routes/hook_routes.py
@@ -9,11 +9,11 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import Dict, List, Optional, Any
 from datetime import datetime
+from typing import Any, Dict, List, Optional
 
 try:
-    from fastapi import APIRouter, HTTPException, Query, Path
+    from fastapi import APIRouter, HTTPException, Path, Query
 except ImportError as e:  # pragma: no cover - runtime dependency
     raise ImportError(
         "FastAPI is required for hook routes. Install via `pip install fastapi`."
@@ -26,7 +26,8 @@ except ImportError as e:  # pragma: no cover - runtime dependency
         "Pydantic is required for hook routes. Install via `pip install pydantic`."
     ) from e
 
-from ai_karen_engine.hooks import get_hook_manager, HookTypes, HookContext
+from ai_karen_engine.core.error_handler import handle_api_errors
+from ai_karen_engine.hooks import HookContext, HookTypes, get_hook_manager
 
 logger = logging.getLogger(__name__)
 
@@ -36,9 +37,12 @@ router = APIRouter(tags=["hooks"])
 # Request/Response Models
 class RegisterHookRequest(BaseModel):
     """Request model for registering a hook."""
+
     hook_type: str = Field(..., description="Type of hook to register")
     priority: int = Field(100, description="Hook priority (lower = higher priority)")
-    conditions: Optional[Dict[str, Any]] = Field(None, description="Conditions for hook execution")
+    conditions: Optional[Dict[str, Any]] = Field(
+        None, description="Conditions for hook execution"
+    )
     source_type: str = Field("api", description="Type of source registering the hook")
     source_name: Optional[str] = Field(None, description="Name of the source")
     enabled: bool = Field(True, description="Whether the hook is enabled")
@@ -46,6 +50,7 @@ class RegisterHookRequest(BaseModel):
 
 class HookRegistrationResponse(BaseModel):
     """Response model for hook registration."""
+
     hook_id: str = Field(..., description="Unique hook ID")
     hook_type: str = Field(..., description="Type of hook")
     priority: int = Field(..., description="Hook priority")
@@ -57,6 +62,7 @@ class HookRegistrationResponse(BaseModel):
 
 class TriggerHookRequest(BaseModel):
     """Request model for triggering hooks."""
+
     hook_type: str = Field(..., description="Type of hooks to trigger")
     data: Dict[str, Any] = Field(..., description="Hook execution data")
     user_context: Optional[Dict[str, Any]] = Field(None, description="User context")
@@ -65,6 +71,7 @@ class TriggerHookRequest(BaseModel):
 
 class HookExecutionResponse(BaseModel):
     """Response model for hook execution."""
+
     hook_type: str = Field(..., description="Type of hooks executed")
     total_hooks: int = Field(..., description="Total hooks triggered")
     successful_hooks: int = Field(..., description="Successfully executed hooks")
@@ -75,6 +82,7 @@ class HookExecutionResponse(BaseModel):
 
 class HookStatsResponse(BaseModel):
     """Response model for hook statistics."""
+
     enabled: bool = Field(..., description="Whether hook manager is enabled")
     total_hooks: int = Field(..., description="Total registered hooks")
     hook_types: int = Field(..., description="Number of hook types")
@@ -84,6 +92,7 @@ class HookStatsResponse(BaseModel):
 
 class HookListResponse(BaseModel):
     """Response model for listing hooks."""
+
     hooks: List[HookRegistrationResponse] = Field(..., description="List of hooks")
     total_count: int = Field(..., description="Total number of hooks")
     hook_types: List[str] = Field(..., description="Available hook types")
@@ -91,23 +100,26 @@ class HookListResponse(BaseModel):
 
 # Hook Management Endpoints
 @router.post("/register", response_model=HookRegistrationResponse)
+@handle_api_errors()
 async def register_hook(
     request: RegisterHookRequest,
     # session: dict = Depends(validate_session)  # Temporarily disabled for web UI integration
 ):
     """
     Register a new hook with the hook system.
-    
+
     This endpoint allows external systems to register hooks that will be
     triggered at specific points in the chat processing pipeline.
     """
     try:
         hook_manager = get_hook_manager()
-        
+
         # Validate hook type
         if not HookTypes.is_valid_type(request.hook_type):
-            logger.warning(f"Registering hook with non-standard type: {request.hook_type}")
-        
+            logger.warning(
+                f"Registering hook with non-standard type: {request.hook_type}"
+            )
+
         # Create a placeholder handler for API-registered hooks
         # In a real implementation, this would be more sophisticated
         async def api_hook_handler(context: HookContext) -> Dict[str, Any]:
@@ -118,9 +130,9 @@ async def register_hook(
                 "source_name": request.source_name,
                 "executed_at": datetime.utcnow().isoformat(),
                 "data_keys": list(context.data.keys()),
-                "message": f"API hook {request.hook_type} executed successfully"
+                "message": f"API hook {request.hook_type} executed successfully",
             }
-        
+
         # Register the hook
         hook_id = await hook_manager.register_hook(
             hook_type=request.hook_type,
@@ -128,16 +140,18 @@ async def register_hook(
             priority=request.priority,
             conditions=request.conditions or {},
             source_type=request.source_type,
-            source_name=request.source_name
+            source_name=request.source_name,
         )
-        
+
         # Get the registered hook for response
         hook_registration = hook_manager.get_hook_by_id(hook_id)
         if not hook_registration:
-            raise HTTPException(status_code=500, detail="Failed to retrieve registered hook")
-        
+            raise HTTPException(
+                status_code=500, detail="Failed to retrieve registered hook"
+            )
+
         logger.info(f"Hook registered via API: {hook_id} ({request.hook_type})")
-        
+
         return HookRegistrationResponse(
             hook_id=hook_id,
             hook_type=hook_registration.hook_type,
@@ -145,15 +159,18 @@ async def register_hook(
             source_type=hook_registration.source_type,
             source_name=hook_registration.source_name,
             enabled=hook_registration.enabled,
-            registered_at=datetime.utcnow().isoformat()
+            registered_at=datetime.utcnow().isoformat(),
         )
-        
+
     except Exception as e:
         logger.error(f"Failed to register hook: {e}")
-        raise HTTPException(status_code=500, detail=f"Failed to register hook: {str(e)}")
+        raise HTTPException(
+            status_code=500, detail=f"Failed to register hook: {str(e)}"
+        )
 
 
 @router.delete("/unregister/{hook_id}")
+@handle_api_errors()
 async def unregister_hook(
     hook_id: str = Path(..., description="Hook ID to unregister"),
     # session: dict = Depends(validate_session)  # Temporarily disabled for web UI integration
@@ -163,70 +180,79 @@ async def unregister_hook(
     """
     try:
         hook_manager = get_hook_manager()
-        
+
         # Check if hook exists
         hook_registration = hook_manager.get_hook_by_id(hook_id)
         if not hook_registration:
             raise HTTPException(status_code=404, detail=f"Hook {hook_id} not found")
-        
+
         # Unregister the hook
         success = await hook_manager.unregister_hook(hook_id)
-        
+
         if not success:
-            raise HTTPException(status_code=500, detail=f"Failed to unregister hook {hook_id}")
-        
+            raise HTTPException(
+                status_code=500, detail=f"Failed to unregister hook {hook_id}"
+            )
+
         logger.info(f"Hook unregistered via API: {hook_id}")
-        
+
         return {
             "success": True,
             "message": f"Hook {hook_id} unregistered successfully",
-            "hook_id": hook_id
+            "hook_id": hook_id,
         }
-        
+
     except HTTPException:
         raise
     except Exception as e:
         logger.error(f"Failed to unregister hook {hook_id}: {e}")
-        raise HTTPException(status_code=500, detail=f"Failed to unregister hook: {str(e)}")
+        raise HTTPException(
+            status_code=500, detail=f"Failed to unregister hook: {str(e)}"
+        )
 
 
 @router.post("/trigger", response_model=HookExecutionResponse)
+@handle_api_errors()
 async def trigger_hooks(
     request: TriggerHookRequest,
     # session: dict = Depends(validate_session)  # Temporarily disabled for web UI integration
 ):
     """
     Manually trigger hooks of a specific type.
-    
+
     This endpoint allows testing and manual execution of hooks.
     """
     try:
         hook_manager = get_hook_manager()
-        
+
         # Create hook context
         context = HookContext(
             hook_type=request.hook_type,
             data=request.data,
-            user_context=request.user_context or {}
+            user_context=request.user_context or {},
         )
-        
+
         # Trigger hooks
         summary = await hook_manager.trigger_hooks(context, request.timeout_seconds)
-        
-        logger.info(f"Hooks triggered via API: {request.hook_type} - {summary.successful_hooks}/{summary.total_hooks} successful")
-        
+
+        logger.info(
+            f"Hooks triggered via API: {request.hook_type} - {summary.successful_hooks}/{summary.total_hooks} successful"
+        )
+
         return HookExecutionResponse(
             hook_type=summary.hook_type,
             total_hooks=summary.total_hooks,
             successful_hooks=summary.successful_hooks,
             failed_hooks=summary.failed_hooks,
             total_execution_time_ms=summary.total_execution_time_ms,
-            results=[result.__dict__ for result in summary.results]
+            results=[result.__dict__ for result in summary.results],
         )
-        
+
     except Exception as e:
         logger.error(f"Failed to trigger hooks: {e}")
-        raise HTTPException(status_code=500, detail=f"Failed to trigger hooks: {str(e)}")
+        raise HTTPException(
+            status_code=500, detail=f"Failed to trigger hooks: {str(e)}"
+        )
 
 
 # Hook Information Endpoints
@@ -243,7 +269,7 @@ async def list_hooks(
     """
     try:
         hook_manager = get_hook_manager()
-        
+
         # Get hooks based on filters
         if hook_type:
             hooks = hook_manager.get_hooks_by_type(hook_type)
@@ -251,30 +277,32 @@ async def list_hooks(
             hooks = hook_manager.get_hooks_by_source(source_type, source_name)
         else:
             hooks = hook_manager.get_all_hooks()
-        
+
         # Filter by enabled status if requested
         if enabled_only:
             hooks = [hook for hook in hooks if hook.enabled]
-        
+
         # Convert to response format
         hook_responses = []
         for hook in hooks:
-            hook_responses.append(HookRegistrationResponse(
-                hook_id=hook.id,
-                hook_type=hook.hook_type,
-                priority=hook.priority,
-                source_type=hook.source_type,
-                source_name=hook.source_name,
-                enabled=hook.enabled,
-                registered_at=datetime.utcnow().isoformat()  # Placeholder - would be actual registration time
-            ))
-        
+            hook_responses.append(
+                HookRegistrationResponse(
+                    hook_id=hook.id,
+                    hook_type=hook.hook_type,
+                    priority=hook.priority,
+                    source_type=hook.source_type,
+                    source_name=hook.source_name,
+                    enabled=hook.enabled,
+                    registered_at=datetime.utcnow().isoformat(),  # Placeholder - would be actual registration time
+                )
+            )
+
         return HookListResponse(
             hooks=hook_responses,
             total_count=len(hook_responses),
-            hook_types=hook_manager.get_hook_types()
+            hook_types=hook_manager.get_hook_types(),
         )
-        
+
     except Exception as e:
         logger.error(f"Failed to list hooks: {e}")
         raise HTTPException(status_code=500, detail=f"Failed to list hooks: {str(e)}")
@@ -289,21 +317,23 @@ async def get_hook_types():
         standard_types = HookTypes.get_all_types()
         hook_manager = get_hook_manager()
         registered_types = hook_manager.get_hook_types()
-        
+
         # Combine standard and registered types
         all_types = list(set(standard_types + registered_types))
-        
+
         return {
             "standard_types": standard_types,
             "registered_types": registered_types,
             "all_types": sorted(all_types),
             "lifecycle_hooks": HookTypes.get_lifecycle_hooks(),
-            "error_hooks": HookTypes.get_error_hooks()
+            "error_hooks": HookTypes.get_error_hooks(),
         }
-        
+
     except Exception as e:
         logger.error(f"Failed to get hook types: {e}")
-        raise HTTPException(status_code=500, detail=f"Failed to get hook types: {str(e)}")
+        raise HTTPException(
+            status_code=500, detail=f"Failed to get hook types: {str(e)}"
+        )
 
 
 @router.get("/stats", response_model=HookStatsResponse)
@@ -314,18 +344,20 @@ async def get_hook_stats():
     try:
         hook_manager = get_hook_manager()
         summary = hook_manager.get_summary()
-        
+
         return HookStatsResponse(
             enabled=summary["enabled"],
             total_hooks=summary["total_hooks"],
             hook_types=summary["hook_types"],
             source_types=summary["source_types"],
-            execution_stats=summary["execution_stats"]
+            execution_stats=summary["execution_stats"],
         )
-        
+
     except Exception as e:
         logger.error(f"Failed to get hook stats: {e}")
-        raise HTTPException(status_code=500, detail=f"Failed to get hook stats: {str(e)}")
+        raise HTTPException(
+            status_code=500, detail=f"Failed to get hook stats: {str(e)}"
+        )
 
 
 @router.get("/{hook_id}")
@@ -339,10 +371,10 @@ async def get_hook_details(
     try:
         hook_manager = get_hook_manager()
         hook_registration = hook_manager.get_hook_by_id(hook_id)
-        
+
         if not hook_registration:
             raise HTTPException(status_code=404, detail=f"Hook {hook_id} not found")
-        
+
         return {
             "hook_id": hook_registration.id,
             "hook_type": hook_registration.hook_type,
@@ -353,15 +385,19 @@ async def get_hook_details(
             "enabled": hook_registration.enabled,
             "handler_info": {
                 "is_async": asyncio.iscoroutinefunction(hook_registration.handler),
-                "handler_name": getattr(hook_registration.handler, '__name__', 'unknown')
-            }
+                "handler_name": getattr(
+                    hook_registration.handler, "__name__", "unknown"
+                ),
+            },
         }
-        
+
     except HTTPException:
         raise
     except Exception as e:
         logger.error(f"Failed to get hook details for {hook_id}: {e}")
-        raise HTTPException(status_code=500, detail=f"Failed to get hook details: {str(e)}")
+        raise HTTPException(
+            status_code=500, detail=f"Failed to get hook details: {str(e)}"
+        )
 
 
 # Hook Management Operations
@@ -376,19 +412,19 @@ async def enable_hook(
     try:
         hook_manager = get_hook_manager()
         hook_registration = hook_manager.get_hook_by_id(hook_id)
-        
+
         if not hook_registration:
             raise HTTPException(status_code=404, detail=f"Hook {hook_id} not found")
-        
+
         hook_registration.enabled = True
         logger.info(f"Hook enabled via API: {hook_id}")
-        
+
         return {
             "success": True,
             "message": f"Hook {hook_id} enabled successfully",
-            "hook_id": hook_id
+            "hook_id": hook_id,
         }
-        
+
     except HTTPException:
         raise
     except Exception as e:
@@ -407,19 +443,19 @@ async def disable_hook(
     try:
         hook_manager = get_hook_manager()
         hook_registration = hook_manager.get_hook_by_id(hook_id)
-        
+
         if not hook_registration:
             raise HTTPException(status_code=404, detail=f"Hook {hook_id} not found")
-        
+
         hook_registration.enabled = False
         logger.info(f"Hook disabled via API: {hook_id}")
-        
+
         return {
             "success": True,
             "message": f"Hook {hook_id} disabled successfully",
-            "hook_id": hook_id
+            "hook_id": hook_id,
         }
-        
+
     except HTTPException:
         raise
     except Exception as e:
@@ -430,7 +466,9 @@ async def disable_hook(
 @router.delete("/clear/{source_type}")
 async def clear_hooks_by_source(
     source_type: str = Path(..., description="Source type to clear"),
-    source_name: Optional[str] = Query(None, description="Specific source name to clear"),
+    source_name: Optional[str] = Query(
+        None, description="Specific source name to clear"
+    ),
     # session: dict = Depends(validate_session)  # Temporarily disabled for web UI integration
 ):
     """
@@ -438,18 +476,22 @@ async def clear_hooks_by_source(
     """
     try:
         hook_manager = get_hook_manager()
-        cleared_count = await hook_manager.clear_hooks_by_source(source_type, source_name)
-        
-        logger.info(f"Cleared {cleared_count} hooks from source {source_type}/{source_name}")
-        
+        cleared_count = await hook_manager.clear_hooks_by_source(
+            source_type, source_name
+        )
+
+        logger.info(
+            f"Cleared {cleared_count} hooks from source {source_type}/{source_name}"
+        )
+
         return {
             "success": True,
             "message": f"Cleared {cleared_count} hooks from source {source_type}",
             "cleared_count": cleared_count,
             "source_type": source_type,
-            "source_name": source_name
+            "source_name": source_name,
         }
-        
+
     except Exception as e:
         logger.error(f"Failed to clear hooks from source {source_type}: {e}")
         raise HTTPException(status_code=500, detail=f"Failed to clear hooks: {str(e)}")
@@ -466,18 +508,20 @@ async def enable_hook_system(
     try:
         hook_manager = get_hook_manager()
         hook_manager.enable()
-        
+
         logger.info("Hook system enabled via API")
-        
+
         return {
             "success": True,
             "message": "Hook system enabled successfully",
-            "enabled": True
+            "enabled": True,
         }
-        
+
     except Exception as e:
         logger.error(f"Failed to enable hook system: {e}")
-        raise HTTPException(status_code=500, detail=f"Failed to enable hook system: {str(e)}")
+        raise HTTPException(
+            status_code=500, detail=f"Failed to enable hook system: {str(e)}"
+        )
 
 
 @router.post("/system/disable")
@@ -490,18 +534,20 @@ async def disable_hook_system(
     try:
         hook_manager = get_hook_manager()
         hook_manager.disable()
-        
+
         logger.info("Hook system disabled via API")
-        
+
         return {
             "success": True,
             "message": "Hook system disabled successfully",
-            "enabled": False
+            "enabled": False,
         }
-        
+
     except Exception as e:
         logger.error(f"Failed to disable hook system: {e}")
-        raise HTTPException(status_code=500, detail=f"Failed to disable hook system: {str(e)}")
+        raise HTTPException(
+            status_code=500, detail=f"Failed to disable hook system: {str(e)}"
+        )
 
 
 @router.delete("/system/clear-stats")
@@ -514,17 +560,19 @@ async def clear_execution_stats(
     try:
         hook_manager = get_hook_manager()
         hook_manager.clear_execution_stats()
-        
+
         logger.info("Hook execution statistics cleared via API")
-        
+
         return {
             "success": True,
-            "message": "Hook execution statistics cleared successfully"
+            "message": "Hook execution statistics cleared successfully",
         }
-        
+
     except Exception as e:
         logger.error(f"Failed to clear execution stats: {e}")
-        raise HTTPException(status_code=500, detail=f"Failed to clear execution stats: {str(e)}")
+        raise HTTPException(
+            status_code=500, detail=f"Failed to clear execution stats: {str(e)}"
+        )
 
 
 # Health check endpoint
@@ -536,23 +584,23 @@ async def hook_system_health():
     try:
         hook_manager = get_hook_manager()
         summary = hook_manager.get_summary()
-        
+
         return {
             "status": "healthy" if summary["enabled"] else "disabled",
             "hook_manager": {
                 "enabled": summary["enabled"],
                 "total_hooks": summary["total_hooks"],
                 "hook_types": summary["hook_types"],
-                "source_types": summary["source_types"]
+                "source_types": summary["source_types"],
             },
             "execution_stats": summary["execution_stats"],
-            "timestamp": datetime.utcnow().isoformat()
+            "timestamp": datetime.utcnow().isoformat(),
         }
-        
+
     except Exception as e:
         logger.error(f"Hook system health check failed: {e}")
         return {
             "status": "error",
             "error": str(e),
-            "timestamp": datetime.utcnow().isoformat()
+            "timestamp": datetime.utcnow().isoformat(),
         }

--- a/src/ai_karen_engine/core/error_handler.py
+++ b/src/ai_karen_engine/core/error_handler.py
@@ -1,8 +1,22 @@
+"""Utilities for standardized API error handling."""
+
+import logging
+from functools import wraps
+from typing import Any, Awaitable, Callable, TypeVar, cast
+
+from fastapi import HTTPException
 from fastapi.responses import JSONResponse
+
 from ai_karen_engine.core.errors.handlers import get_error_handler
 
+logger = logging.getLogger(__name__)
 
-def handle_api_exception(error: Exception, user_message: str | None = None) -> JSONResponse:
+F = TypeVar("F", bound=Callable[..., Awaitable[Any]])
+
+
+def handle_api_exception(
+    error: Exception, user_message: str | None = None
+) -> JSONResponse:
     """Convert exceptions to standardized JSON responses for API routes.
 
     Args:
@@ -18,3 +32,31 @@ def handle_api_exception(error: Exception, user_message: str | None = None) -> J
         error_response.message = user_message
     status_code = handler.get_http_status_code(error_response.error_code)
     return JSONResponse(status_code=status_code, content=error_response.dict())
+
+
+def handle_api_errors(user_message: str | None = None) -> Callable[[F], F]:
+    """Decorator to standardize API error handling for route functions.
+
+    Args:
+        user_message: Optional message to override the default error message
+            when an exception is raised.
+    """
+
+    def decorator(func: F) -> F:
+        @wraps(func)
+        async def wrapper(*args: Any, **kwargs: Any) -> Any:
+            try:
+                return await func(*args, **kwargs)
+            except HTTPException:
+                # Let FastAPI handle HTTPExceptions as-is
+                raise
+            except Exception as error:  # noqa: BLE001
+                logger.exception("Unhandled API error")
+                return handle_api_exception(error, user_message)
+
+        return cast(F, wrapper)
+
+    return decorator
+
+
+__all__ = ["handle_api_exception", "handle_api_errors"]


### PR DESCRIPTION
## Summary
- add `handle_api_errors` decorator to standardize API error handling
- apply error wrapper in auth, database, and hook routes

## Testing
- `pre-commit run --files src/ai_karen_engine/core/error_handler.py src/ai_karen_engine/api_routes/auth.py src/ai_karen_engine/api_routes/database.py src/ai_karen_engine/api_routes/hook_routes.py` *(fails: missing libraries in mypy)*
- `pytest tests/test_error_responses.py tests/test_hook_api_routes.py -q` *(fails: ImportError: cannot import name '__version__' from pydantic_stub)*

------
https://chatgpt.com/codex/tasks/task_e_68927a9b3d5c8324b44d013d97c33ddc