### PR TITLE
Add compat shims for legacy auth service accessors

### DIFF
--- a/src/ai_karen_engine/security/compat.py
+++ b/src/ai_karen_engine/security/compat.py
@@ -1,0 +1,73 @@
+"""Compatibility shims for legacy authentication APIs.
+
+This module provides thin wrappers that map deprecated helper
+functions from earlier versions of the codebase to the new
+:class:`~ai_karen_engine.security.auth_service.AuthService` factory.
+Each shim emits a :class:`DeprecationWarning` when used to help callers
+migrate to the modern API ``auth_service()``.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+from ai_karen_engine.security.auth_service import AuthService, auth_service
+
+
+def _deprecated_alias(name: str) -> AuthService:
+    """Return the shared :class:`AuthService` instance with a warning.
+
+    Parameters
+    ----------
+    name:
+        The name of the deprecated accessor that was used.  It is
+        interpolated into the warning message so users know which symbol
+        to replace.
+    """
+
+    warnings.warn(
+        f"'{name}' is deprecated. Use 'auth_service()' instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return auth_service()
+
+
+def get_production_auth_service() -> AuthService:
+    """Deprecated accessor for production environments.
+
+    Historically the project offered separate helpers for different
+    environments.  The new unified :func:`auth_service` replaces all of
+    them, but this function remains as a thin shim for older imports.
+    """
+
+    return _deprecated_alias("get_production_auth_service")
+
+
+def get_demo_auth_service() -> AuthService:
+    """Deprecated accessor for demo environments.
+
+    Returns the same shared service instance as
+    :func:`get_production_auth_service` and exists solely for backwards
+    compatibility with older code.  A ``DeprecationWarning`` is emitted
+    when invoked.
+    """
+
+    return _deprecated_alias("get_demo_auth_service")
+
+
+def get_auth_service() -> AuthService:
+    """Generic deprecated accessor.
+
+    This mirrors :func:`auth_service` but is kept to ease the transition
+    for any callers still importing the old name.
+    """
+
+    return _deprecated_alias("get_auth_service")
+
+
+__all__ = [
+    "get_production_auth_service",
+    "get_demo_auth_service",
+    "get_auth_service",
+]

--- a/tests/security/test_compat_layer.py
+++ b/tests/security/test_compat_layer.py
@@ -1,0 +1,27 @@
+import pytest
+
+from ai_karen_engine.security import compat
+from ai_karen_engine.security.auth_service import AuthService, auth_service
+
+
+@pytest.mark.asyncio
+async def test_compat_wrappers_delegate_to_auth_service():
+    """Legacy accessors should return the shared AuthService and warn."""
+
+    accessors = [
+        compat.get_production_auth_service,
+        compat.get_demo_auth_service,
+        compat.get_auth_service,
+    ]
+    emails = ["prod@example.com", "demo@example.com", "generic@example.com"]
+
+    for accessor, email in zip(accessors, emails):
+        with pytest.warns(DeprecationWarning):
+            service = accessor()
+        assert isinstance(service, AuthService)
+        # All accessors should return the same singleton instance
+        assert service is auth_service()
+        # Returned service should expose modern AuthService features
+        await service.create_user(email, "password")
+        user = await service.authenticate_user(email, "password")
+        assert user and user.email == email


### PR DESCRIPTION
## Summary
- provide `compat` module exposing `get_production_auth_service`, `get_demo_auth_service`, and `get_auth_service`
- each shim forwards to new `auth_service()` and raises `DeprecationWarning`
- test that legacy accessors return the singleton `AuthService` and support modern features

## Testing
- `pytest tests/security/test_compat_layer.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6893f5b924a08324ae14c76b7be7b135