### PR TITLE
Add security enhancer with rate limiting and audit logging

### DIFF
--- a/src/ai_karen_engine/security/__init__.py
+++ b/src/ai_karen_engine/security/__init__.py
@@ -1,4 +1,7 @@
 """Security utilities and canonical authentication service."""
 # mypy: ignore-errors
 
-__all__: list[str] = []
+from .security_enhancer import AuditLogger, RateLimiter, SecurityEnhancer
+
+__all__ = ["AuditLogger", "RateLimiter", "SecurityEnhancer"]
+

--- a/src/ai_karen_engine/security/config.py
+++ b/src/ai_karen_engine/security/config.py
@@ -31,6 +31,8 @@ class FeatureToggles:
     use_database: bool = False
     enable_intelligent_checks: bool = False
     enable_refresh_tokens: bool = True
+    enable_rate_limiter: bool = False
+    enable_audit_logging: bool = False
 
 
 @dataclass

--- a/src/ai_karen_engine/security/security_enhancer.py
+++ b/src/ai_karen_engine/security/security_enhancer.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+"""Security enhancement utilities for authentication services.
+
+This module defines three lightweight components used to harden the
+``AuthService`` implementation:
+
+``RateLimiter``
+    Throttles authentication attempts using an in-memory fixed window.
+``AuditLogger``
+    Records authentication events and optionally forwards metrics to a
+    user supplied hook.
+``SecurityEnhancer``
+    Convenience wrapper bundling the two components and providing helper
+    methods for the authentication service.
+"""
+
+import time
+from collections import defaultdict, deque
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Callable, Deque, Dict, List, Optional
+
+from ai_karen_engine.core.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+class RateLimiter:
+    """Simple in-memory rate limiter.
+
+    Parameters
+    ----------
+    max_calls:
+        Maximum number of allowed calls within ``period`` seconds.
+    period:
+        Time window in seconds for rate limiting.
+    """
+
+    def __init__(self, max_calls: int, period: float) -> None:
+        self.max_calls = max_calls
+        self.period = period
+        self._calls: Dict[str, Deque[float]] = defaultdict(deque)
+
+    def allow(self, key: str) -> bool:
+        """Return ``True`` if another call for ``key`` is allowed."""
+
+        now = time.monotonic()
+        calls = self._calls[key]
+        # Drop timestamps outside the current window
+        while calls and now - calls[0] > self.period:
+            calls.popleft()
+        if len(calls) >= self.max_calls:
+            return False
+        calls.append(now)
+        return True
+
+
+@dataclass
+class AuditEvent:
+    event: str
+    data: Dict[str, object]
+    timestamp: datetime
+
+
+class AuditLogger:
+    """Capture authentication events and forward metrics."""
+
+    def __init__(
+        self,
+        metrics_hook: Optional[Callable[[str, Dict[str, object]], None]] = None,
+    ) -> None:
+        self.metrics_hook = metrics_hook
+        self.events: List[AuditEvent] = []
+
+    def log_event(self, event: str, data: Optional[Dict[str, object]] = None) -> None:
+        record = AuditEvent(event=event, data=data or {}, timestamp=datetime.utcnow())
+        self.events.append(record)
+        logger.info(f"AUTH EVENT {event} {record.data}")
+        if self.metrics_hook:
+            self.metrics_hook(event, record.data)
+
+
+class SecurityEnhancer:
+    """Bundle rate limiting and audit logging helpers."""
+
+    def __init__(
+        self,
+        rate_limiter: Optional[RateLimiter] = None,
+        audit_logger: Optional[AuditLogger] = None,
+    ) -> None:
+        self.rate_limiter = rate_limiter
+        self.audit_logger = audit_logger
+
+    def allow_auth_attempt(self, key: str) -> bool:
+        """Check rate limit for ``key`` and log if blocked."""
+
+        if not self.rate_limiter:
+            return True
+        allowed = self.rate_limiter.allow(key)
+        if not allowed and self.audit_logger:
+            self.audit_logger.log_event("rate_limit_exceeded", {"key": key})
+        return allowed
+
+    def log_event(self, event: str, data: Optional[Dict[str, object]] = None) -> None:
+        if self.audit_logger:
+            self.audit_logger.log_event(event, data)

--- a/tests/security/test_security_enhancer.py
+++ b/tests/security/test_security_enhancer.py
@@ -1,0 +1,53 @@
+import pytest
+
+from ai_karen_engine.security.auth_service import AuthService
+from ai_karen_engine.security.config import AuthConfig
+from ai_karen_engine.security.security_enhancer import RateLimiter
+
+
+@pytest.mark.asyncio
+async def test_logging_with_metrics_hook():
+    metrics: list[tuple[str, dict]] = []
+    config = AuthConfig()
+    config.features.enable_audit_logging = True
+    service = AuthService(config=config, metrics_hook=lambda e, d: metrics.append((e, d)))
+
+    assert service.security_enhancer is not None
+    logger = service.security_enhancer.audit_logger
+
+    await service.create_user("user@example.com", "password")
+    user = await service.authenticate_user("user@example.com", "password")
+    assert user is not None
+    assert await service.authenticate_user("user@example.com", "wrong") is None
+
+    events = [e.event for e in logger.events]
+    assert "login_success" in events
+    assert "login_failure" in events
+    logged = [name for name, _ in metrics]
+    assert "login_success" in logged and "login_failure" in logged
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_blocks_excessive_attempts():
+    metrics: list[tuple[str, dict]] = []
+    config = AuthConfig()
+    config.features.enable_audit_logging = True
+    config.features.enable_rate_limiter = True
+    service = AuthService(config=config, metrics_hook=lambda e, d: metrics.append((e, d)))
+
+    # make rate limiter very small for the test
+    assert service.security_enhancer is not None
+    service.security_enhancer.rate_limiter = RateLimiter(2, 60)
+    logger = service.security_enhancer.audit_logger
+
+    await service.create_user("rate@example.com", "password")
+    assert await service.authenticate_user("rate@example.com", "wrong") is None
+    assert await service.authenticate_user("rate@example.com", "wrong") is None
+    # third attempt should be blocked by rate limiter
+    assert await service.authenticate_user("rate@example.com", "wrong") is None
+
+    events = [e.event for e in logger.events]
+    assert events.count("login_failure") >= 2
+    assert "rate_limit_exceeded" in events
+    logged = [name for name, _ in metrics]
+    assert "rate_limit_exceeded" in logged


### PR DESCRIPTION
## Summary
- introduce RateLimiter, AuditLogger, and SecurityEnhancer utilities
- connect security enhancer to AuthService via feature flags and metrics hook
- test rate limiting and audit logging behavior

## Testing
- `pytest tests/security/test_security_enhancer.py -q`

------
https://chatgpt.com/codex/tasks/task_e_689356521bf48324b6dbf29d95220f1b