### PR TITLE
feat: add basic llm router

### DIFF
--- a/src/ai_karen_engine/integrations/llm_router.py
+++ b/src/ai_karen_engine/integrations/llm_router.py
@@ -1,8 +1,12 @@
-"""Profile-based LLM provider router."""
+"""LLM routing utilities."""
+
 import json
+import logging
 import time
 from pathlib import Path
-from typing import Dict, Any
+from typing import Any, Dict, List, Optional
+
+from ai_karen_engine.integrations.llm_registry import get_registry
 
 try:
     import yaml  # type: ignore
@@ -11,33 +15,50 @@ except Exception:  # pragma: no cover - optional
 
 try:
     from prometheus_client import Counter, Histogram
+
     METRICS_ENABLED = True
 except Exception:  # pragma: no cover - optional
     METRICS_ENABLED = False
+
     class _DummyMetric:
         def labels(self, **kwargs):
             return self
+
         def inc(self, n: int = 1):
             pass
+
         def observe(self, v: float):
             pass
+
     Counter = Histogram = _DummyMetric
 
-MODEL_INVOCATIONS_TOTAL = Counter(
-    "model_invocations_total",
-    "Total LLM model invocations",
-    ["model"],
-) if METRICS_ENABLED else Counter()
-FALLBACK_RATE = Counter(
-    "fallback_rate",
-    "Fallback invocations",
-    ["profile"],
-) if METRICS_ENABLED else Counter()
-AVG_RESPONSE_TIME = Histogram(
-    "avg_response_time",
-    "LLM response time",
-    ["model"],
-) if METRICS_ENABLED else Histogram()
+MODEL_INVOCATIONS_TOTAL = (
+    Counter(
+        "model_invocations_total",
+        "Total LLM model invocations",
+        ["model"],
+    )
+    if METRICS_ENABLED
+    else Counter()
+)
+FALLBACK_RATE = (
+    Counter(
+        "fallback_rate",
+        "Fallback invocations",
+        ["profile"],
+    )
+    if METRICS_ENABLED
+    else Counter()
+)
+AVG_RESPONSE_TIME = (
+    Histogram(
+        "avg_response_time",
+        "LLM response time",
+        ["model"],
+    )
+    if METRICS_ENABLED
+    else Histogram()
+)
 
 DEFAULT_PATH = Path(__file__).parents[2] / "config" / "llm_profiles.yml"
 
@@ -84,3 +105,73 @@ class LLMProfileRouter:
         finally:
             MODEL_INVOCATIONS_TOTAL.labels(model=provider).inc()
             AVG_RESPONSE_TIME.labels(model=provider).observe(time.time() - start)
+
+
+class LLMRouter:
+    """Basic provider router prioritizing local models."""
+
+    def __init__(
+        self,
+        registry=None,
+        local_priority: Optional[List[str]] = None,
+    ) -> None:
+        self.registry = registry or get_registry()
+        self.logger = logging.getLogger("kari.llm_router")
+        self.local_priority = local_priority or ["ollama", "llama.cpp", "llama_cpp"]
+
+    def _is_healthy(self, name: str) -> bool:
+        """Check if a provider is healthy using the registry health check."""
+        try:
+            result = self.registry.health_check(name)
+            return result.get("status") == "healthy"
+        except Exception as exc:  # pragma: no cover - safety
+            self.logger.debug("Health check failed for %s: %s", name, exc)
+            return False
+
+    def _get_provider(self, name: str):
+        try:
+            return self.registry.get_provider(name)
+        except Exception:
+            return None
+
+    def select_provider(
+        self,
+        request: Optional[Dict[str, Any]] = None,
+        user_preferences: Optional[Dict[str, Any]] = None,
+    ):
+        """Select the best available provider.
+
+        The order of precedence is:
+        1. User preferred provider if healthy
+        2. Local providers (Ollama, llama.cpp) if healthy
+        3. First healthy remote provider from registry
+        """
+
+        pref = (user_preferences or {}).get("provider")
+        if pref and self._is_healthy(pref):
+            provider = self._get_provider(pref)
+            if provider:
+                return provider
+
+        for name in self.local_priority:
+            if self._is_healthy(name):
+                provider = self._get_provider(name)
+                if provider:
+                    return provider
+
+        for name in self.registry.list_providers():
+            if name in self.local_priority:
+                continue
+            if self._is_healthy(name):
+                provider = self._get_provider(name)
+                if provider:
+                    return provider
+
+        return None
+
+    async def generate(self, prompt: str, **kwargs) -> str:
+        """Generate text using the selected provider."""
+        provider = self.select_provider(user_preferences=kwargs.get("user_preferences"))
+        if not provider:
+            raise RuntimeError("No LLM providers available")
+        return provider.generate_text(prompt, **kwargs)

--- a/tests/test_llm_router_service.py
+++ b/tests/test_llm_router_service.py
@@ -1,0 +1,74 @@
+import pytest  # type: ignore[import-not-found]
+
+from ai_karen_engine.integrations.llm_router import (  # type: ignore[import-not-found]
+    LLMRouter,
+)
+from ai_karen_engine.integrations.llm_utils import (  # type: ignore[import-not-found]
+    LLMProviderBase,
+)
+
+
+class DummyProvider(LLMProviderBase):  # type: ignore[misc]
+    def __init__(self, name: str) -> None:
+        self.provider_name = name
+
+    def generate_text(
+        self, prompt: str, **kwargs: object
+    ) -> str:  # pragma: no cover - trivial
+        return f"{self.provider_name}:{prompt}"
+
+    def embed(
+        self, text: str, **kwargs: object
+    ) -> list[float]:  # pragma: no cover - trivial
+        return []
+
+    def get_provider_info(self) -> dict[str, str]:  # pragma: no cover - simple
+        return {"name": self.provider_name}
+
+
+class DummyRegistry:
+    def __init__(self, status_map: dict[str, str]) -> None:
+        self.status_map = status_map
+
+    def list_providers(self) -> list[str]:
+        return list(self.status_map.keys())
+
+    def get_provider(self, name: str) -> DummyProvider | None:
+        if self.status_map.get(name) != "fail_create":
+            return DummyProvider(name)
+        return None
+
+    def health_check(self, name: str) -> dict[str, str]:
+        status = self.status_map.get(name, "unknown")
+        if status == "fail_create":
+            return {"status": "failed_to_create"}
+        return {"status": status}
+
+
+def test_local_provider_preferred() -> None:
+    registry = DummyRegistry({"ollama": "healthy", "openai": "healthy"})
+    router = LLMRouter(registry=registry)
+    provider = router.select_provider()
+    assert provider.provider_name == "ollama"
+
+
+def test_fallback_to_remote_provider() -> None:
+    registry = DummyRegistry({"ollama": "failed_to_create", "openai": "healthy"})
+    router = LLMRouter(registry=registry)
+    provider = router.select_provider()
+    assert provider.provider_name == "openai"
+
+
+def test_user_preference_respected() -> None:
+    registry = DummyRegistry({"ollama": "healthy", "openai": "healthy"})
+    router = LLMRouter(registry=registry)
+    provider = router.select_provider(user_preferences={"provider": "openai"})
+    assert provider.provider_name == "openai"
+
+
+@pytest.mark.asyncio  # type: ignore[misc]
+async def test_generate_uses_selected_provider() -> None:
+    registry = DummyRegistry({"ollama": "healthy"})
+    router = LLMRouter(registry=registry)
+    result = await router.generate("hi")
+    assert result == "ollama:hi"


### PR DESCRIPTION
## Summary
- add `LLMRouter` to prioritize healthy local providers before remote fallbacks
- cover routing behavior with unit tests

## Testing
- `pre-commit run --files tests/test_llm_router_service.py` *(fails: reformatted, now passes after rerun; initial runs showed missing type stubs in other modules)*
- `PYTHONPATH=src pytest tests/test_llm_router_service.py -q` *(fails: NameError: name 'os' is not defined in tests/conftest.py)*

------
https://chatgpt.com/codex/tasks/task_e_6895984f4bd48324a9932b5c373a688c