### PR TITLE
chore: add AG-UI chat core schema

### DIFF
--- a/src/ai_karen_engine/database/migrations/001_agui_chat_core.sql
+++ b/src/ai_karen_engine/database/migrations/001_agui_chat_core.sql
@@ -1,4 +1,4 @@
--- AI Karen Database Schema: AG-UI + Copilot-ready Chat Core
+-- Initial schema for AG-UI + Copilot-ready chat core
 
 CREATE TABLE auth_users (
   user_id           TEXT PRIMARY KEY,


### PR DESCRIPTION
## Summary
- add migration defining auth, chat, memory, extensions, and analytics tables
- consolidate database_schema.sql with AG-UI chat core definition

## Testing
- `pre-commit run --files database_schema.sql src/ai_karen_engine/database/migrations/001_agui_chat_core.sql`
- `PYTHONPATH=src pytest` *(fails: TypeError: object() takes no arguments)*

------
https://chatgpt.com/codex/tasks/task_e_6895b39a3c4083248ba712e114f20ecf