### PR TITLE
Add CoreAuthenticator with database-backed auth and tests

### DIFF
--- a/src/ai_karen_engine/fastapi_stub/__init__.py
+++ b/src/ai_karen_engine/fastapi_stub/__init__.py
@@ -1,3 +1,6 @@
+"""Lightweight FastAPI stub used for testing."""
+# mypy: ignore-errors
+
 import asyncio
 import json
 import re
@@ -28,6 +31,7 @@ class _Route:
             regex = re.sub(r"{(\w+)}", r"(?P<\1>[^/]+)", path)
             self.pattern = re.compile(f"^{regex}$")
 
+
 class FastAPI:
     def __init__(self, *_, **__):
         self.routes = []
@@ -42,6 +46,7 @@ class FastAPI:
         def decorator(func):
             self._middlewares.append(func)
             return func
+
         return decorator
 
     async def _handle_request(self, method, path, json=None, headers=None):
@@ -119,35 +124,49 @@ class FastAPI:
         resp = Response(data)
         content = json.dumps(resp.json()).encode()
         headers = [(b"content-type", b"application/json")]
-        await send({"type": "http.response.start", "status": resp.status_code, "headers": headers})
+        await send(
+            {
+                "type": "http.response.start",
+                "status": resp.status_code,
+                "headers": headers,
+            }
+        )
         await send({"type": "http.response.body", "body": content})
 
     def get(self, path, **_kw):
         tags = _kw.get("tags")
+
         def decorator(func):
             self.routes.append(_Route("GET", path, func, tags=tags))
             return func
+
         return decorator
 
     def post(self, path, **_kw):
         tags = _kw.get("tags")
+
         def decorator(func):
             self.routes.append(_Route("POST", path, func, tags=tags))
             return func
+
         return decorator
 
     def put(self, path, **_kw):
         tags = _kw.get("tags")
+
         def decorator(func):
             self.routes.append(_Route("PUT", path, func, tags=tags))
             return func
+
         return decorator
 
     def delete(self, path, **_kw):
         tags = _kw.get("tags")
+
         def decorator(func):
             self.routes.append(_Route("DELETE", path, func, tags=tags))
             return func
+
         return decorator
 
     def on_event(self, event: str):
@@ -155,11 +174,13 @@ class FastAPI:
             if event == "startup":
                 self._startup.append(func)
             return func
+
         return decorator
 
     def exception_handler(self, exc):
         def decorator(func):
             return func
+
         return decorator
 
     def include_router(self, router, prefix: str = ""):
@@ -182,31 +203,40 @@ class APIRouter(FastAPI):
 
     def get(self, path, **_kw):
         tags = _kw.get("tags") or self.tags
+
         def decorator(func):
             self.routes.append(_Route("GET", path, func, tags=tags))
             return func
+
         return decorator
 
     def post(self, path, **_kw):
         tags = _kw.get("tags") or self.tags
+
         def decorator(func):
             self.routes.append(_Route("POST", path, func, tags=tags))
             return func
+
         return decorator
 
     def put(self, path, **_kw):
         tags = _kw.get("tags") or self.tags
+
         def decorator(func):
             self.routes.append(_Route("PUT", path, func, tags=tags))
             return func
+
         return decorator
 
     def delete(self, path, **_kw):
         tags = _kw.get("tags") or self.tags
+
         def decorator(func):
             self.routes.append(_Route("DELETE", path, func, tags=tags))
             return func
+
         return decorator
+
 
 class Response:
     def __init__(self, content=None, status_code=200, media_type=None, headers=None):
@@ -259,9 +289,13 @@ def Depends(func):
     return func
 
 
+def Query(default=None, **_kw):
+    """Simplified Query parameter stub."""
+    return default
+
+
 class status:
     HTTP_401_UNAUTHORIZED = 401
-
 
 
 class Request:
@@ -269,6 +303,7 @@ class Request:
         self.client = SimpleNamespace(host=client_host)
         self.headers = {}
         self.cookies = {}
+
 
 class TestClient:
     def __init__(self, app):
@@ -285,7 +320,9 @@ class TestClient:
         resp = Response(
             getattr(data, "_data", data),
             status,
-            media_type=data.headers.get("content-type") if hasattr(data, "headers") else None,
+            media_type=data.headers.get("content-type")
+            if hasattr(data, "headers")
+            else None,
         )
         resp.headers.update(getattr(data, "headers", {}))
         return resp
@@ -296,7 +333,9 @@ class TestClient:
         resp = Response(
             getattr(data, "_data", data),
             status,
-            media_type=data.headers.get("content-type") if hasattr(data, "headers") else None,
+            media_type=data.headers.get("content-type")
+            if hasattr(data, "headers")
+            else None,
         )
         resp.headers.update(getattr(data, "headers", {}))
         return resp

--- a/src/ai_karen_engine/pydantic_stub/__init__.py
+++ b/src/ai_karen_engine/pydantic_stub/__init__.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 # mypy: ignore-errors
 from typing import Any, Optional
 
+__version__ = "1.10"
+
 
 class ValidationError(Exception):
     """Pydantic validation error stub."""

--- a/src/ai_karen_engine/security/__init__.py
+++ b/src/ai_karen_engine/security/__init__.py
@@ -1,6 +1,4 @@
 """Security utilities and canonical authentication service."""
 # mypy: ignore-errors
 
-from ai_karen_engine.security.auth_service import AuthService
-
-__all__ = ["AuthService"]
+__all__: list[str] = []

--- a/tests/security/test_core_authenticator.py
+++ b/tests/security/test_core_authenticator.py
@@ -1,0 +1,57 @@
+# mypy: ignore-errors
+
+import importlib
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from ai_karen_engine.database.models.auth_models import Base
+
+
+@pytest.fixture()
+def auth(tmp_path):
+    db_path = tmp_path / "auth.db"
+    engine = create_engine(f"sqlite:///{db_path}")
+    Base.metadata.create_all(bind=engine)
+    SessionLocal = sessionmaker(bind=engine)
+
+    def get_session_override():
+        return SessionLocal()
+
+    import ai_karen_engine.database.client as db_client_module
+
+    db_client_module.get_db_session = get_session_override
+
+    import ai_karen_engine.security.auth_service as auth_module
+
+    importlib.reload(auth_module)
+    authenticator = auth_module.CoreAuthenticator()
+    yield authenticator
+
+
+@pytest.mark.asyncio
+async def test_password_utilities(auth):
+    hashed = auth.hash_password("secret")
+    assert hashed != "secret"
+    assert auth.verify_password("secret", hashed)
+    assert not auth.verify_password("wrong", hashed)
+
+
+@pytest.mark.asyncio
+async def test_authentication(auth):
+    await auth.create_user("user@example.com", "password")
+    user = await auth.authenticate_user("user@example.com", "password")
+    assert user is not None
+    assert user.email == "user@example.com"
+    assert await auth.authenticate_user("user@example.com", "wrong") is None
+
+
+@pytest.mark.asyncio
+async def test_session_creation_and_validation(auth):
+    user = await auth.create_user("session@example.com", "password")
+    session = await auth.create_session(user.user_id)
+    assert session.session_token
+    validated = await auth.validate_session(session.session_token)
+    assert validated is not None
+    assert validated.email == "session@example.com"


### PR DESCRIPTION
## Summary
- implement CoreAuthenticator using bcrypt and database-backed sessions
- cover password hashing, authentication and session validation with tests
- extend pydantic and FastAPI stubs for test compatibility

## Testing
- `pre-commit run --files src/ai_karen_engine/security/auth_service.py src/ai_karen_engine/security/__init__.py src/ai_karen_engine/pydantic_stub/__init__.py src/ai_karen_engine/fastapi_stub/__init__.py tests/security/test_core_authenticator.py`
- `pytest tests/security/test_core_authenticator.py`


------
https://chatgpt.com/codex/tasks/task_e_68934f940ae483249754f2fc4093503a