### PR TITLE
Refactor auth service to shared models and config

### DIFF
--- a/src/ai_karen_engine/security/auth_service.py
+++ b/src/ai_karen_engine/security/auth_service.py
@@ -23,14 +23,16 @@ from __future__ import annotations
 
 import hashlib
 import time
-from dataclasses import dataclass
+from datetime import datetime
 from typing import Any, Dict, Optional
 
 from ai_karen_engine.core.logging import get_logger
+from ai_karen_engine.security.config import AuthConfig
 from ai_karen_engine.security.intelligent_auth_service import (
     AuthContext,
     IntelligentAuthService,
 )
+from ai_karen_engine.security.models import SessionData, UserData
 from ai_karen_engine.security.production_auth_service import ProductionAuthService
 from ai_karen_engine.services.auth_service import AuthService as BasicAuthService
 
@@ -40,14 +42,6 @@ from ai_karen_engine.services.auth_service import AuthService as BasicAuthServic
 logger = get_logger(__name__)
 
 
-@dataclass
-class AuthConfig:
-    """Configuration switches for :class:`AuthService`."""
-
-    use_database: bool = False
-    enable_intelligent_checks: bool = False
-
-
 class AuthService:
     """High level authentication façade with optional advanced features."""
 
@@ -55,10 +49,12 @@ class AuthService:
         self.config = config or AuthConfig()
         self.basic_service = BasicAuthService()
         self.production_service: Optional[ProductionAuthService] = (
-            ProductionAuthService() if self.config.use_database else None
+            ProductionAuthService() if self.config.features.use_database else None
         )
         self.intelligent_service: Optional[IntelligentAuthService] = (
-            IntelligentAuthService() if self.config.enable_intelligent_checks else None
+            IntelligentAuthService()
+            if self.config.features.enable_intelligent_checks
+            else None
         )
 
     async def create_user(
@@ -69,11 +65,11 @@ class AuthService:
         roles: Optional[list[str]] = None,
         tenant_id: str = "default",
         preferences: Optional[Dict[str, Any]] = None,
-    ) -> Any:
+    ) -> UserData:
         """Create a new user using the configured backend."""
 
         if self.production_service:
-            return await self.production_service.create_user(
+            user = await self.production_service.create_user(
                 email=email,
                 password=password,
                 full_name=full_name,
@@ -81,8 +77,9 @@ class AuthService:
                 tenant_id=tenant_id,
                 preferences=preferences,
             )
+            return self._to_user_data(user)
 
-        return await self.basic_service.create_user(
+        user = await self.basic_service.create_user(
             email=email,
             password=password,
             full_name=full_name,
@@ -90,6 +87,7 @@ class AuthService:
             tenant_id=tenant_id,
             preferences=preferences,
         )
+        return self._to_user_data(user)
 
     async def authenticate_user(
         self,
@@ -97,7 +95,7 @@ class AuthService:
         password: str,
         ip_address: str = "unknown",
         user_agent: str = "",
-    ) -> Optional[Dict[str, Any]]:
+    ) -> Optional[UserData]:
         """Authenticate a user and optionally run intelligent checks."""
 
         if self.production_service:
@@ -118,12 +116,15 @@ class AuthService:
         if not user:
             return None
 
+        user_data = self._to_user_data(user)
+
         if self.intelligent_service:
             context = AuthContext(
                 email=email,
                 password_hash=hashlib.sha256(password.encode()).hexdigest(),
-                ip_address=ip_address,
+                client_ip=ip_address,
                 user_agent=user_agent,
+                timestamp=datetime.utcnow(),
                 request_id=f"{email}:{int(time.time()*1000)}",
             )
             analysis = await self.intelligent_service.analyze_login_attempt(context)
@@ -131,7 +132,7 @@ class AuthService:
                 logger.warning("Login attempt blocked by intelligent auth service")
                 return None
 
-        return user
+        return user_data
 
     async def create_session(
         self,
@@ -139,44 +140,51 @@ class AuthService:
         ip_address: str = "unknown",
         user_agent: str = "",
         device_fingerprint: Optional[str] = None,
-    ) -> Dict[str, Any]:
+    ) -> SessionData:
         """Create a session using the configured backend."""
 
         if self.production_service:
-            return await self.production_service.create_session(
+            session = await self.production_service.create_session(
+                user_id=user_id,
+                ip_address=ip_address,
+                user_agent=user_agent,
+                device_fingerprint=device_fingerprint,
+            )
+        else:
+            session = await self.basic_service.create_session(
                 user_id=user_id,
                 ip_address=ip_address,
                 user_agent=user_agent,
                 device_fingerprint=device_fingerprint,
             )
 
-        return await self.basic_service.create_session(
-            user_id=user_id,
-            ip_address=ip_address,
-            user_agent=user_agent,
-            device_fingerprint=device_fingerprint,
-        )
+        return self._to_session_data(session)
 
     async def validate_session(
         self,
         session_token: str,
         ip_address: str = "unknown",
         user_agent: str = "",
-    ) -> Optional[Dict[str, Any]]:
+    ) -> Optional[UserData]:
         """Validate a session token and return associated user data."""
 
         if self.production_service:
-            return await self.production_service.validate_session(
+            user = await self.production_service.validate_session(
+                session_token=session_token,
+                ip_address=ip_address,
+                user_agent=user_agent,
+            )
+        else:
+            user = await self.basic_service.validate_session(
                 session_token=session_token,
                 ip_address=ip_address,
                 user_agent=user_agent,
             )
 
-        return await self.basic_service.validate_session(
-            session_token=session_token,
-            ip_address=ip_address,
-            user_agent=user_agent,
-        )
+        if not user:
+            return None
+
+        return self._to_user_data(user)
 
     async def invalidate_session(self, session_token: str) -> bool:
         """Invalidate a session token if supported by the backend."""
@@ -185,6 +193,57 @@ class AuthService:
             return await self.production_service.invalidate_session(session_token)
 
         return await self.basic_service.invalidate_session(session_token)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+
+    def _to_user_data(self, data: Any) -> UserData:
+        """Convert various user representations into :class:`UserData`."""
+
+        if isinstance(data, UserData):
+            return data
+
+        if isinstance(data, dict):
+            return UserData(
+                user_id=str(data.get("user_id") or data.get("id", "")),
+                email=data.get("email", ""),
+                full_name=data.get("full_name"),
+                roles=list(data.get("roles", [])),
+                tenant_id=data.get("tenant_id", "default"),
+                preferences=data.get("preferences", {}),
+                two_factor_enabled=data.get("two_factor_enabled", False),
+                is_verified=data.get("is_verified", True),
+            )
+
+        return UserData(
+            user_id=str(getattr(data, "id", getattr(data, "user_id", ""))),
+            email=getattr(data, "email", ""),
+            full_name=getattr(data, "full_name", None),
+            roles=list(getattr(data, "roles", []) or []),
+            tenant_id=getattr(data, "tenant_id", "default"),
+            preferences=getattr(data, "preferences", {}),
+            two_factor_enabled=getattr(data, "two_factor_enabled", False),
+            is_verified=getattr(data, "is_verified", True),
+        )
+
+    def _to_session_data(
+        self, data: Any, user_data: Optional[UserData] = None
+    ) -> SessionData:
+        """Convert raw session data into :class:`SessionData`."""
+
+        if isinstance(data, SessionData):
+            return data
+
+        if isinstance(data, dict):
+            return SessionData(
+                access_token=data.get("access_token", ""),
+                refresh_token=data.get("refresh_token", ""),
+                session_token=data.get("session_token", ""),
+                expires_in=data.get("expires_in", 0),
+                user_data=user_data,
+            )
+
+        return SessionData("", "", "", 0, user_data)
 
 
 __all__ = ["AuthService", "AuthConfig"]

--- a/src/ai_karen_engine/security/config.py
+++ b/src/ai_karen_engine/security/config.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+"""Configuration models for authentication services."""
+
+from dataclasses import dataclass, field
+from datetime import timedelta
+
+
+@dataclass
+class JWTConfig:
+    """JWT related settings."""
+
+    secret_key: str = "change-me"
+    algorithm: str = "HS256"
+    access_token_expiry: timedelta = timedelta(minutes=15)
+    refresh_token_expiry: timedelta = timedelta(days=7)
+
+
+@dataclass
+class SessionConfig:
+    """Session management settings."""
+
+    session_timeout: timedelta = timedelta(hours=1)
+    cookie_name: str = "session"
+
+
+@dataclass
+class FeatureToggles:
+    """Feature switches for authentication behaviour."""
+
+    use_database: bool = False
+    enable_intelligent_checks: bool = False
+    enable_refresh_tokens: bool = True
+
+
+@dataclass
+class AuthConfig:
+    """Top level authentication configuration grouping settings."""
+
+    jwt: JWTConfig = field(default_factory=JWTConfig)
+    session: SessionConfig = field(default_factory=SessionConfig)
+    features: FeatureToggles = field(default_factory=FeatureToggles)
+

--- a/src/ai_karen_engine/security/exceptions.py
+++ b/src/ai_karen_engine/security/exceptions.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+"""Custom exceptions for authentication and security modules."""
+
+
+class AuthError(Exception):
+    """Base class for authentication related errors."""
+
+
+class AuthenticationError(AuthError):
+    """Raised when authentication fails."""
+
+
+class AuthorizationError(AuthError):
+    """Raised when a user is not permitted to perform an action."""
+
+
+class SessionError(AuthError):
+    """Raised for problems related to session management."""
+
+
+class TokenError(AuthError):
+    """Raised for JWT and token related issues."""
+

--- a/src/ai_karen_engine/security/models.py
+++ b/src/ai_karen_engine/security/models.py
@@ -11,8 +11,43 @@ import json
 from dataclasses import dataclass, field, asdict
 from datetime import datetime, timedelta
 from enum import Enum
-from typing import Dict, List, Optional, Any, Union
+from typing import Any, Dict, List, Optional, Union
 from pathlib import Path
+
+
+@dataclass
+class UserData:
+    """Basic user profile returned by authentication flows."""
+
+    user_id: str
+    email: str
+    full_name: Optional[str] = None
+    roles: List[str] = field(default_factory=list)
+    tenant_id: str = "default"
+    preferences: Dict[str, Any] = field(default_factory=dict)
+    two_factor_enabled: bool = False
+    is_verified: bool = True
+
+
+@dataclass
+class SessionData:
+    """Session token bundle issued after authentication."""
+
+    access_token: str
+    refresh_token: str
+    session_token: str
+    expires_in: int
+    user_data: Optional[UserData] = None
+
+
+@dataclass
+class AuthEvent:
+    """Represents an authentication related event."""
+
+    event_type: str
+    user: UserData
+    timestamp: datetime = field(default_factory=datetime.utcnow)
+    metadata: Dict[str, Any] = field(default_factory=dict)
 
 
 class RiskLevel(Enum):


### PR DESCRIPTION
## Summary
- centralize user/session/event dataclasses in `security.models`
- add `AuthConfig` with JWT, session, and feature flags
- use shared models/config in unified `AuthService`
- extract auth-specific error hierarchy
- update base auth service to return shared dataclasses

## Testing
- `pytest tests/test_authentication_flow.py tests/test_production_auth.py -q` *(fails: ImportError: cannot import name '__version__' from 'ai_karen_engine.pydantic_stub')*


------
https://chatgpt.com/codex/tasks/task_e_689349aa8eb483249bf0785b9649337d