### PR TITLE
Add audit logging metrics and monitoring tests

### DIFF
--- a/src/ai_karen_engine/security/auth_metrics.py
+++ b/src/ai_karen_engine/security/auth_metrics.py
@@ -1,0 +1,76 @@
+"""Authentication metrics integration with Prometheus."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+from ai_karen_engine.integrations.llm_utils import PROM_REGISTRY
+
+try:  # pragma: no cover - optional dependency
+    from prometheus_client import Counter, Histogram, CollectorRegistry
+except Exception:  # pragma: no cover
+    class _DummyMetric:
+        def inc(self, amount: int = 1) -> None:
+            pass
+
+        def observe(self, value: float) -> None:
+            pass
+
+    Counter = Histogram = _DummyMetric  # type: ignore
+    CollectorRegistry = object  # type: ignore
+
+AUTH_SUCCESS = None
+AUTH_FAILURE = None
+AUTH_PROCESSING_TIME = None
+
+
+def init_auth_metrics(
+    registry: CollectorRegistry | None = PROM_REGISTRY,
+    force: bool = False,
+):
+    """Initialize authentication metrics.
+
+    Parameters
+    ----------
+    registry:
+        Prometheus registry to register metrics with. Defaults to the
+        global ``PROM_REGISTRY`` used across the project.
+    force:
+        Force reinitialization even if metrics were already created.
+    """
+    global AUTH_SUCCESS, AUTH_FAILURE, AUTH_PROCESSING_TIME
+    if AUTH_SUCCESS is not None and not force:
+        return AUTH_SUCCESS, AUTH_FAILURE, AUTH_PROCESSING_TIME
+
+    AUTH_SUCCESS = Counter(
+        "kari_auth_success_total",
+        "Total successful authentication events",
+        registry=registry,
+    )
+    AUTH_FAILURE = Counter(
+        "kari_auth_failure_total",
+        "Total failed authentication events",
+        registry=registry,
+    )
+    AUTH_PROCESSING_TIME = Histogram(
+        "kari_auth_processing_seconds",
+        "Time spent processing authentication events",
+        registry=registry,
+    )
+    return AUTH_SUCCESS, AUTH_FAILURE, AUTH_PROCESSING_TIME
+
+
+# Initialize metrics with default registry at import time
+init_auth_metrics()
+
+
+def metrics_hook(event: str, data: Dict[str, object]) -> None:
+    """Forward authentication events to Prometheus metrics."""
+    duration = float(data.get("processing_time", 0) or 0)
+    if event == "login_success":
+        AUTH_SUCCESS.inc()
+        AUTH_PROCESSING_TIME.observe(duration)
+    elif event in {"login_failure", "login_blocked", "rate_limit_exceeded"}:
+        AUTH_FAILURE.inc()
+        if duration:
+            AUTH_PROCESSING_TIME.observe(duration)

--- a/src/ai_karen_engine/security/security_enhancer.py
+++ b/src/ai_karen_engine/security/security_enhancer.py
@@ -15,6 +15,7 @@ This module defines three lightweight components used to harden the
 
 from __future__ import annotations
 
+import json
 import time
 from collections import defaultdict, deque
 from dataclasses import dataclass
@@ -78,7 +79,9 @@ class AuditLogger:
     def log_event(self, event: str, data: Optional[Dict[str, object]] = None) -> None:
         record = AuditEvent(event=event, data=data or {}, timestamp=datetime.utcnow())
         self.events.append(record)
-        logger.info(f"AUTH EVENT {event} {record.data}")
+        logger.info(
+            f"AUTH EVENT {event} {json.dumps(record.data, sort_keys=True)}"
+        )
         if self.metrics_hook:
             self.metrics_hook(event, record.data)
 

--- a/tests/security/test_logging_monitoring.py
+++ b/tests/security/test_logging_monitoring.py
@@ -1,0 +1,38 @@
+import logging
+import re
+
+import pytest
+from prometheus_client import CollectorRegistry
+
+from ai_karen_engine.security.auth_metrics import (
+    init_auth_metrics,
+    metrics_hook,
+)
+from ai_karen_engine.security.auth_service import AuthService
+from ai_karen_engine.security.config import AuthConfig
+
+
+@pytest.mark.asyncio
+async def test_audit_logging_and_metrics(caplog):
+    registry = CollectorRegistry()
+    init_auth_metrics(registry=registry, force=True)
+
+    config = AuthConfig()
+    config.features.enable_audit_logging = True
+    service = AuthService(config=config, metrics_hook=metrics_hook)
+
+    with caplog.at_level(logging.INFO):
+        await service.create_user("log@example.com", "password")
+        user = await service.authenticate_user("log@example.com", "password")
+        assert user is not None
+        assert await service.authenticate_user("log@example.com", "wrong") is None
+
+    messages = [r.getMessage() for r in caplog.records]
+    assert any(re.match(r"AUTH EVENT login_success", m) for m in messages)
+    assert any(re.match(r"AUTH EVENT login_failure", m) for m in messages)
+
+    assert registry.get_sample_value("kari_auth_success_total") == 1
+    failure_total = registry.get_sample_value("kari_auth_failure_total")
+    assert failure_total and failure_total >= 1
+    duration_sum = registry.get_sample_value("kari_auth_processing_seconds_sum")
+    assert duration_sum and duration_sum > 0


### PR DESCRIPTION
## Summary
- log authentication events with JSON-formatted AuditLogger entries
- expose Prometheus auth metrics for success/failure counts and processing time
- add tests verifying audit logging and metric export

## Testing
- `pytest tests/security/test_logging_monitoring.py -q`
- `pytest tests/security/test_security_enhancer.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6894162036488324a127c814bef84090