### PR TITLE
feat: add pluggable session store

### DIFF
--- a/src/ai_karen_engine/api_routes/auth.py
+++ b/src/ai_karen_engine/api_routes/auth.py
@@ -137,7 +137,7 @@ async def register(
 
         # Create session
         session_data = await auth_service.create_session(
-            user_data=user,
+            user_id=user.user_id,
             ip_address=request_meta["ip_address"],
             user_agent=request_meta["user_agent"],
         )
@@ -211,7 +211,7 @@ async def login(
 
         # Create session
         session_data = await auth_service.create_session(
-            user_data=user_data,
+            user_id=user_data.user_id,
             ip_address=request_meta["ip_address"],
             user_agent=request_meta["user_agent"],
         )
@@ -357,7 +357,7 @@ async def update_credentials(
 
         # Create new session (invalidates old one)
         session_data = await auth_service.create_session(
-            user_data=updated_user_data,
+            user_id=updated_user_data.user_id,
             ip_address=request_meta["ip_address"],
             user_agent=request_meta["user_agent"],
         )

--- a/src/ai_karen_engine/pydantic_stub/__init__.py
+++ b/src/ai_karen_engine/pydantic_stub/__init__.py
@@ -12,6 +12,11 @@ class ValidationError(Exception):
     pass
 
 
+class EmailStr(str):
+    """Simple EmailStr stub for compatibility."""
+    pass
+
+
 def Field(
     default: Any = ...,
     *,

--- a/src/ai_karen_engine/security/config.py
+++ b/src/ai_karen_engine/security/config.py
@@ -58,6 +58,8 @@ class SessionConfig:
 
     session_timeout: timedelta = timedelta(hours=1)
     cookie_name: str = "session"
+    storage_backend: str = "memory"
+    redis_url: Optional[str] = None
 
     @classmethod
     def from_env(cls) -> "SessionConfig":
@@ -73,6 +75,12 @@ class SessionConfig:
         return cls(
             session_timeout=timedelta(seconds=timeout_seconds),
             cookie_name=os.getenv("AUTH_SESSION_COOKIE_NAME", defaults.cookie_name),
+            storage_backend=os.getenv("AUTH_SESSION_BACKEND", defaults.storage_backend),
+            redis_url=os.getenv(
+                "AUTH_SESSION_REDIS_URL",
+                os.getenv("REDIS_URL", defaults.redis_url or ""),
+            )
+            or None,
         )
 
 
@@ -167,6 +175,12 @@ class AuthConfig:
                 )
             ),
             cookie_name=session_data.get("cookie_name", SessionConfig().cookie_name),
+            storage_backend=session_data.get(
+                "storage_backend", SessionConfig().storage_backend
+            ),
+            redis_url=session_data.get(
+                "redis_url", SessionConfig().redis_url
+            ),
         )
 
         feature_cfg = FeatureToggles(


### PR DESCRIPTION
## Summary
- make session backend configurable
- use session store for API and UI session management
- stub `EmailStr` in pydantic shim

## Testing
- `pytest tests/security/test_session_store.py tests/security/test_auth_service.py tests/test_auth_middleware.py tests/test_intelligent_auth_router.py` *(fails: attribute errors in test_intelligent_auth_router)*

------
https://chatgpt.com/codex/tasks/task_e_6893d5e0d88c8324a90c1f7d82f47dec