### PR TITLE
feat: expand auth schema

### DIFF
--- a/create_test_user.py
+++ b/create_test_user.py
@@ -9,7 +9,7 @@ os.environ['DATABASE_URL'] = 'postgresql://karen_user:karen_secure_pass_change_m
 
 from sqlalchemy import create_engine, text
 from sqlalchemy.orm import sessionmaker
-from src.ai_karen_engine.database.models.auth_models import User
+from src.ai_karen_engine.database.models.auth_models import AuthUser
 import bcrypt
 import uuid
 from datetime import datetime
@@ -25,7 +25,7 @@ def create_test_user():
         
         with SessionLocal() as session:
             # Check if test user already exists
-            existing_user = session.query(User).filter(User.email == 'test@example.com').first()
+            existing_user = session.query(AuthUser).filter(AuthUser.email == 'test@example.com').first()
             
             if existing_user:
                 print("✓ Test user already exists")
@@ -34,13 +34,15 @@ def create_test_user():
             # Create test user
             hashed_password = bcrypt.hashpw('testpassword'.encode('utf-8'), bcrypt.gensalt()).decode('utf-8')
             
-            test_user = User(
-                id=str(uuid.uuid4()),
+            test_user = AuthUser(
+                user_id=str(uuid.uuid4()),
                 email='test@example.com',
-                username='testuser',
+                full_name='Test User',
                 password_hash=hashed_password,
                 is_active=True,
                 is_verified=True,
+                roles=['user'],
+                tenant_id='default',
                 created_at=datetime.utcnow(),
                 updated_at=datetime.utcnow()
             )

--- a/database_schema.sql
+++ b/database_schema.sql
@@ -48,6 +48,7 @@ CREATE TABLE auth_providers (
   tenant_id     TEXT,
   type          TEXT NOT NULL,           -- oauth|saml|oidc
   config        JSONB NOT NULL,
+  metadata      JSONB DEFAULT '{}'::jsonb,
   enabled       BOOLEAN DEFAULT TRUE,
   created_at    TIMESTAMP DEFAULT now(),
   updated_at    TIMESTAMP DEFAULT now()

--- a/examples/multitenant_demo.py
+++ b/examples/multitenant_demo.py
@@ -16,7 +16,7 @@ from datetime import datetime
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
 try:
-    from src.ai_karen_engine.database.models import Tenant, User, TenantConversation, TenantMemoryEntry
+    from src.ai_karen_engine.database.models import Tenant, AuthUser, TenantConversation, TenantMemoryEntry
     from src.ai_karen_engine.database.client import MultiTenantPostgresClient
     from src.ai_karen_engine.database.migrations import MigrationManager
     from src.ai_karen_engine.clients.database.postgres_client import PostgresClient
@@ -63,10 +63,10 @@ def demo_models():
     print(f"  Settings: {tenant.settings}")
     
     # Create user
-    user_id = uuid.uuid4()
-    user = User(
-        id=user_id,
-        tenant_id=tenant_id,
+    user_id = str(uuid.uuid4())
+    user = AuthUser(
+        user_id=user_id,
+        tenant_id=str(tenant_id),
         email="admin@acme-corp.com",
         roles=["tenant_admin", "user_manager"],
         preferences={"language": "en", "timezone": "UTC"},
@@ -74,7 +74,7 @@ def demo_models():
     )
     
     print(f"\nCreated User: {user}")
-    print(f"  ID: {user.id}")
+    print(f"  ID: {user.user_id}")
     print(f"  Email: {user.email}")
     print(f"  Roles: {user.roles}")
     print(f"  Tenant ID: {user.tenant_id}")

--- a/scripts/create_production_db.py
+++ b/scripts/create_production_db.py
@@ -34,10 +34,10 @@ async def create_admin_user():
 
         # Check if admin user already exists
         with db_client.session_scope() as session:
-            from ai_karen_engine.database.models.auth_models import User
+            from ai_karen_engine.database.models.auth_models import AuthUser
 
             existing_admin = (
-                session.query(User).filter(User.email == admin_email).first()
+                session.query(AuthUser).filter(AuthUser.email == admin_email).first()
             )
 
             if existing_admin:
@@ -73,9 +73,9 @@ async def create_admin_user():
 
         # Mark admin as verified
         with db_client.session_scope() as session:
-            from ai_karen_engine.database.models.auth_models import User
+            from ai_karen_engine.database.models.auth_models import AuthUser
 
-            admin_db_user = session.query(User).filter(User.id == admin_user.id).first()
+            admin_db_user = session.query(AuthUser).filter(AuthUser.user_id == admin_user.id).first()
             if admin_db_user:
                 admin_db_user.is_verified = True
                 session.commit()
@@ -99,9 +99,9 @@ async def create_demo_user():
 
         # Check if demo user already exists
         with db_client.session_scope() as session:
-            from ai_karen_engine.database.models.auth_models import User
+            from ai_karen_engine.database.models.auth_models import AuthUser
 
-            existing_demo = session.query(User).filter(User.email == demo_email).first()
+            existing_demo = session.query(AuthUser).filter(AuthUser.email == demo_email).first()
 
             if existing_demo:
                 logger.info("Demo user already exists")
@@ -136,9 +136,9 @@ async def create_demo_user():
 
         # Mark demo user as verified
         with db_client.session_scope() as session:
-            from ai_karen_engine.database.models.auth_models import User
+            from ai_karen_engine.database.models.auth_models import AuthUser
 
-            demo_db_user = session.query(User).filter(User.id == demo_user.id).first()
+            demo_db_user = session.query(AuthUser).filter(AuthUser.user_id == demo_user.id).first()
             if demo_db_user:
                 demo_db_user.is_verified = True
                 session.commit()

--- a/scripts/init_auth_database.py
+++ b/scripts/init_auth_database.py
@@ -90,7 +90,7 @@ def run_python_migration():
         from sqlalchemy.orm import sessionmaker
         
         # Import models to ensure they're registered
-        from src.ai_karen_engine.database.models.auth_models import Base, User
+        from src.ai_karen_engine.database.models.auth_models import Base, AuthUser
         import bcrypt
         import uuid
         from datetime import datetime
@@ -107,7 +107,7 @@ def run_python_migration():
         
         with SessionLocal() as session:
             # Check if test user exists
-            existing_user = session.query(User).filter(User.email == 'test@example.com').first()
+            existing_user = session.query(AuthUser).filter(AuthUser.email == 'test@example.com').first()
             
             if not existing_user:
                 print("👤 Creating test user...")
@@ -115,14 +115,14 @@ def run_python_migration():
                 # Create test user
                 hashed_password = bcrypt.hashpw('testpassword'.encode('utf-8'), bcrypt.gensalt()).decode('utf-8')
                 
-                test_user = User(
-                    id=str(uuid.uuid4()),
+                test_user = AuthUser(
+                    user_id=str(uuid.uuid4()),
                     email='test@example.com',
                     full_name='Test User',
                     password_hash=hashed_password,
                     is_active=True,
                     is_verified=True,
-                    roles='["user"]',
+                    roles=['user'],
                     tenant_id='default',
                     created_at=datetime.utcnow(),
                     updated_at=datetime.utcnow()
@@ -138,7 +138,7 @@ def run_python_migration():
                 print("ℹ️  Test user already exists: test@example.com")
             
             # Check if admin user exists
-            existing_admin = session.query(User).filter(User.email == 'admin@example.com').first()
+            existing_admin = session.query(AuthUser).filter(AuthUser.email == 'admin@example.com').first()
             
             if not existing_admin:
                 print("👑 Creating admin user...")
@@ -146,14 +146,14 @@ def run_python_migration():
                 # Create admin user
                 hashed_password = bcrypt.hashpw('adminpassword'.encode('utf-8'), bcrypt.gensalt()).decode('utf-8')
                 
-                admin_user = User(
-                    id=str(uuid.uuid4()),
+                admin_user = AuthUser(
+                    user_id=str(uuid.uuid4()),
                     email='admin@example.com',
                     full_name='Admin User',
                     password_hash=hashed_password,
                     is_active=True,
                     is_verified=True,
-                    roles='["admin", "user"]',
+                    roles=['admin', 'user'],
                     tenant_id='default',
                     created_at=datetime.utcnow(),
                     updated_at=datetime.utcnow()
@@ -169,9 +169,9 @@ def run_python_migration():
                 print("ℹ️  Admin user already exists: admin@example.com")
             
             # Show user statistics
-            user_count = session.query(User).count()
-            active_users = session.query(User).filter(User.is_active == True).count()
-            verified_users = session.query(User).filter(User.is_verified == True).count()
+            user_count = session.query(AuthUser).count()
+            active_users = session.query(AuthUser).filter(AuthUser.is_active == True).count()
+            verified_users = session.query(AuthUser).filter(AuthUser.is_verified == True).count()
             
             print(f"\n📊 Database Statistics:")
             print(f"   👥 Total users: {user_count}")

--- a/scripts/multitenant_cli.py
+++ b/scripts/multitenant_cli.py
@@ -18,7 +18,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from src.ai_karen_engine.database.client import MultiTenantPostgresClient
     from src.ai_karen_engine.database.migrations import MigrationManager
-    from src.ai_karen_engine.database.models import Tenant, User
+    from src.ai_karen_engine.database.models import Tenant, AuthUser
 except ImportError as e:
     print(f"Error importing modules: {e}")
     print("Please ensure all dependencies are installed.")

--- a/src/ai_karen_engine/chat/enhanced_conversation_manager.py
+++ b/src/ai_karen_engine/chat/enhanced_conversation_manager.py
@@ -18,7 +18,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from ai_karen_engine.database.client import MultiTenantPostgresClient
-from ai_karen_engine.database.models import TenantConversation, User
+from ai_karen_engine.database.models import TenantConversation, AuthUser
 from ai_karen_engine.chat.conversation_models import (
     Conversation, ChatMessage, ConversationFolder, ConversationTemplate,
     ConversationFilters, ConversationSearchResult, ConversationExportOptions,

--- a/src/ai_karen_engine/database/conversation_manager.py
+++ b/src/ai_karen_engine/database/conversation_manager.py
@@ -19,7 +19,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from ai_karen_engine.database.client import MultiTenantPostgresClient
-from ai_karen_engine.database.models import TenantConversation, User
+from ai_karen_engine.database.models import TenantConversation, AuthUser
 from ai_karen_engine.database.memory_manager import MemoryManager, MemoryQuery
 from ai_karen_engine.core.embedding_manager import EmbeddingManager
 

--- a/src/ai_karen_engine/database/migrations/002_auth_provider_metadata.sql
+++ b/src/ai_karen_engine/database/migrations/002_auth_provider_metadata.sql
@@ -1,0 +1,12 @@
+-- Migration: add 2FA and provider metadata columns
+-- Ensures auth_users has two-factor and login tracking fields
+-- Adds metadata column to auth_providers
+
+ALTER TABLE auth_users
+    ADD COLUMN IF NOT EXISTS two_factor_enabled BOOLEAN DEFAULT FALSE,
+    ADD COLUMN IF NOT EXISTS two_factor_secret TEXT,
+    ADD COLUMN IF NOT EXISTS failed_login_attempts INT DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS locked_until TIMESTAMP;
+
+ALTER TABLE auth_providers
+    ADD COLUMN IF NOT EXISTS metadata JSONB DEFAULT '{}'::jsonb;

--- a/src/ai_karen_engine/database/models/auth_models.py
+++ b/src/ai_karen_engine/database/models/auth_models.py
@@ -1,221 +1,204 @@
-"""
-Production Database Models for Authentication
-SQLAlchemy models for users, sessions, and authentication data
-"""
+"""Authentication related SQLAlchemy models."""
 
 import uuid
 from datetime import datetime
-from typing import Optional, Any, Dict, List
+from typing import Any, Dict, List
 
 from sqlalchemy import (
-    Column, String, DateTime, Boolean, Integer, Text, ForeignKey, Index
+    Boolean,
+    Column,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    Numeric,
+    String,
+    Text,
 )
-from sqlalchemy.dialects.postgresql import UUID
-from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import relationship
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import declarative_base, relationship
 from sqlalchemy.sql import func
 
 Base = declarative_base()
 
 
-class User(Base):
-    """Production user model with proper security"""
-    __tablename__ = "users"
+class AuthUser(Base):
+    """Application user account"""
 
-    # Primary key
-    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    __tablename__ = "auth_users"
 
-    # Authentication fields
+    user_id = Column(String, primary_key=True, default=lambda: str(uuid.uuid4()))
     email = Column(String(255), unique=True, nullable=False, index=True)
-    password_hash = Column(String(255), nullable=False)
-
-    # Profile fields
-    full_name = Column(String(255), nullable=True)
-    is_active = Column(Boolean, default=True, nullable=False)
+    full_name = Column(String(255))
+    password_hash = Column(String(255))
+    tenant_id = Column(String)
+    roles = Column(JSONB, nullable=False, default=list)
+    preferences = Column(JSONB, default=dict)
     is_verified = Column(Boolean, default=False, nullable=False)
-
-    # Role and permissions
-    roles = Column(Text, nullable=False, default="user")  # JSON array of roles
-    tenant_id = Column(String(36), nullable=False, default="default")
-
-    # Preferences
-    preferences = Column(Text, nullable=True)  # JSON preferences
-
-    # 2FA settings
+    is_active = Column(Boolean, default=True, nullable=False)
     two_factor_enabled = Column(Boolean, default=False, nullable=False)
-    two_factor_secret = Column(String(32), nullable=True)
-    backup_codes = Column(Text, nullable=True)  # JSON array of backup codes
-
-    # Security tracking
-    failed_login_attempts = Column(Integer, default=0, nullable=False)
-    locked_until = Column(DateTime, nullable=True)
-    last_login_at = Column(DateTime, nullable=True)
-    last_login_ip = Column(String(45), nullable=True)  # IPv6 compatible
-
-    # Timestamps
+    two_factor_secret = Column(String(32))
     created_at = Column(DateTime, default=func.now(), nullable=False)
     updated_at = Column(DateTime, default=func.now(), onupdate=func.now(), nullable=False)
+    last_login_at = Column(DateTime)
+    failed_login_attempts = Column(Integer, default=0, nullable=False)
+    locked_until = Column(DateTime)
 
-    # Relationships
-    sessions = relationship("UserSession", back_populates="user", cascade="all, delete-orphan")
+    sessions = relationship("AuthSession", back_populates="user", cascade="all, delete-orphan")
     chat_memories = relationship("ChatMemory", back_populates="user", cascade="all, delete-orphan")
 
-    # Indexes
     __table_args__ = (
-        Index("idx_user_email_active", "email", "is_active"),
-        Index("idx_user_tenant", "tenant_id"),
-        Index("idx_user_created", "created_at"),
+        Index("idx_auth_user_email_active", "email", "is_active"),
+        Index("idx_auth_user_tenant", "tenant_id"),
+        Index("idx_auth_user_created", "created_at"),
     )
 
-    def __repr__(self):
-        return f"<User(id={self.id}, email={self.email})>"
+    def __repr__(self) -> str:  # pragma: no cover - simple repr
+        return f"<AuthUser(user_id={self.user_id}, email={self.email})>"
 
 
-class UserSession(Base):
-    """Production session management"""
-    __tablename__ = "user_sessions"
+class AuthSession(Base):
+    """Session tokens tied to a user"""
 
-    # Primary key
-    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    __tablename__ = "auth_sessions"
 
-    # Foreign key to user
-    user_id = Column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False)
-
-    # Session data
-    session_token = Column(String(255), unique=True, nullable=False, index=True)
-    refresh_token = Column(String(255), unique=True, nullable=True, index=True)
-
-    # Session metadata
-    user_agent = Column(Text, nullable=True)
-    ip_address = Column(String(45), nullable=True)
-    device_fingerprint = Column(String(255), nullable=True)
-
-    # Session state
-    is_active = Column(Boolean, default=True, nullable=False)
-    expires_at = Column(DateTime, nullable=False)
-    last_activity_at = Column(DateTime, default=func.now(), nullable=False)
-
-    # Security flags
-    is_suspicious = Column(Boolean, default=False, nullable=False)
-    risk_score = Column(Integer, default=0, nullable=False)  # 0-100 risk score
-
-    # Timestamps
+    session_token = Column(String, primary_key=True)
+    user_id = Column(String, ForeignKey("auth_users.user_id", ondelete="CASCADE"), nullable=False)
+    access_token = Column(String, nullable=False)
+    refresh_token = Column(String, nullable=False)
+    expires_in = Column(Integer, nullable=False)
     created_at = Column(DateTime, default=func.now(), nullable=False)
-    updated_at = Column(DateTime, default=func.now(), onupdate=func.now(), nullable=False)
+    last_accessed = Column(DateTime, default=func.now(), nullable=False)
+    ip_address = Column(String)
+    user_agent = Column(Text)
+    device_fingerprint = Column(String)
+    geolocation = Column(JSONB)
+    risk_score = Column(Numeric(5, 2), default=0)
+    security_flags = Column(JSONB, default=list)
+    is_active = Column(Boolean, default=True, nullable=False)
+    invalidated_at = Column(DateTime)
+    invalidation_reason = Column(Text)
 
-    # Relationships
-    user = relationship("User", back_populates="sessions")
+    user = relationship("AuthUser", back_populates="sessions")
 
-    # Indexes
     __table_args__ = (
-        Index("idx_session_token_active", "session_token", "is_active"),
-        Index("idx_session_user_active", "user_id", "is_active"),
-        Index("idx_session_expires", "expires_at"),
-        Index("idx_session_activity", "last_activity_at"),
+        Index("idx_auth_sessions_user_active", "user_id", "is_active"),
+        Index("idx_auth_sessions_last_accessed", "last_accessed"),
     )
 
-    def __repr__(self):
-        return f"<UserSession(id={self.id}, user_id={self.user_id})>"
+    def __repr__(self) -> str:  # pragma: no cover - simple repr
+        return f"<AuthSession(session_token={self.session_token}, user_id={self.user_id})>"
+
+
+class AuthProvider(Base):
+    """Authentication provider configuration"""
+
+    __tablename__ = "auth_providers"
+
+    provider_id = Column(String, primary_key=True)
+    tenant_id = Column(String)
+    type = Column(String, nullable=False)
+    config = Column(JSONB, nullable=False)
+    metadata = Column(JSONB, default=dict)
+    enabled = Column(Boolean, default=True)
+    created_at = Column(DateTime, default=func.now())
+    updated_at = Column(DateTime, default=func.now(), onupdate=func.now())
+
+    identities = relationship("UserIdentity", back_populates="provider", cascade="all, delete-orphan")
+
+    def __repr__(self) -> str:  # pragma: no cover
+        return f"<AuthProvider(provider_id={self.provider_id})>"
+
+
+class UserIdentity(Base):
+    """Links a user to an external auth provider identity"""
+
+    __tablename__ = "user_identities"
+
+    identity_id = Column(String, primary_key=True, default=lambda: str(uuid.uuid4()))
+    user_id = Column(String, ForeignKey("auth_users.user_id", ondelete="CASCADE"), nullable=False)
+    provider_id = Column(String, ForeignKey("auth_providers.provider_id"), nullable=False)
+    provider_user = Column(String, nullable=False)
+    metadata = Column(JSONB)
+    created_at = Column(DateTime, default=func.now())
+
+    user = relationship("AuthUser")
+    provider = relationship("AuthProvider", back_populates="identities")
+
+    def __repr__(self) -> str:  # pragma: no cover
+        return f"<UserIdentity(identity_id={self.identity_id}, user_id={self.user_id})>"
 
 
 class ChatMemory(Base):
     """Chat memory metadata for user isolation"""
+
     __tablename__ = "chat_memories"
 
-    # Primary key
-    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-
-    # Foreign key to user
-    user_id = Column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False)
-
-    # Chat identification
+    id = Column(String, primary_key=True, default=lambda: str(uuid.uuid4()))
+    user_id = Column(String, ForeignKey("auth_users.user_id", ondelete="CASCADE"), nullable=False)
     chat_id = Column(String(36), nullable=False, index=True)
-
-    # Memory settings (user-configurable)
     short_term_days = Column(Integer, default=1, nullable=False)
     long_term_days = Column(Integer, default=30, nullable=False)
     tail_turns = Column(Integer, default=3, nullable=False)
     summarize_threshold_tokens = Column(Integer, default=3000, nullable=False)
-
-    # Memory state
     total_turns = Column(Integer, default=0, nullable=False)
-    last_summarized_at = Column(DateTime, nullable=True)
+    last_summarized_at = Column(DateTime)
     current_token_count = Column(Integer, default=0, nullable=False)
-
-    # Timestamps
     created_at = Column(DateTime, default=func.now(), nullable=False)
     updated_at = Column(DateTime, default=func.now(), onupdate=func.now(), nullable=False)
 
-    # Relationships
-    user = relationship("User", back_populates="chat_memories")
+    user = relationship("AuthUser", back_populates="chat_memories")
 
-    # Indexes
     __table_args__ = (
         Index("idx_chat_user_chat", "user_id", "chat_id"),
         Index("idx_chat_updated", "updated_at"),
     )
 
-    def __repr__(self):
+    def __repr__(self) -> str:  # pragma: no cover
         return f"<ChatMemory(id={self.id}, user_id={self.user_id}, chat_id={self.chat_id})>"
 
 
 class PasswordResetToken(Base):
     """Password reset tokens"""
+
     __tablename__ = "password_reset_tokens"
 
-    # Primary key
-    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-
-    # Foreign key to user
-    user_id = Column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False)
-
-    # Token data
+    id = Column(String, primary_key=True, default=lambda: str(uuid.uuid4()))
+    user_id = Column(String, ForeignKey("auth_users.user_id", ondelete="CASCADE"), nullable=False)
     token = Column(String(255), unique=True, nullable=False, index=True)
     expires_at = Column(DateTime, nullable=False)
     is_used = Column(Boolean, default=False, nullable=False)
-
-    # Security tracking
-    ip_address = Column(String(45), nullable=True)
-    user_agent = Column(Text, nullable=True)
-
-    # Timestamps
+    ip_address = Column(String(45))
+    user_agent = Column(Text)
     created_at = Column(DateTime, default=func.now(), nullable=False)
-    used_at = Column(DateTime, nullable=True)
+    used_at = Column(DateTime)
 
-    # Indexes
     __table_args__ = (
         Index("idx_reset_token_expires", "token", "expires_at", "is_used"),
         Index("idx_reset_user", "user_id"),
     )
 
-    def __repr__(self):
+    def __repr__(self) -> str:  # pragma: no cover
         return f"<PasswordResetToken(id={self.id}, user_id={self.user_id})>"
 
 
 class EmailVerificationToken(Base):
     """Email verification tokens"""
+
     __tablename__ = "email_verification_tokens"
 
-    # Primary key
-    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-
-    # Foreign key to user
-    user_id = Column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False)
-
-    # Token data
+    id = Column(String, primary_key=True, default=lambda: str(uuid.uuid4()))
+    user_id = Column(String, ForeignKey("auth_users.user_id", ondelete="CASCADE"), nullable=False)
     token = Column(String(255), unique=True, nullable=False, index=True)
     expires_at = Column(DateTime, nullable=False)
     is_used = Column(Boolean, default=False, nullable=False)
-
-    # Timestamps
     created_at = Column(DateTime, default=func.now(), nullable=False)
-    used_at = Column(DateTime, nullable=True)
+    used_at = Column(DateTime)
 
-    # Indexes
     __table_args__ = (
         Index("idx_verify_token_expires", "token", "expires_at", "is_used"),
         Index("idx_verify_user", "user_id"),
     )
 
-    def __repr__(self):
+    def __repr__(self) -> str:  # pragma: no cover
         return f"<EmailVerificationToken(id={self.id}, user_id={self.user_id})>"

--- a/src/ai_karen_engine/database/seed/__init__.py
+++ b/src/ai_karen_engine/database/seed/__init__.py
@@ -1,0 +1,5 @@
+"""Bootstrap seed helpers for authentication tables."""
+
+from .auth_seed import seed_default_auth
+
+__all__ = ["seed_default_auth"]

--- a/src/ai_karen_engine/database/seed/auth_seed.py
+++ b/src/ai_karen_engine/database/seed/auth_seed.py
@@ -1,0 +1,38 @@
+"""Seed data for authentication tables."""
+
+import uuid
+from datetime import datetime
+from typing import Sequence
+
+from sqlalchemy.orm import Session
+
+from ai_karen_engine.database.models.auth_models import AuthUser, AuthProvider
+
+
+def seed_default_auth(session: Session) -> None:
+    """Insert default auth provider and admin user if missing."""
+    if not session.query(AuthProvider).filter_by(provider_id="local").first():
+        provider = AuthProvider(
+            provider_id="local",
+            type="local",
+            config={},
+            metadata={},
+        )
+        session.add(provider)
+
+    if not session.query(AuthUser).filter_by(email="admin@karen.ai").first():
+        admin = AuthUser(
+            user_id=str(uuid.uuid4()),
+            email="admin@karen.ai",
+            full_name="Admin User",
+            password_hash="change-me",
+            is_active=True,
+            is_verified=True,
+            roles=["admin", "user"],
+            tenant_id="default",
+            created_at=datetime.utcnow(),
+            updated_at=datetime.utcnow(),
+        )
+        session.add(admin)
+
+    session.commit()

--- a/tests/test_multitenant_database.py
+++ b/tests/test_multitenant_database.py
@@ -9,7 +9,7 @@ from datetime import datetime
 
 # Test imports
 try:
-    from src.ai_karen_engine.database.models import Base, Tenant, User, TenantConversation, TenantMemoryEntry
+    from src.ai_karen_engine.database.models import Base, Tenant, AuthUser, TenantConversation, TenantMemoryEntry
     from src.ai_karen_engine.database.client import MultiTenantPostgresClient
     from src.ai_karen_engine.database.migrations import MigrationManager
     from src.ai_karen_engine.clients.database.postgres_client import PostgresClient
@@ -44,19 +44,19 @@ class TestMultiTenantModels:
         assert tenant.settings == {}
     
     def test_user_model_creation(self):
-        """Test User model creation and relationships."""
-        tenant_id = uuid.uuid4()
-        user_id = uuid.uuid4()
-        
-        user = User(
-            id=user_id,
+        """Test AuthUser model creation and relationships."""
+        tenant_id = "tenant-123"
+        user_id = str(uuid.uuid4())
+
+        user = AuthUser(
+            user_id=user_id,
             tenant_id=tenant_id,
             email="test@example.com",
             roles=["end_user", "analyst"],
-            is_active=True  # Explicitly set for testing
+            is_active=True,
         )
-        
-        assert user.id == user_id
+
+        assert user.user_id == user_id
         assert user.tenant_id == tenant_id
         assert user.email == "test@example.com"
         assert user.roles == ["end_user", "analyst"]

--- a/tests/test_user_database_integration.py
+++ b/tests/test_user_database_integration.py
@@ -200,7 +200,7 @@ def test_database_integration():
     
     try:
         from ai_karen_engine.database.client import MultiTenantPostgresClient
-        from ai_karen_engine.database.models import User, Tenant
+        from ai_karen_engine.database.models import AuthUser, Tenant
         
         # Initialize database client
         db_client = MultiTenantPostgresClient()


### PR DESCRIPTION
## Summary
- migrate database schema to auth_users/auth_sessions tables with provider metadata
- add SQLAlchemy models and seed helpers for auth providers and identities
- update scripts, services, and tests to use AuthUser/AuthSession

## Testing
- `python -m compileall create_test_user.py scripts/init_auth_database.py scripts/create_production_db.py scripts/multitenant_cli.py src/ai_karen_engine/database/models/auth_models.py src/ai_karen_engine/database/models/__init__.py src/ai_karen_engine/services/user_service.py src/ai_karen_engine/database/conversation_manager.py src/ai_karen_engine/chat/enhanced_conversation_manager.py src/ai_karen_engine/database/seed/auth_seed.py examples/multitenant_demo.py tests/test_multitenant_database.py tests/test_user_database_integration.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'ai_karen_engine')*

------
https://chatgpt.com/codex/tasks/task_e_6895bb8f848c8324ab79bf25796ef2d1