### PR TITLE
refactor: add auth service factory

### DIFF
--- a/scripts/create_production_db.py
+++ b/scripts/create_production_db.py
@@ -14,10 +14,9 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 from ai_karen_engine.core.logging import get_logger
 from ai_karen_engine.database.client import create_database_tables, db_client
-from ai_karen_engine.security.auth_service import AuthService
-from ai_karen_engine.security.config import AuthConfig, FeatureToggles
+from ai_karen_engine.security.auth_service import get_auth_service
 
-auth_service = AuthService(AuthConfig(features=FeatureToggles(use_database=True)))
+auth_service = get_auth_service()
 
 logger = get_logger(__name__)
 

--- a/src/ai_karen_engine/api_routes/auth.py
+++ b/src/ai_karen_engine/api_routes/auth.py
@@ -15,10 +15,11 @@ from ai_karen_engine.core.dependencies import (
 )
 from ai_karen_engine.core.chat_memory_config import settings
 from ai_karen_engine.core.logging import get_logger
-from ai_karen_engine.security.auth_service import auth_service
+from ai_karen_engine.security.auth_service import get_auth_service
 
 logger = get_logger(__name__)
 router = APIRouter(tags=["auth"])
+auth_service = get_auth_service()
 
 
 # Alias core dependencies for clarity

--- a/src/ai_karen_engine/core/dependencies.py
+++ b/src/ai_karen_engine/core/dependencies.py
@@ -25,7 +25,7 @@ from ai_karen_engine.core.service_registry import (
 )
 from ai_karen_engine.core.config_manager import get_config, AIKarenConfig
 from ai_karen_engine.core.health_monitor import get_health_monitor, HealthMonitor
-from ai_karen_engine.security.auth_service import auth_service
+from ai_karen_engine.security.auth_service import get_auth_service
 
 logger = logging.getLogger(__name__)
 
@@ -50,6 +50,7 @@ async def get_current_user_context(request: Request) -> Dict[str, Any]:
             session_token = auth_header.split(" ")[1]
     if not session_token:
         raise HTTPException(status_code=401, detail="Authentication required")
+    auth_service = get_auth_service()
     user_data = await auth_service.validate_session(
         session_token=session_token,
         ip_address=request.client.host if request.client else "unknown",

--- a/src/ai_karen_engine/services/auth_utils.py
+++ b/src/ai_karen_engine/services/auth_utils.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, Optional
 from fastapi import HTTPException, Request, Response, status
 
 from ai_karen_engine.core.chat_memory_config import settings
-from ai_karen_engine.security.auth_service import auth_service
+from ai_karen_engine.security.auth_service import get_auth_service
 
 # Shared cookie name for authentication sessions
 COOKIE_NAME = "kari_session"
@@ -47,6 +47,7 @@ async def get_current_user(request: Request) -> Dict[str, Any]:
             detail="Missing authentication token",
         )
 
+    auth_service = get_auth_service()
     user_data = await auth_service.validate_session(
         session_token=session_token,
         ip_address=request.client.host if request.client else "unknown",

--- a/src/ai_karen_engine/utils/auth.py
+++ b/src/ai_karen_engine/utils/auth.py
@@ -9,7 +9,7 @@ import asyncio
 
 import jwt
 
-from ai_karen_engine.security.auth_service import auth_service
+from ai_karen_engine.security.auth_service import get_auth_service
 from ai_karen_engine.core.logging import get_logger
 
 logger = get_logger(__name__)
@@ -41,7 +41,7 @@ def create_session(
         # Use auth service to create session
         loop = asyncio.get_event_loop()
         session_data = loop.run_until_complete(
-            auth_service.create_session(
+            get_auth_service().create_session(
                 user_id=user_id,
                 ip_address=ip,
                 user_agent=user_agent,
@@ -77,7 +77,7 @@ def validate_session(token: str, user_agent: str, ip: str) -> Optional[Dict[str,
         # First try to validate using auth service
         loop = asyncio.get_event_loop()
         user_data = loop.run_until_complete(
-            auth_service.validate_session(
+            get_auth_service().validate_session(
                 session_token=token,
                 ip_address=ip,
                 user_agent=user_agent

--- a/tests/security/test_intelligence_engine.py
+++ b/tests/security/test_intelligence_engine.py
@@ -100,7 +100,7 @@ async def test_auth_service_blocks_on_high_risk(monkeypatch: MonkeyPatch) -> Non
     auth = AuthService(config=config)
 
     monkeypatch.setattr(
-        auth.basic_service,
+        auth.core_authenticator,
         "authenticate_user",
         AsyncMock(return_value={"user_id": "1", "email": "user@example.com"}),
     )


### PR DESCRIPTION
## Summary
- add `get_auth_service()` factory and deprecate direct `auth_service` import
- update auth utilities, dependencies, and API routes to use factory
- adjust scripts and tests for new access pattern

## Testing
- `pytest tests/test_totp_login.py tests/security/test_auth_service.py tests/security/test_core_authenticator.py tests/security/test_security_enhancer.py tests/security/test_intelligence_engine.py`

------
https://chatgpt.com/codex/tasks/task_e_6893d69e16388324b543facd72bec811