### PR TITLE
Compile regex patterns once and add tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@
 import importlib
 import sys
 import types
+import os
 # Prefer the real `requests` package when available to support
 # libraries that rely on its internal structure. Fall back to the
 # lightweight stub only if `requests` cannot be imported.

--- a/tests/test_memory_processor.py
+++ b/tests/test_memory_processor.py
@@ -105,6 +105,13 @@ class TestMemoryProcessor:
             max_context_memories=10,
             recency_weight=0.3
         )
+
+    def test_compiled_patterns(self, memory_processor):
+        """Ensure regex patterns are compiled once and reusable."""
+        import re
+
+        for pattern, _ in memory_processor.preference_patterns + memory_processor.fact_patterns:
+            assert isinstance(pattern, re.Pattern)
     
     @pytest.mark.asyncio
     async def test_extract_entity_memories(self, memory_processor, sample_parsed_message, sample_embeddings):


### PR DESCRIPTION
## Summary
- precompile regexes in `MemoryProcessor` to avoid recompilation on each call
- update preference and fact extraction loops to use compiled pattern matching
- add unit test ensuring patterns are compiled and reusable
- fix test config by importing missing `os`

## Testing
- `PYTHONPATH=src pytest tests/test_memory_processor.py::TestMemoryProcessor::test_compiled_patterns tests/test_memory_processor.py::TestMemoryProcessor::test_extract_preference_memories tests/test_memory_processor.py::TestMemoryProcessor::test_extract_fact_memories tests/test_memory_processor_task_3_2.py::TestMemoryProcessorTask32::test_intelligent_context_building -q`

------
https://chatgpt.com/codex/tasks/task_e_68959f1a1a108324a7be9e687d892f4c