### PR TITLE
feat: add ephemeral signing key fallback

### DIFF
--- a/src/ai_karen_engine/llm_orchestrator.py
+++ b/src/ai_karen_engine/llm_orchestrator.py
@@ -7,23 +7,22 @@ LLMOrchestrator: Nuclear-Grade LLM Routing Engine for Kari
 - Enhanced with failover strategies and resource monitoring
 """
 
-import os
-import logging
-import time
 import hashlib
 import hmac
-from typing import Optional, Dict, Any, List, Tuple, Callable, Union
-from pathlib import Path
-from concurrent.futures import ThreadPoolExecutor, TimeoutError, Future
-import threading
+import importlib.util
+import logging
+import os
 import random
+import secrets
 import sys
+import threading
+import time
 import uuid
-import traceback
-import json
+from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import dataclass, field
 from enum import Enum, auto
-import signal
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 # === Constants & Configuration ===
 DEFAULT_CONFIG = {
@@ -35,37 +34,39 @@ DEFAULT_CONFIG = {
     "memory_threshold": 0.8,  # 80% memory usage threshold
 }
 
+
 # === Enhanced Logging ===
 class SecureLogger:
     """Logging with redaction and secure handling"""
-    REDACTION_KEYS = {'api_key', 'token', 'password', 'secret'}
-    
+
+    REDACTION_KEYS = {"api_key", "token", "password", "secret"}
+
     def __init__(self):
         self.logger = self._setup_logger()
-        
+
     def _setup_logger(self) -> logging.Logger:
         log_file = self._resolve_log_path()
         logger = logging.getLogger("llm_orchestrator")
         logger.setLevel(logging.INFO)
-        
+
         formatter = logging.Formatter(
-            '%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-            datefmt='%Y-%m-%d %H:%M:%S%z'
+            "%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+            datefmt="%Y-%m-%d %H:%M:%S%z",
         )
-        
-        file_handler = logging.FileHandler(log_file, encoding='utf-8')
+
+        file_handler = logging.FileHandler(log_file, encoding="utf-8")
         file_handler.setFormatter(formatter)
         file_handler.addFilter(self._security_filter)
-        
+
         console_handler = logging.StreamHandler(sys.stdout)
         console_handler.setFormatter(formatter)
         console_handler.addFilter(self._security_filter)
-        
+
         logger.addHandler(file_handler)
         logger.addHandler(console_handler)
-        
+
         return logger
-    
+
     def _security_filter(self, record: logging.LogRecord) -> bool:
         """Redact sensitive information from logs"""
         try:
@@ -75,18 +76,18 @@ class SecureLogger:
                     record.msg = "[REDACTED]"
                     record.args = ()
                     break
-        except:
+        except Exception:
             pass
         return True
-    
+
     def _resolve_log_path(self) -> Path:
         """Resolve log file path with fallbacks"""
         paths = [
             os.getenv("KARI_LOG_DIR"),
             "/var/log/kari",
-            Path.home() / ".kari" / "logs"
+            Path.home() / ".kari" / "logs",
         ]
-        
+
         for path in paths:
             if not path:
                 continue
@@ -97,68 +98,87 @@ class SecureLogger:
                 log_file.touch(exist_ok=True)
                 os.chmod(log_file, 0o600)
                 return log_file
-            except (OSError, PermissionError) as e:
+            except (OSError, PermissionError):
                 continue
-                
+
         raise RuntimeError("Could not establish secure logging location")
 
+
 logger = SecureLogger().logger
+
 
 # === Security Core ===
 class SecurityEngine:
     """Centralized security operations"""
+
     def __init__(self):
         self._signing_key = self._load_signing_key()
-        
+
     def _load_signing_key(self) -> bytes:
-        """Load and validate signing key"""
+        """Load and validate signing key
+
+        Falls back to an ephemeral key in non-production environments if the
+        environment variable is missing. This is intended only for local
+        development; production environments must always provide a valid key.
+        """
         key = os.getenv("KARI_MODEL_SIGNING_KEY")
-        if not key or len(key) < 32:
+        if key:
+            if len(key) < 32:
+                raise RuntimeError(
+                    "KARI_MODEL_SIGNING_KEY must be at least 32 characters long"
+                )
+            return key.encode("utf-8")
+
+        env = os.getenv("KARI_ENV", "local").lower()
+        if env == "production":
             raise RuntimeError(
-                "KARI_MODEL_SIGNING_KEY must be set and at least 32 characters long"
+                "KARI_MODEL_SIGNING_KEY is required in production environments"
             )
-        return key.encode('utf-8')
-    
+
+        logger.warning(
+            "KARI_MODEL_SIGNING_KEY not set; generating ephemeral key for development."
+            " Do NOT use this in production."
+        )
+        return secrets.token_bytes(32)
+
     def generate_signature(self, *parts: str) -> str:
         """Generate HMAC-SHA256 signature"""
-        message = "|".join(parts).encode('utf-8')
-        return hmac.new(
-            self._signing_key,
-            message,
-            hashlib.sha256
-        ).hexdigest()
-    
+        message = "|".join(parts).encode("utf-8")
+        return hmac.new(self._signing_key, message, hashlib.sha256).hexdigest()
+
     def verify_signature(self, signature: str, *parts: str) -> bool:
         """Verify HMAC-SHA256 signature"""
         expected = self.generate_signature(*parts)
         return hmac.compare_digest(signature, expected)
 
+
 # === Hardware Isolation ===
 class HardwareManager:
     """Manage hardware resources and isolation"""
+
     def __init__(self):
         self.cpu_count = self._detect_cpu_count()
         self.psutil_available = self._check_psutil()
-        
+
     def _detect_cpu_count(self) -> int:
         """Get available CPU count with safety margin"""
         total = os.cpu_count() or 4
-        reserved = max(1, int(total * DEFAULT_CONFIG['cpu_reservation']))
+        reserved = max(1, int(total * DEFAULT_CONFIG["cpu_reservation"]))
         return max(1, total - reserved)
-    
+
     def _check_psutil(self) -> bool:
         """Check if psutil is available"""
         try:
-            import psutil
-            return True
-        except ImportError:
+            return importlib.util.find_spec("psutil") is not None
+        except Exception:
             return False
-    
+
     def set_affinity(self, cpu_id: int) -> bool:
         """Set CPU affinity for current thread"""
         try:
             if self.psutil_available:
                 import psutil
+
                 p = psutil.Process(os.getpid())
                 p.cpu_affinity([cpu_id])
             elif hasattr(os, "sched_setaffinity"):
@@ -169,17 +189,19 @@ class HardwareManager:
         except Exception as e:
             logger.warning(f"CPU affinity setting failed: {e}")
             return False
-    
+
     def check_memory(self) -> bool:
         """Check if memory usage is within safe thresholds"""
         try:
             if self.psutil_available:
                 import psutil
+
                 mem = psutil.virtual_memory()
-                return mem.percent < (DEFAULT_CONFIG['memory_threshold'] * 100)
+                return mem.percent < (DEFAULT_CONFIG["memory_threshold"] * 100)
             return True
-        except:
+        except Exception:
             return True
+
 
 # === Model Definitions ===
 class ModelStatus(Enum):
@@ -187,6 +209,7 @@ class ModelStatus(Enum):
     DEGRADED = auto()
     FAILED = auto()
     CIRCUIT_BROKEN = auto()
+
 
 @dataclass
 class ModelInfo:
@@ -201,38 +224,44 @@ class ModelInfo:
     created: float = field(default_factory=time.time)
     status: ModelStatus = ModelStatus.ACTIVE
 
+
 # === Enhanced Model Registry ===
 class ModelRegistry:
     """Secure model registry with enhanced management"""
+
     def __init__(self, security: SecurityEngine):
         self._models: Dict[str, ModelInfo] = {}
         self._lock = threading.RLock()
         self.security = security
-        
+
     def register(self, model_id: str, model: Any, capabilities: List[str], **kwargs):
         """Register a new model with cryptographic validation"""
         with self._lock:
             if model_id in self._models:
                 raise ValueError(f"Model {model_id} already registered")
-                
-            signature = self._generate_signature(model_id, capabilities, kwargs.get('weight', 1))
+
+            signature = self._generate_signature(
+                model_id, capabilities, kwargs.get("weight", 1)
+            )
             self._models[model_id] = ModelInfo(
                 model_id=model_id,
                 model=model,
                 capabilities=capabilities,
                 signature=signature,
-                **kwargs
+                **kwargs,
             )
-            logger.info(f"Registered model {model_id} with capabilities: {capabilities}")
-    
-    def _generate_signature(self, model_id: str, capabilities: List[str], weight: int) -> str:
+            logger.info(
+                f"Registered model {model_id} with capabilities: {capabilities}"
+            )
+
+    def _generate_signature(
+        self, model_id: str, capabilities: List[str], weight: int
+    ) -> str:
         """Generate cryptographic signature for model"""
         return self.security.generate_signature(
-            model_id,
-            ",".join(sorted(capabilities)),
-            str(weight)
+            model_id, ",".join(sorted(capabilities)), str(weight)
         )
-    
+
     def verify(self, model_id: str) -> bool:
         """Verify model integrity"""
         with self._lock:
@@ -240,19 +269,17 @@ class ModelRegistry:
                 return False
             model = self._models[model_id]
             expected = self._generate_signature(
-                model_id,
-                model.capabilities,
-                model.weight
+                model_id, model.capabilities, model.weight
             )
             return hmac.compare_digest(expected, model.signature)
-    
+
     def get(self, model_id: str) -> Optional[ModelInfo]:
         """Get model info if it exists and is valid"""
         with self._lock:
             if model_id in self._models and self.verify(model_id):
                 return self._models[model_id]
             return None
-    
+
     def list_models(self) -> List[Dict[str, Any]]:
         """Get list of all valid models"""
         with self._lock:
@@ -263,35 +290,37 @@ class ModelRegistry:
                     "tags": model.tags,
                     "status": model.status.name,
                     "last_used": model.last_used,
-                    "failure_count": model.failure_count
+                    "failure_count": model.failure_count,
                 }
                 for model in self._models.values()
                 if self.verify(model.model_id)
             ]
 
+
 # === Execution Pool with Enhanced Features ===
 class ExecutionPool:
     """Secure execution environment with resource management"""
+
     def __init__(self, hardware: HardwareManager):
         self.hardware = hardware
         self.executor = ThreadPoolExecutor(
-            max_workers=DEFAULT_CONFIG['max_concurrent_requests'],
-            thread_name_prefix="llm_worker"
+            max_workers=DEFAULT_CONFIG["max_concurrent_requests"],
+            thread_name_prefix="llm_worker",
         )
         self.circuit_breakers: Dict[str, int] = {}
         self.lock = threading.RLock()
-        
+
     def execute(self, model_id: str, fn: Callable, *args, **kwargs) -> Future:
         """Execute function in secure environment"""
         if not self.hardware.check_memory():
             raise RuntimeError("System memory threshold exceeded")
-            
+
         if self._check_circuit(model_id):
             raise RuntimeError(f"Circuit breaker tripped for {model_id}")
-        
+
         cpu_id = random.randint(0, self.hardware.cpu_count - 1)
         job_id = str(uuid.uuid4())[:8]
-        
+
         def _wrapped():
             try:
                 self.hardware.set_affinity(cpu_id)
@@ -302,41 +331,47 @@ class ExecutionPool:
                 raise
             finally:
                 logger.info(f"[{job_id}] Execution completed")
-        
+
         future = self.executor.submit(_wrapped)
         future.model_id = model_id  # type: ignore
         future.job_id = job_id  # type: ignore
         return future
-    
+
     def _check_circuit(self, model_id: str) -> bool:
         """Check if circuit breaker is tripped"""
         with self.lock:
-            return self.circuit_breakers.get(model_id, 0) >= DEFAULT_CONFIG['failure_trip_limit']
-    
+            return (
+                self.circuit_breakers.get(model_id, 0)
+                >= DEFAULT_CONFIG["failure_trip_limit"]
+            )
+
     def _record_outcome(self, model_id: str, success: bool):
         """Update circuit breaker state"""
         with self.lock:
             if success:
                 self.circuit_breakers[model_id] = 0
             else:
-                self.circuit_breakers[model_id] = self.circuit_breakers.get(model_id, 0) + 1
+                self.circuit_breakers[model_id] = (
+                    self.circuit_breakers.get(model_id, 0) + 1
+                )
+
 
 # === Core Orchestrator ===
 class LLMOrchestrator:
     """Enhanced LLM routing engine with failover strategies"""
-    
+
     _instance = None
     _lock = threading.Lock()
-    
+
     def __new__(cls):
         with cls._lock:
             if cls._instance is None:
                 cls._instance = super().__new__(cls)
                 cls._instance.__init__()
         return cls._instance
-    
+
     def __init__(self):
-        if not hasattr(self, '_initialized'):
+        if not hasattr(self, "_initialized"):
             self.security = SecurityEngine()
             self.hardware = HardwareManager()
             self.registry = ModelRegistry(self.security)
@@ -344,21 +379,20 @@ class LLMOrchestrator:
             self._setup_watchdog()
             self._initialized = True
             logger.info("LLMOrchestrator initialized in secure mode")
-    
+
     def _setup_watchdog(self):
         """Start monitoring thread"""
+
         def _monitor():
             while True:
-                time.sleep(DEFAULT_CONFIG['watchdog_interval'])
+                time.sleep(DEFAULT_CONFIG["watchdog_interval"])
                 self._audit_models()
-        
+
         thread = threading.Thread(
-            target=_monitor,
-            daemon=True,
-            name="orchestrator-watchdog"
+            target=_monitor, daemon=True, name="orchestrator-watchdog"
         )
         thread.start()
-    
+
     def _audit_models(self):
         """Periodically verify all models"""
         with self.registry._lock:
@@ -366,29 +400,28 @@ class LLMOrchestrator:
                 if not self.registry.verify(model_id):
                     logger.warning(f"Model integrity check failed: {model_id}")
                     del self.registry._models[model_id]
-    
+
     def route(self, prompt: str, skill: Optional[str] = None, **kwargs) -> str:
         """Route request to appropriate model"""
         model_id, model = self._select_model(skill)
         if not model:
             raise RuntimeError("No suitable model available")
-        
+
         try:
             future = self.pool.execute(
-                model_id,
-                model.model.generate_text,
-                prompt,
-                **kwargs
+                model_id, model.model.generate_text, prompt, **kwargs
             )
-            result = future.result(timeout=DEFAULT_CONFIG['request_timeout'])
+            result = future.result(timeout=DEFAULT_CONFIG["request_timeout"])
             self.pool._record_outcome(model_id, True)
             return result
         except Exception as e:
             self.pool._record_outcome(model_id, False)
             logger.error(f"Request failed: {str(e)}")
             raise
-    
-    def route_with_copilotkit(self, prompt: str, context: Optional[Dict[str, Any]] = None, **kwargs) -> str:
+
+    def route_with_copilotkit(
+        self, prompt: str, context: Optional[Dict[str, Any]] = None, **kwargs
+    ) -> str:
         """Route request specifically to CopilotKit provider with enhanced context"""
         # Try to get CopilotKit provider first
         copilotkit_model = None
@@ -396,26 +429,25 @@ class LLMOrchestrator:
             if "copilotkit" in model_id.lower() and model.status == ModelStatus.ACTIVE:
                 copilotkit_model = (model_id, model)
                 break
-        
+
         if not copilotkit_model:
             # Fallback to regular routing if CopilotKit not available
-            logger.warning("CopilotKit provider not available, falling back to regular routing")
+            logger.warning(
+                "CopilotKit provider not available, falling back to regular routing"
+            )
             return self.route(prompt, **kwargs)
-        
+
         model_id, model = copilotkit_model
-        
+
         try:
             # Add conversation context for CopilotKit
             if context:
                 kwargs["conversation_context"] = context
-            
+
             future = self.pool.execute(
-                model_id,
-                model.model.generate_text,
-                prompt,
-                **kwargs
+                model_id, model.model.generate_text, prompt, **kwargs
             )
-            result = future.result(timeout=DEFAULT_CONFIG['request_timeout'])
+            result = future.result(timeout=DEFAULT_CONFIG["request_timeout"])
             self.pool._record_outcome(model_id, True)
             return result
         except Exception as e:
@@ -423,8 +455,10 @@ class LLMOrchestrator:
             logger.error(f"CopilotKit request failed: {str(e)}")
             # Fallback to regular routing
             return self.route(prompt, **kwargs)
-    
-    async def get_code_suggestions(self, code: str, language: str = "python", **kwargs) -> List[Dict[str, Any]]:
+
+    async def get_code_suggestions(
+        self, code: str, language: str = "python", **kwargs
+    ) -> List[Dict[str, Any]]:
         """Get code suggestions from CopilotKit provider or enhanced providers"""
         # First try CopilotKit provider
         copilotkit_model = None
@@ -432,69 +466,84 @@ class LLMOrchestrator:
             if "copilotkit" in model_id.lower() and model.status == ModelStatus.ACTIVE:
                 copilotkit_model = (model_id, model)
                 break
-        
+
         if copilotkit_model:
             model_id, model = copilotkit_model
             try:
-                if hasattr(model.model, 'get_code_suggestions'):
-                    return await model.model.get_code_suggestions(code, language, **kwargs)
+                if hasattr(model.model, "get_code_suggestions"):
+                    return await model.model.get_code_suggestions(
+                        code, language, **kwargs
+                    )
             except Exception as e:
                 logger.warning(f"CopilotKit code suggestions failed: {e}")
-        
+
         # Fallback to any provider with code assistance capabilities
         for model_id, model in self.registry._models.items():
             if model.status == ModelStatus.ACTIVE:
                 try:
-                    if hasattr(model.model, 'get_code_suggestions'):
-                        return await model.model.get_code_suggestions(code, language, **kwargs)
+                    if hasattr(model.model, "get_code_suggestions"):
+                        return await model.model.get_code_suggestions(
+                            code, language, **kwargs
+                        )
                 except Exception as e:
                     logger.debug(f"Provider {model_id} code suggestions failed: {e}")
                     continue
-        
+
         logger.warning("No providers available for code suggestions")
         return []
-    
-    async def get_debugging_assistance(self, code: str, error_message: str = "", language: str = "python", **kwargs) -> Dict[str, Any]:
+
+    async def get_debugging_assistance(
+        self, code: str, error_message: str = "", language: str = "python", **kwargs
+    ) -> Dict[str, Any]:
         """Get debugging assistance from enhanced providers"""
         # Try providers with debugging assistance capabilities
         for model_id, model in self.registry._models.items():
             if model.status == ModelStatus.ACTIVE:
                 try:
-                    if hasattr(model.model, 'get_debugging_assistance'):
+                    if hasattr(model.model, "get_debugging_assistance"):
                         return await model.model.get_debugging_assistance(
                             code=code,
                             error_message=error_message,
                             language=language,
-                            **kwargs
+                            **kwargs,
                         )
                 except Exception as e:
-                    logger.debug(f"Provider {model_id} debugging assistance failed: {e}")
+                    logger.debug(
+                        f"Provider {model_id} debugging assistance failed: {e}"
+                    )
                     continue
-        
+
         logger.warning("No providers available for debugging assistance")
         return {"suggestions": [], "analysis": "No debugging assistance available"}
-    
-    async def generate_documentation(self, code: str, language: str = "python", style: str = "comprehensive", **kwargs) -> str:
+
+    async def generate_documentation(
+        self,
+        code: str,
+        language: str = "python",
+        style: str = "comprehensive",
+        **kwargs,
+    ) -> str:
         """Generate documentation using enhanced providers"""
         # Try providers with documentation generation capabilities
         for model_id, model in self.registry._models.items():
             if model.status == ModelStatus.ACTIVE:
                 try:
-                    if hasattr(model.model, 'generate_documentation'):
+                    if hasattr(model.model, "generate_documentation"):
                         return await model.model.generate_documentation(
-                            code=code,
-                            language=language,
-                            style=style,
-                            **kwargs
+                            code=code, language=language, style=style, **kwargs
                         )
                 except Exception as e:
-                    logger.debug(f"Provider {model_id} documentation generation failed: {e}")
+                    logger.debug(
+                        f"Provider {model_id} documentation generation failed: {e}"
+                    )
                     continue
-        
+
         logger.warning("No providers available for documentation generation")
         return f"Documentation generation unavailable for {language} code"
-    
-    async def get_contextual_suggestions(self, message: str, context: Dict[str, Any], **kwargs) -> List[Dict[str, Any]]:
+
+    async def get_contextual_suggestions(
+        self, message: str, context: Dict[str, Any], **kwargs
+    ) -> List[Dict[str, Any]]:
         """Get contextual suggestions from CopilotKit provider or enhanced providers"""
         # First try CopilotKit provider
         copilotkit_model = None
@@ -502,90 +551,96 @@ class LLMOrchestrator:
             if "copilotkit" in model_id.lower() and model.status == ModelStatus.ACTIVE:
                 copilotkit_model = (model_id, model)
                 break
-        
+
         if copilotkit_model:
             model_id, model = copilotkit_model
             try:
-                if hasattr(model.model, 'get_contextual_suggestions'):
-                    return await model.model.get_contextual_suggestions(message, context, **kwargs)
+                if hasattr(model.model, "get_contextual_suggestions"):
+                    return await model.model.get_contextual_suggestions(
+                        message, context, **kwargs
+                    )
             except Exception as e:
                 logger.warning(f"CopilotKit contextual suggestions failed: {e}")
-        
+
         # Fallback to any provider with contextual suggestions capabilities
         for model_id, model in self.registry._models.items():
             if model.status == ModelStatus.ACTIVE:
                 try:
-                    if hasattr(model.model, 'get_contextual_suggestions'):
-                        return await model.model.get_contextual_suggestions(message, context, **kwargs)
+                    if hasattr(model.model, "get_contextual_suggestions"):
+                        return await model.model.get_contextual_suggestions(
+                            message, context, **kwargs
+                        )
                 except Exception as e:
-                    logger.debug(f"Provider {model_id} contextual suggestions failed: {e}")
+                    logger.debug(
+                        f"Provider {model_id} contextual suggestions failed: {e}"
+                    )
                     continue
-        
+
         logger.warning("No providers available for contextual suggestions")
         return []
-    
-    async def enhanced_route(self, prompt: str, skill: Optional[str] = None, **kwargs) -> str:
+
+    async def enhanced_route(
+        self, prompt: str, skill: Optional[str] = None, **kwargs
+    ) -> str:
         """Enhanced routing with CopilotKit code assistance integration"""
         model_id, model = self._select_model(skill)
         if not model:
             raise RuntimeError("No suitable model available")
-        
+
         try:
             # Use enhanced response generation if available
-            if hasattr(model.model, 'enhanced_generate_response'):
+            if hasattr(model.model, "enhanced_generate_response"):
                 future = self.pool.execute(
-                    model_id,
-                    model.model.enhanced_generate_response,
-                    prompt,
-                    **kwargs
+                    model_id, model.model.enhanced_generate_response, prompt, **kwargs
                 )
             else:
                 # Fallback to regular generation
                 future = self.pool.execute(
-                    model_id,
-                    model.model.generate_response,
-                    prompt,
-                    **kwargs
+                    model_id, model.model.generate_response, prompt, **kwargs
                 )
-            
-            result = future.result(timeout=DEFAULT_CONFIG['request_timeout'])
+
+            result = future.result(timeout=DEFAULT_CONFIG["request_timeout"])
             self.pool._record_outcome(model_id, True)
             return result
         except Exception as e:
             self.pool._record_outcome(model_id, False)
             logger.error(f"Enhanced request failed: {str(e)}")
             raise
-    
-    def _select_model(self, skill: Optional[str]) -> Tuple[Optional[str], Optional[ModelInfo]]:
+
+    def _select_model(
+        self, skill: Optional[str]
+    ) -> Tuple[Optional[str], Optional[ModelInfo]]:
         """Select best model for the task"""
         with self.registry._lock:
             candidates = []
-            
+
             # First pass: exact skill matches
             if skill:
                 candidates.extend(
-                    (mid, model) for mid, model in self.registry._models.items()
+                    (mid, model)
+                    for mid, model in self.registry._models.items()
                     if skill in model.capabilities
                     and model.status == ModelStatus.ACTIVE
                 )
-            
+
             # Second pass: generic models
             if not candidates:
                 candidates.extend(
-                    (mid, model) for mid, model in self.registry._models.items()
+                    (mid, model)
+                    for mid, model in self.registry._models.items()
                     if "generic" in model.capabilities
                     and model.status == ModelStatus.ACTIVE
                 )
-            
+
             if candidates:
                 # Select least used, lowest weight model
                 candidates.sort(key=lambda x: (x[1].weight, x[1].last_used))
                 selected = candidates[0]
                 selected[1].last_used = time.time()
                 return selected
-            
+
             return None, None
-    
+
     def health_check(self) -> Dict[str, Any]:
         """System health status"""
         return {
@@ -593,12 +648,14 @@ class LLMOrchestrator:
             "models": len(self.registry._models),
             "active_workers": self.pool.executor._work_queue.qsize(),
             "memory_ok": self.hardware.check_memory(),
-            "timestamp": time.time()
+            "timestamp": time.time(),
         }
+
 
 # === Singleton Access ===
 def get_orchestrator() -> LLMOrchestrator:
     """Get the orchestrator instance"""
     return LLMOrchestrator()
+
 
 llm_orchestrator = get_orchestrator()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ import importlib
 import os
 import sys
 import types
+
 # Prefer the real `requests` package when available to support
 # libraries that rely on its internal structure. Fall back to the
 # lightweight stub only if `requests` cannot be imported.
@@ -51,10 +52,21 @@ sys.modules.setdefault(
 sys.modules.setdefault("ai_karen_engine", importlib.import_module("ai_karen_engine"))
 sys.modules.setdefault("ui_logic", importlib.import_module("ui_logic"))
 sys.modules.setdefault("services", importlib.import_module("ai_karen_engine.services"))
-sys.modules.setdefault("integrations", importlib.import_module("ai_karen_engine.integrations"))
-sys.modules.setdefault("integrations.llm_registry", importlib.import_module("ai_karen_engine.integrations.llm_registry"))
-sys.modules.setdefault("integrations.model_discovery", importlib.import_module("ai_karen_engine.integrations.model_discovery"))
-sys.modules.setdefault("integrations.llm_utils", importlib.import_module("ai_karen_engine.integrations.llm_utils"))
+sys.modules.setdefault(
+    "integrations", importlib.import_module("ai_karen_engine.integrations")
+)
+sys.modules.setdefault(
+    "integrations.llm_registry",
+    importlib.import_module("ai_karen_engine.integrations.llm_registry"),
+)
+sys.modules.setdefault(
+    "integrations.model_discovery",
+    importlib.import_module("ai_karen_engine.integrations.model_discovery"),
+)
+sys.modules.setdefault(
+    "integrations.llm_utils",
+    importlib.import_module("ai_karen_engine.integrations.llm_utils"),
+)
 # Ensure required runtime dependencies are available
 try:  # pragma: no cover - fail early if missing
     import fastapi  # noqa: F401
@@ -64,7 +76,7 @@ except Exception as e:  # pragma: no cover
         "FastAPI and Pydantic must be installed for tests. Install with `pip install fastapi pydantic`."
     ) from e
 
-os.environ.setdefault("KARI_MODEL_SIGNING_KEY", "test")
+os.environ.setdefault("KARI_MODEL_SIGNING_KEY", "0123456789abcdef0123456789abcdef")
 os.environ.setdefault("KARI_DUCKDB_PASSWORD", "test")
 os.environ.setdefault("KARI_JOB_SIGNING_KEY", "test")
 os.environ.setdefault("DUCKDB_PATH", ":memory:")


### PR DESCRIPTION
## Summary
- allow LLM orchestrator to generate a temporary signing key for local development when `KARI_MODEL_SIGNING_KEY` is missing
- warn in logs and require explicit key in production deployments
- update test configuration with a valid-length default signing key

## Testing
- `SKIP=mypy pre-commit run --files src/ai_karen_engine/llm_orchestrator.py tests/conftest.py`
- `PYTHONPATH=src pytest tests/test_basic_setup.py -q` *(fails: TypeError: object() takes no arguments)*

------
https://chatgpt.com/codex/tasks/task_e_6895b1a34be48324858da2faec62ec5c