### PR TITLE
feat: centralize auth configuration

### DIFF
--- a/src/ai_karen_engine/security/auth_manager.py
+++ b/src/ai_karen_engine/security/auth_manager.py
@@ -94,7 +94,9 @@ _USERS: Dict[str, Dict[str, Any]] = load_users()
 # token -> email mapping
 EMAIL_VERIFICATION_TOKENS: Dict[str, str] = {}
 PASSWORD_RESET_TOKENS: Dict[str, Dict[str, Any]] = {}
-PASSWORD_RESET_TOKEN_TTL = 3600  # seconds
+DEFAULT_PASSWORD_RESET_TOKEN_TTL = int(
+    os.getenv("AUTH_PASSWORD_RESET_TOKEN_TTL", "3600")
+)
 
 
 def save_users() -> None:
@@ -170,11 +172,12 @@ def mark_user_verified(email: str) -> None:
         save_users()
 
 
-def create_password_reset_token(email: str) -> str:
+def create_password_reset_token(email: str, ttl: int = DEFAULT_PASSWORD_RESET_TOKEN_TTL) -> str:
+    """Create a password reset token with configurable TTL."""
     token = generate_token()
     PASSWORD_RESET_TOKENS[token] = {
         "email": email,
-        "expires": time.time() + PASSWORD_RESET_TOKEN_TTL,
+        "expires": time.time() + ttl,
     }
     return token
 

--- a/src/ai_karen_engine/security/auth_service.py
+++ b/src/ai_karen_engine/security/auth_service.py
@@ -61,6 +61,9 @@ class InMemoryAuthenticator:
         self.refresh_token_expire_days = int(
             config.jwt.refresh_token_expiry.total_seconds() // 86400
         )
+        self.password_reset_ttl = int(
+            config.jwt.password_reset_token_expiry.total_seconds()
+        )
         self._active_sessions: Dict[str, Dict[str, Any]] = {}
         if hasattr(auth_manager, "_USERS"):
             auth_manager._USERS = {}
@@ -250,7 +253,7 @@ class InMemoryAuthenticator:
     ) -> Optional[str]:
         if email not in auth_manager._USERS:
             return None
-        return auth_manager.create_password_reset_token(email)
+        return auth_manager.create_password_reset_token(email, self.password_reset_ttl)
 
     async def verify_password_reset_token(self, token: str, new_password: str) -> bool:
         email = auth_manager.verify_password_reset_token(token)
@@ -266,6 +269,9 @@ class DatabaseAuthenticator:
     def __init__(self, config: AuthConfig) -> None:
         self.session_expire_hours = int(
             config.session.session_timeout.total_seconds() // 3600
+        )
+        self.password_reset_ttl = int(
+            config.jwt.password_reset_token_expiry.total_seconds()
         )
 
     def hash_password(self, password: str) -> str:
@@ -419,7 +425,8 @@ class DatabaseAuthenticator:
             reset = PasswordResetToken(
                 user_id=user.id,
                 token=token,
-                expires_at=datetime.utcnow() + timedelta(hours=1),
+                expires_at=datetime.utcnow()
+                + timedelta(seconds=self.password_reset_ttl),
                 ip_address=ip_address,
                 user_agent=user_agent,
             )
@@ -562,7 +569,10 @@ class AuthService:
             or self.config.features.enable_audit_logging
         ):
             rate_limiter = (
-                RateLimiter(max_calls=5, period=60)
+                RateLimiter(
+                    max_calls=self.config.rate_limiter.max_calls,
+                    period=self.config.rate_limiter.period_seconds,
+                )
                 if self.config.features.enable_rate_limiter
                 else None
             )
@@ -728,7 +738,7 @@ def get_auth_service() -> AuthService:
     """Return a shared :class:`AuthService` instance."""
     global _auth_service_instance
     if _auth_service_instance is None:
-        _auth_service_instance = AuthService(AuthConfig.from_env())
+        _auth_service_instance = AuthService(AuthConfig.load())
     return _auth_service_instance
 
 


### PR DESCRIPTION
## Summary
- add dataclasses for JWT, session, feature flags, and rate limiter settings
- load AuthConfig from environment/files and apply across auth service
- remove hard-coded rate limiter and password reset TTL values

## Testing
- `PYTHONWARNINGS=ignore pytest tests/security/test_auth_service.py tests/security/test_security_enhancer.py tests/security/test_intelligence_engine.py -q`
- `PYTHONWARNINGS=ignore pytest tests/test_intelligent_auth_service.py -q` *(fails: process_feedback not called, risk thresholds)*


------
https://chatgpt.com/codex/tasks/task_e_6893dd0add2483248715ef6389ab4a09