### PR TITLE
Fix Gmail plugin fallback and add compose_email test

### DIFF
--- a/src/ai_karen_engine/plugins/gmail_plugin/handler.py
+++ b/src/ai_karen_engine/plugins/gmail_plugin/handler.py
@@ -8,7 +8,10 @@ import logging
 logger = logging.getLogger(__name__)
 from typing import Any, Dict
 
-from .gmail_service import GmailService
+import os
+
+from ai_karen_engine.plugins.gmail_plugin.client import GmailClient
+from ai_karen_engine.plugins.gmail_plugin.gmail_service import GmailService
 
 
 async def run(params: Dict[str, Any]) -> Dict[str, Any]:
@@ -21,8 +24,12 @@ async def run(params: Dict[str, Any]) -> Dict[str, Any]:
         body: message body (compose_email)
     """
     action = params.get("action")
-    
+
     service = GmailService()
+    client: GmailClient | None = None
+    token = params.get("access_token") or os.getenv("GMAIL_API_TOKEN")
+    if token:
+        client = GmailClient(token)
 
     try:
         if action == "check_unread":

--- a/tests/test_gmail_plugin.py
+++ b/tests/test_gmail_plugin.py
@@ -1,0 +1,28 @@
+import pytest
+
+from ai_karen_engine.plugins.gmail_plugin import handler
+
+
+@pytest.mark.asyncio
+async def test_compose_email_fallback(monkeypatch):
+    async def fake_compose_email(self, recipient, subject, body):
+        raise RuntimeError("service unavailable")
+
+    async def fake_create_draft(self, recipient, subject, body):
+        return "draft123"
+
+    monkeypatch.setattr(handler.GmailService, "compose_email", fake_compose_email)
+    monkeypatch.setattr(handler.GmailClient, "create_draft", fake_create_draft)
+
+    result = await handler.run(
+        {
+            "action": "compose_email",
+            "recipient": "user@example.com",
+            "subject": "Hi",
+            "body": "Hello",
+            "access_token": "token",
+        }
+    )
+
+    assert result["success"] is True
+    assert result["draftId"] == "draft123"


### PR DESCRIPTION
## Summary
- Instantiate Gmail API client in Gmail plugin handler and use it for draft creation when Gmail service is unavailable
- Add unit test ensuring compose_email falls back to draft creation successfully

## Testing
- `PYTHONPATH=src python - <<'PY'
import sys, types, pytest, builtins, os
sys.modules['pyautogui'] = types.ModuleType('pyautogui')
builtins.os = os
res = pytest.main(['tests/test_gmail_plugin.py', '-q'])
print('exit code', res)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68959de940688324bb54736c42ca242a