### PR TITLE
feat: add external auth provider models and logic

### DIFF
--- a/src/ai_karen_engine/auth/core.py
+++ b/src/ai_karen_engine/auth/core.py
@@ -11,6 +11,7 @@ from uuid import uuid4
 import bcrypt
 
 from .config import AuthConfig
+from .database import DatabaseClient
 from .exceptions import (
     AccountDisabledError,
     AccountLockedError,
@@ -22,44 +23,43 @@ from .exceptions import (
     UserNotFoundError,
 )
 from .models import AuthEvent, AuthEventType, SessionData, UserData
-from .database import DatabaseClient
 from .session import SessionManager
 from .tokens import TokenManager
 
 
 class PasswordHasher:
     """Secure password hashing using bcrypt."""
-    
+
     def __init__(self, rounds: int = 12) -> None:
         """Initialize password hasher with specified bcrypt rounds."""
         if not (4 <= rounds <= 20):
             raise ValueError("Bcrypt rounds must be between 4 and 20")
         self.rounds = rounds
-    
+
     def hash_password(self, password: str) -> str:
         """Hash a password using bcrypt."""
         if not password:
             raise ValueError("Password cannot be empty")
-        
+
         salt = bcrypt.gensalt(rounds=self.rounds)
-        hashed = bcrypt.hashpw(password.encode('utf-8'), salt)
-        return hashed.decode('utf-8')
-    
+        hashed = bcrypt.hashpw(password.encode("utf-8"), salt)
+        return hashed.decode("utf-8")
+
     def verify_password(self, password: str, hashed: str) -> bool:
         """Verify a password against its hash."""
         if not password or not hashed:
             return False
-        
+
         try:
-            return bcrypt.checkpw(password.encode('utf-8'), hashed.encode('utf-8'))
+            return bcrypt.checkpw(password.encode("utf-8"), hashed.encode("utf-8"))
         except (ValueError, TypeError):
             return False
-    
+
     def needs_rehash(self, hashed: str) -> bool:
         """Check if a password hash needs to be updated."""
         try:
-            parts = hashed.split('$')
-            if len(parts) >= 3 and parts[1] == '2b':
+            parts = hashed.split("$")
+            if len(parts) >= 3 and parts[1] == "2b":
                 current_rounds = int(parts[2])
                 return current_rounds < self.rounds
         except (ValueError, IndexError):
@@ -69,29 +69,31 @@ class PasswordHasher:
 
 class PasswordValidator:
     """Password validation according to security requirements."""
-    
+
     def __init__(self, min_length: int = 8, require_complexity: bool = True) -> None:
         """Initialize password validator with requirements."""
         self.min_length = min_length
         self.require_complexity = require_complexity
-    
+
     def validate_password(self, password: str) -> Tuple[bool, List[str]]:
         """Validate password against requirements."""
         errors = []
-        
+
         if not password:
             errors.append("Password is required")
             return False, errors
-        
+
         if len(password) < self.min_length:
-            errors.append(f"Password must be at least {self.min_length} characters long")
-        
+            errors.append(
+                f"Password must be at least {self.min_length} characters long"
+            )
+
         if self.require_complexity:
             has_upper = any(c.isupper() for c in password)
             has_lower = any(c.islower() for c in password)
             has_digit = any(c.isdigit() for c in password)
             has_special = any(c in "!@#$%^&*()_+-=[]{}|;:,.<>?" for c in password)
-            
+
             if not has_upper:
                 errors.append("Password must contain at least one uppercase letter")
             if not has_lower:
@@ -100,13 +102,13 @@ class PasswordValidator:
                 errors.append("Password must contain at least one digit")
             if not has_special:
                 errors.append("Password must contain at least one special character")
-        
+
         return len(errors) == 0, errors
 
 
 class CoreAuthenticator:
     """Core authentication logic without advanced security or intelligence features."""
-    
+
     def __init__(self, config: AuthConfig) -> None:
         """Initialize core authenticator with configuration."""
         self.config = config
@@ -116,24 +118,24 @@ class CoreAuthenticator:
         self.password_hasher = PasswordHasher(config.security.password_hash_rounds)
         self.password_validator = PasswordValidator(
             min_length=config.security.min_password_length,
-            require_complexity=config.security.require_password_complexity
+            require_complexity=config.security.require_password_complexity,
         )
-    
+
     async def authenticate_user(
         self,
         email: str,
         password: str,
         ip_address: str = "unknown",
         user_agent: str = "",
-        **kwargs
+        **kwargs,
     ) -> Optional[UserData]:
         """Authenticate a user with email and password."""
         start_time = datetime.utcnow()
-        
+
         try:
             if not email or not password:
                 raise InvalidCredentialsError("Email and password are required")
-            
+
             user_data = await self.db_client.get_user_by_email(email)
             if not user_data:
                 await self._log_auth_event(
@@ -143,40 +145,51 @@ class CoreAuthenticator:
                     user_agent=user_agent,
                     success=False,
                     error_message="User not found",
-                    start_time=start_time
+                    start_time=start_time,
                 )
                 raise InvalidCredentialsError()
-            
+
             if not user_data.is_active:
                 raise AccountDisabledError(user_id=user_data.user_id)
-            
+
             if user_data.is_locked():
                 raise AccountLockedError(
-                    locked_until=user_data.locked_until.isoformat() if user_data.locked_until else None,
-                    failed_attempts=user_data.failed_login_attempts
+                    locked_until=user_data.locked_until.isoformat()
+                    if user_data.locked_until
+                    else None,
+                    failed_attempts=user_data.failed_login_attempts,
                 )
-            
-            password_hash = await self.db_client.get_user_password_hash(user_data.user_id)
+
+            password_hash = await self.db_client.get_user_password_hash(
+                user_data.user_id
+            )
             if not password_hash:
                 raise InvalidCredentialsError()
-            
+
             if not self.password_hasher.verify_password(password, password_hash):
                 user_data.increment_failed_attempts()
-                
-                if user_data.failed_login_attempts >= self.config.security.max_failed_attempts:
-                    user_data.lock_account(self.config.security.lockout_duration_minutes)
-                
+
+                if (
+                    user_data.failed_login_attempts
+                    >= self.config.security.max_failed_attempts
+                ):
+                    user_data.lock_account(
+                        self.config.security.lockout_duration_minutes
+                    )
+
                 await self.db_client.update_user(user_data)
                 raise InvalidCredentialsError()
-            
+
             user_data.reset_failed_attempts()
             user_data.update_last_login()
             await self.db_client.update_user(user_data)
-            
+
             if self.password_hasher.needs_rehash(password_hash):
                 new_hash = self.password_hasher.hash_password(password)
-                await self.db_client.update_user_password_hash(user_data.user_id, new_hash)
-            
+                await self.db_client.update_user_password_hash(
+                    user_data.user_id, new_hash
+                )
+
             await self._log_auth_event(
                 AuthEventType.LOGIN_SUCCESS,
                 user_id=user_data.user_id,
@@ -184,13 +197,15 @@ class CoreAuthenticator:
                 ip_address=ip_address,
                 user_agent=user_agent,
                 success=True,
-                start_time=start_time
+                start_time=start_time,
             )
-            
+
             return user_data
-            
+
         except Exception as e:
-            if not isinstance(e, (InvalidCredentialsError, AccountLockedError, AccountDisabledError)):
+            if not isinstance(
+                e, (InvalidCredentialsError, AccountLockedError, AccountDisabledError)
+            ):
                 await self._log_auth_event(
                     AuthEventType.LOGIN_FAILED,
                     email=email,
@@ -198,21 +213,81 @@ class CoreAuthenticator:
                     user_agent=user_agent,
                     success=False,
                     error_message=str(e),
-                    start_time=start_time
+                    start_time=start_time,
                 )
             raise
-    
+
+    async def authenticate_external(
+        self,
+        provider_id: str,
+        provider_type: str,
+        provider_user: str,
+        email: Optional[str] = None,
+        full_name: Optional[str] = None,
+        config: Optional[Dict[str, Any]] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        tenant_id: str = "default",
+        **kwargs,
+    ) -> Optional[UserData]:
+        """Authenticate a user via external identity provider."""
+        start_time = datetime.utcnow()
+
+        # Ensure provider record exists
+        provider = await self.db_client.get_auth_provider(provider_id)
+        if not provider:
+            await self.db_client.upsert_auth_provider(
+                provider_id,
+                provider_type,
+                config or {},
+                metadata={},
+                tenant_id=tenant_id,
+            )
+
+        identity = await self.db_client.get_user_identity(provider_id, provider_user)
+        if identity:
+            user = await self.db_client.get_user_by_id(identity["user_id"])
+        else:
+            user = None
+            if email:
+                user = await self.db_client.get_user_by_email(email)
+
+            if not user and email:
+                random_password = str(uuid4()) + "Aa1!"
+                user = await self.create_user(
+                    email=email,
+                    password=random_password,
+                    full_name=full_name,
+                    tenant_id=tenant_id,
+                )
+
+            if not user:
+                return None
+
+            await self.db_client.link_user_identity(
+                user.user_id, provider_id, provider_user, metadata
+            )
+
+        await self._log_auth_event(
+            AuthEventType.LOGIN_SUCCESS,
+            user_id=user.user_id,
+            email=user.email,
+            success=True,
+            start_time=start_time,
+        )
+
+        return user
+
     async def create_session(
         self,
         user_data: UserData,
         ip_address: str = "unknown",
         user_agent: str = "",
         device_fingerprint: Optional[str] = None,
-        **kwargs
+        **kwargs,
     ) -> SessionData:
         """Create a new authentication session for a user."""
         start_time = datetime.utcnow()
-        
+
         try:
             session_data = await self.session_manager.create_session(
                 user_data,
@@ -220,7 +295,7 @@ class CoreAuthenticator:
                 user_agent=user_agent,
                 device_fingerprint=device_fingerprint,
             )
-            
+
             await self._log_auth_event(
                 AuthEventType.SESSION_CREATED,
                 user_id=user_data.user_id,
@@ -229,7 +304,7 @@ class CoreAuthenticator:
                 user_agent=user_agent,
                 session_token=session_data.session_token,
                 success=True,
-                start_time=start_time
+                start_time=start_time,
             )
 
             return session_data
@@ -243,15 +318,17 @@ class CoreAuthenticator:
                 user_agent=user_agent,
                 success=False,
                 error_message=str(e),
-                start_time=start_time
+                start_time=start_time,
             )
             raise
-    
-    async def validate_session(self, session_token: str, **kwargs) -> Optional[UserData]:
+
+    async def validate_session(
+        self, session_token: str, **kwargs
+    ) -> Optional[UserData]:
         """Validate a session token and return user data if valid."""
         if not session_token:
             raise SessionNotFoundError()
-        
+
         try:
             session_data = await self.session_manager.store.get_session(session_token)
             if not session_data:
@@ -268,30 +345,32 @@ class CoreAuthenticator:
 
         except (SessionExpiredError, SessionNotFoundError):
             raise
-    
-    async def invalidate_session(self, session_token: str, reason: str = "manual", **kwargs) -> bool:
+
+    async def invalidate_session(
+        self, session_token: str, reason: str = "manual", **kwargs
+    ) -> bool:
         """Invalidate a session token."""
         if not session_token:
             return False
-        
+
         try:
             session_data = await self.session_manager.store.get_session(session_token)
             deleted = await self.session_manager.delete_session(session_token)
-            
+
             if deleted and session_data:
                 await self._log_auth_event(
                     AuthEventType.SESSION_INVALIDATED,
                     user_id=session_data.user_data.user_id,
                     session_token=session_token,
                     success=True,
-                    details={"reason": reason}
+                    details={"reason": reason},
                 )
-            
+
             return deleted
-            
+
         except Exception:
             return False
-    
+
     async def create_user(
         self,
         email: str,
@@ -299,28 +378,27 @@ class CoreAuthenticator:
         full_name: Optional[str] = None,
         tenant_id: str = "default",
         roles: Optional[List[str]] = None,
-        **kwargs
+        **kwargs,
     ) -> UserData:
         """Create a new user account."""
         start_time = datetime.utcnow()
-        
+
         try:
             if not email or "@" not in email:
                 raise PasswordValidationError("Invalid email format")
-            
+
             is_valid, errors = self.password_validator.validate_password(password)
             if not is_valid:
                 raise PasswordValidationError(
-                    message="Password validation failed",
-                    requirements=errors
+                    message="Password validation failed", requirements=errors
                 )
-            
+
             existing_user = await self.db_client.get_user_by_email(email)
             if existing_user:
                 raise UserAlreadyExistsError(email=email)
-            
+
             password_hash = self.password_hasher.hash_password(password)
-            
+
             user_data = UserData(
                 user_id=str(uuid4()),
                 email=email,
@@ -328,78 +406,79 @@ class CoreAuthenticator:
                 tenant_id=tenant_id,
                 roles=roles or ["user"],
                 is_verified=not self.config.features.enable_email_verification,
-                **kwargs
+                **kwargs,
             )
-            
+
             await self.db_client.create_user(user_data, password_hash)
-            
+
             await self._log_auth_event(
                 AuthEventType.USER_CREATED,
                 user_id=user_data.user_id,
                 email=email,
                 success=True,
-                start_time=start_time
+                start_time=start_time,
             )
-            
+
             return user_data
-            
+
         except (UserAlreadyExistsError, PasswordValidationError):
             raise
-    
+
     async def update_user_password(
         self,
         user_id: str,
         new_password: str,
         current_password: Optional[str] = None,
-        **kwargs
+        **kwargs,
     ) -> bool:
         """Update a user's password."""
         start_time = datetime.utcnow()
-        
+
         try:
             user_data = await self.db_client.get_user_by_id(user_id)
             if not user_data:
                 raise UserNotFoundError(user_id=user_id)
-            
+
             if current_password:
                 current_hash = await self.db_client.get_user_password_hash(user_id)
-                if not current_hash or not self.password_hasher.verify_password(current_password, current_hash):
+                if not current_hash or not self.password_hasher.verify_password(
+                    current_password, current_hash
+                ):
                     raise InvalidCredentialsError("Current password is incorrect")
-            
+
             is_valid, errors = self.password_validator.validate_password(new_password)
             if not is_valid:
                 raise PasswordValidationError(
-                    message="New password validation failed",
-                    requirements=errors
+                    message="New password validation failed", requirements=errors
                 )
-            
+
             new_hash = self.password_hasher.hash_password(new_password)
             await self.db_client.update_user_password_hash(user_id, new_hash)
-            
+
             user_data.updated_at = datetime.utcnow()
             await self.db_client.update_user(user_data)
-            
+
             await self._log_auth_event(
                 AuthEventType.PASSWORD_CHANGED,
                 user_id=user_id,
                 email=user_data.email,
                 success=True,
-                start_time=start_time
+                start_time=start_time,
             )
-            
+
             return True
-            
+
         except (UserNotFoundError, InvalidCredentialsError, PasswordValidationError):
             raise
-    
+
     async def get_user_by_id(self, user_id: str) -> Optional[UserData]:
         """Get user data by user ID."""
         return await self.db_client.get_user_by_id(user_id)
-    
+
     async def get_user_by_email(self, email: str) -> Optional[UserData]:
         """Get user data by email address."""
         return await self.db_client.get_user_by_email(email)
-    
+
     async def _log_auth_event(
         self,
         event_type: AuthEventType,
@@ -411,7 +490,7 @@ class CoreAuthenticator:
         success: bool = True,
         error_message: Optional[str] = None,
         details: Optional[Dict[str, Any]] = None,
-        start_time: Optional[datetime] = None
+        start_time: Optional[datetime] = None,
     ) -> None:
         """Log an authentication event."""
         try:
@@ -424,14 +503,14 @@ class CoreAuthenticator:
                 session_token=session_token,
                 success=success,
                 error_message=error_message,
-                details=details or {}
+                details=details or {},
             )
-            
+
             if start_time:
                 event.set_processing_time(start_time)
-            
+
             if self.config.security.enable_audit_logging:
                 await self.db_client.store_auth_event(event)
-                
+
         except Exception:
             pass

--- a/src/ai_karen_engine/auth/database.py
+++ b/src/ai_karen_engine/auth/database.py
@@ -13,6 +13,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 from urllib.parse import urlparse
+from uuid import uuid4
 
 from .config import DatabaseConfig
 from .exceptions import DatabaseConnectionError, DatabaseOperationError
@@ -22,53 +23,60 @@ from .models import AuthEvent, UserData
 class DatabaseClient:
     """
     Database client for authentication operations.
-    
+
     Supports SQLite for development and can be extended for PostgreSQL
     and other databases in production.
     """
-    
+
     def __init__(self, config: DatabaseConfig) -> None:
         """Initialize database client with configuration."""
         self.config = config
         self.connection: Optional[sqlite3.Connection] = None
         self._setup_database()
-    
+
     def _setup_database(self) -> None:
         """Set up database connection and create tables if needed."""
         try:
             # Parse database URL
             parsed = urlparse(self.config.database_url)
-            
+
             if parsed.scheme == "sqlite":
                 # Extract path from URL (remove leading slash for relative paths)
-                db_path = parsed.path.lstrip("/") if parsed.path.startswith("/") else parsed.path
-                
+                db_path = (
+                    parsed.path.lstrip("/")
+                    if parsed.path.startswith("/")
+                    else parsed.path
+                )
+
                 # Create directory if it doesn't exist
                 Path(db_path).parent.mkdir(parents=True, exist_ok=True)
-                
+
                 # Connect to SQLite database
                 self.connection = sqlite3.connect(
                     db_path,
                     timeout=self.config.connection_timeout_seconds,
-                    check_same_thread=False
+                    check_same_thread=False,
                 )
                 self.connection.row_factory = sqlite3.Row
-                
+
                 # Create tables
                 self._create_tables()
             else:
-                raise DatabaseConnectionError(f"Unsupported database scheme: {parsed.scheme}")
-                
+                raise DatabaseConnectionError(
+                    f"Unsupported database scheme: {parsed.scheme}"
+                )
+
         except Exception as e:
             raise DatabaseConnectionError(f"Failed to connect to database: {e}")
-    
+
     def _create_tables(self) -> None:
         """Create database tables if they don't exist."""
         try:
             cursor = self.connection.cursor()
-            
+
             # Users table
-            cursor.execute("""
+            cursor.execute(
+                """
                 CREATE TABLE IF NOT EXISTS auth_users (
                     user_id TEXT PRIMARY KEY,
                     email TEXT UNIQUE NOT NULL,
@@ -86,10 +94,12 @@ class DatabaseClient:
                     two_factor_enabled BOOLEAN NOT NULL DEFAULT 0,
                     two_factor_secret TEXT
                 )
-            """)
-            
+            """
+            )
+
             # Password hashes table (separate for security)
-            cursor.execute("""
+            cursor.execute(
+                """
                 CREATE TABLE IF NOT EXISTS auth_password_hashes (
                     user_id TEXT PRIMARY KEY,
                     password_hash TEXT NOT NULL,
@@ -97,10 +107,12 @@ class DatabaseClient:
                     updated_at TEXT NOT NULL,
                     FOREIGN KEY (user_id) REFERENCES auth_users (user_id) ON DELETE CASCADE
                 )
-            """)
-            
+            """
+            )
+
             # Sessions table
-            cursor.execute("""
+            cursor.execute(
+                """
                 CREATE TABLE IF NOT EXISTS auth_sessions (
                     session_token TEXT PRIMARY KEY,
                     user_id TEXT NOT NULL,
@@ -120,10 +132,45 @@ class DatabaseClient:
                     invalidation_reason TEXT,
                     FOREIGN KEY (user_id) REFERENCES auth_users (user_id) ON DELETE CASCADE
                 )
-            """)
-            
+            """
+            )
+
+            # Authentication providers
+            cursor.execute(
+                """
+                CREATE TABLE IF NOT EXISTS auth_providers (
+                    provider_id TEXT PRIMARY KEY,
+                    tenant_id TEXT,
+                    type TEXT NOT NULL,
+                    config TEXT NOT NULL,
+                    metadata TEXT NOT NULL DEFAULT '{}',
+                    enabled BOOLEAN NOT NULL DEFAULT 1,
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL
+                )
+            """
+            )
+
+            # External user identities
+            cursor.execute(
+                """
+                CREATE TABLE IF NOT EXISTS user_identities (
+                    identity_id TEXT PRIMARY KEY,
+                    user_id TEXT NOT NULL,
+                    provider_id TEXT NOT NULL,
+                    provider_user TEXT NOT NULL,
+                    metadata TEXT,
+                    created_at TEXT NOT NULL,
+                    FOREIGN KEY (user_id) REFERENCES auth_users (user_id) ON DELETE CASCADE,
+                    FOREIGN KEY (provider_id) REFERENCES auth_providers (provider_id),
+                    UNIQUE (provider_id, provider_user)
+                )
+            """
+            )
+
             # Password reset tokens table
-            cursor.execute("""
+            cursor.execute(
+                """
                 CREATE TABLE IF NOT EXISTS auth_password_reset_tokens (
                     token_id TEXT PRIMARY KEY,
                     user_id TEXT NOT NULL,
@@ -135,10 +182,12 @@ class DatabaseClient:
                     user_agent TEXT NOT NULL DEFAULT '',
                     FOREIGN KEY (user_id) REFERENCES auth_users (user_id) ON DELETE CASCADE
                 )
-            """)
-            
+            """
+            )
+
             # Email verification tokens table
-            cursor.execute("""
+            cursor.execute(
+                """
                 CREATE TABLE IF NOT EXISTS auth_email_verification_tokens (
                     token_id TEXT PRIMARY KEY,
                     user_id TEXT NOT NULL,
@@ -150,10 +199,12 @@ class DatabaseClient:
                     user_agent TEXT NOT NULL DEFAULT '',
                     FOREIGN KEY (user_id) REFERENCES auth_users (user_id) ON DELETE CASCADE
                 )
-            """)
-            
+            """
+            )
+
             # Auth events table for audit logging
-            cursor.execute("""
+            cursor.execute(
+                """
                 CREATE TABLE IF NOT EXISTS auth_events (
                     event_id TEXT PRIMARY KEY,
                     event_type TEXT NOT NULL,
@@ -174,168 +225,385 @@ class DatabaseClient:
                     processing_time_ms REAL NOT NULL DEFAULT 0.0,
                     service_version TEXT NOT NULL DEFAULT 'consolidated-auth-v1'
                 )
-            """)
-            
+            """
+            )
+
             # Create indexes for performance
-            cursor.execute("CREATE INDEX IF NOT EXISTS idx_auth_users_email ON auth_users (email)")
-            cursor.execute("CREATE INDEX IF NOT EXISTS idx_auth_users_tenant ON auth_users (tenant_id)")
-            cursor.execute("CREATE INDEX IF NOT EXISTS idx_auth_sessions_user ON auth_sessions (user_id)")
-            cursor.execute("CREATE INDEX IF NOT EXISTS idx_auth_sessions_active ON auth_sessions (is_active)")
-            cursor.execute("CREATE INDEX IF NOT EXISTS idx_auth_password_reset_tokens_user ON auth_password_reset_tokens (user_id)")
-            cursor.execute("CREATE INDEX IF NOT EXISTS idx_auth_password_reset_tokens_expires ON auth_password_reset_tokens (expires_at)")
-            cursor.execute("CREATE INDEX IF NOT EXISTS idx_auth_email_verification_tokens_user ON auth_email_verification_tokens (user_id)")
-            cursor.execute("CREATE INDEX IF NOT EXISTS idx_auth_email_verification_tokens_expires ON auth_email_verification_tokens (expires_at)")
-            cursor.execute("CREATE INDEX IF NOT EXISTS idx_auth_events_user ON auth_events (user_id)")
-            cursor.execute("CREATE INDEX IF NOT EXISTS idx_auth_events_type ON auth_events (event_type)")
-            cursor.execute("CREATE INDEX IF NOT EXISTS idx_auth_events_timestamp ON auth_events (timestamp)")
-            
+            cursor.execute(
+                "CREATE INDEX IF NOT EXISTS idx_auth_users_email ON auth_users (email)"
+            )
+            cursor.execute(
+                "CREATE INDEX IF NOT EXISTS idx_auth_users_tenant ON auth_users (tenant_id)"
+            )
+            cursor.execute(
+                "CREATE INDEX IF NOT EXISTS idx_auth_sessions_user ON auth_sessions (user_id)"
+            )
+            cursor.execute(
+                "CREATE INDEX IF NOT EXISTS idx_auth_sessions_active ON auth_sessions (is_active)"
+            )
+            cursor.execute(
+                "CREATE INDEX IF NOT EXISTS idx_user_identity_user ON user_identities (user_id)"
+            )
+            cursor.execute(
+                "CREATE INDEX IF NOT EXISTS idx_auth_password_reset_tokens_user ON auth_password_reset_tokens (user_id)"
+            )
+            cursor.execute(
+                "CREATE INDEX IF NOT EXISTS idx_auth_password_reset_tokens_expires ON auth_password_reset_tokens (expires_at)"
+            )
+            cursor.execute(
+                "CREATE INDEX IF NOT EXISTS idx_auth_email_verification_tokens_user ON auth_email_verification_tokens (user_id)"
+            )
+            cursor.execute(
+                "CREATE INDEX IF NOT EXISTS idx_auth_email_verification_tokens_expires ON auth_email_verification_tokens (expires_at)"
+            )
+            cursor.execute(
+                "CREATE INDEX IF NOT EXISTS idx_auth_events_user ON auth_events (user_id)"
+            )
+            cursor.execute(
+                "CREATE INDEX IF NOT EXISTS idx_auth_events_type ON auth_events (event_type)"
+            )
+            cursor.execute(
+                "CREATE INDEX IF NOT EXISTS idx_auth_events_timestamp ON auth_events (timestamp)"
+            )
+
             self.connection.commit()
-            
+
         except Exception as e:
-            raise DatabaseOperationError(f"Failed to create tables: {e}", operation="create_tables")
-    
+            raise DatabaseOperationError(
+                f"Failed to create tables: {e}", operation="create_tables"
+            )
+
     async def create_user(self, user_data: UserData, password_hash: str) -> None:
         """Create a new user with password hash."""
         try:
             cursor = self.connection.cursor()
-            
+
             # Insert user data
-            cursor.execute("""
+            cursor.execute(
+                """
                 INSERT INTO auth_users (
                     user_id, email, full_name, roles, tenant_id, preferences,
                     is_verified, is_active, created_at, updated_at, last_login_at,
                     failed_login_attempts, locked_until, two_factor_enabled, two_factor_secret
                 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            """, (
-                user_data.user_id,
-                user_data.email,
-                user_data.full_name,
-                json.dumps(user_data.roles),
-                user_data.tenant_id,
-                json.dumps(user_data.preferences),
-                user_data.is_verified,
-                user_data.is_active,
-                user_data.created_at.isoformat(),
-                user_data.updated_at.isoformat(),
-                user_data.last_login_at.isoformat() if user_data.last_login_at else None,
-                user_data.failed_login_attempts,
-                user_data.locked_until.isoformat() if user_data.locked_until else None,
-                user_data.two_factor_enabled,
-                user_data.two_factor_secret
-            ))
-            
+            """,
+                (
+                    user_data.user_id,
+                    user_data.email,
+                    user_data.full_name,
+                    json.dumps(user_data.roles),
+                    user_data.tenant_id,
+                    json.dumps(user_data.preferences),
+                    user_data.is_verified,
+                    user_data.is_active,
+                    user_data.created_at.isoformat(),
+                    user_data.updated_at.isoformat(),
+                    user_data.last_login_at.isoformat()
+                    if user_data.last_login_at
+                    else None,
+                    user_data.failed_login_attempts,
+                    user_data.locked_until.isoformat()
+                    if user_data.locked_until
+                    else None,
+                    user_data.two_factor_enabled,
+                    user_data.two_factor_secret,
+                ),
+            )
+
             # Insert password hash
-            cursor.execute("""
+            cursor.execute(
+                """
                 INSERT INTO auth_password_hashes (user_id, password_hash, created_at, updated_at)
                 VALUES (?, ?, ?, ?)
-            """, (
-                user_data.user_id,
-                password_hash,
-                datetime.utcnow().isoformat(),
-                datetime.utcnow().isoformat()
-            ))
-            
+            """,
+                (
+                    user_data.user_id,
+                    password_hash,
+                    datetime.utcnow().isoformat(),
+                    datetime.utcnow().isoformat(),
+                ),
+            )
+
             self.connection.commit()
-            
+
         except sqlite3.IntegrityError as e:
             if "UNIQUE constraint failed" in str(e):
-                raise DatabaseOperationError("User already exists", operation="create_user")
-            raise DatabaseOperationError(f"Database integrity error: {e}", operation="create_user")
+                raise DatabaseOperationError(
+                    "User already exists", operation="create_user"
+                )
+            raise DatabaseOperationError(
+                f"Database integrity error: {e}", operation="create_user"
+            )
         except Exception as e:
             self.connection.rollback()
-            raise DatabaseOperationError(f"Failed to create user: {e}", operation="create_user")
-    
+            raise DatabaseOperationError(
+                f"Failed to create user: {e}", operation="create_user"
+            )
+
     async def get_user_by_id(self, user_id: str) -> Optional[UserData]:
         """Get user data by user ID."""
         try:
             cursor = self.connection.cursor()
             cursor.execute("SELECT * FROM auth_users WHERE user_id = ?", (user_id,))
             row = cursor.fetchone()
-            
+
             if not row:
                 return None
-            
+
             return self._row_to_user_data(row)
-            
+
         except Exception as e:
-            raise DatabaseOperationError(f"Failed to get user by ID: {e}", operation="get_user")
-    
+            raise DatabaseOperationError(
+                f"Failed to get user by ID: {e}", operation="get_user"
+            )
+
     async def get_user_by_email(self, email: str) -> Optional[UserData]:
         """Get user data by email address."""
         try:
             cursor = self.connection.cursor()
             cursor.execute("SELECT * FROM auth_users WHERE email = ?", (email,))
             row = cursor.fetchone()
-            
+
             if not row:
                 return None
-            
+
             return self._row_to_user_data(row)
-            
+
         except Exception as e:
-            raise DatabaseOperationError(f"Failed to get user by email: {e}", operation="get_user")
-    
+            raise DatabaseOperationError(
+                f"Failed to get user by email: {e}", operation="get_user"
+            )
+
     async def update_user(self, user_data: UserData) -> None:
         """Update user data."""
         try:
             cursor = self.connection.cursor()
-            cursor.execute("""
+            cursor.execute(
+                """
                 UPDATE auth_users SET
                     email = ?, full_name = ?, roles = ?, tenant_id = ?, preferences = ?,
                     is_verified = ?, is_active = ?, updated_at = ?, last_login_at = ?,
                     failed_login_attempts = ?, locked_until = ?, two_factor_enabled = ?,
                     two_factor_secret = ?
                 WHERE user_id = ?
-            """, (
-                user_data.email,
-                user_data.full_name,
-                json.dumps(user_data.roles),
-                user_data.tenant_id,
-                json.dumps(user_data.preferences),
-                user_data.is_verified,
-                user_data.is_active,
-                user_data.updated_at.isoformat(),
-                user_data.last_login_at.isoformat() if user_data.last_login_at else None,
-                user_data.failed_login_attempts,
-                user_data.locked_until.isoformat() if user_data.locked_until else None,
-                user_data.two_factor_enabled,
-                user_data.two_factor_secret,
-                user_data.user_id
-            ))
-            
+            """,
+                (
+                    user_data.email,
+                    user_data.full_name,
+                    json.dumps(user_data.roles),
+                    user_data.tenant_id,
+                    json.dumps(user_data.preferences),
+                    user_data.is_verified,
+                    user_data.is_active,
+                    user_data.updated_at.isoformat(),
+                    user_data.last_login_at.isoformat()
+                    if user_data.last_login_at
+                    else None,
+                    user_data.failed_login_attempts,
+                    user_data.locked_until.isoformat()
+                    if user_data.locked_until
+                    else None,
+                    user_data.two_factor_enabled,
+                    user_data.two_factor_secret,
+                    user_data.user_id,
+                ),
+            )
+
             self.connection.commit()
-            
+
         except Exception as e:
             self.connection.rollback()
-            raise DatabaseOperationError(f"Failed to update user: {e}", operation="update_user")
-    
+            raise DatabaseOperationError(
+                f"Failed to update user: {e}", operation="update_user"
+            )
+
     async def get_user_password_hash(self, user_id: str) -> Optional[str]:
         """Get password hash for a user."""
         try:
             cursor = self.connection.cursor()
-            cursor.execute("SELECT password_hash FROM auth_password_hashes WHERE user_id = ?", (user_id,))
+            cursor.execute(
+                "SELECT password_hash FROM auth_password_hashes WHERE user_id = ?",
+                (user_id,),
+            )
             row = cursor.fetchone()
-            
+
             return row["password_hash"] if row else None
-            
+
         except Exception as e:
-            raise DatabaseOperationError(f"Failed to get password hash: {e}", operation="get_password_hash")
-    
+            raise DatabaseOperationError(
+                f"Failed to get password hash: {e}", operation="get_password_hash"
+            )
+
     async def update_user_password_hash(self, user_id: str, password_hash: str) -> None:
         """Update password hash for a user."""
         try:
             cursor = self.connection.cursor()
-            cursor.execute("""
+            cursor.execute(
+                """
                 UPDATE auth_password_hashes SET password_hash = ?, updated_at = ?
                 WHERE user_id = ?
-            """, (password_hash, datetime.utcnow().isoformat(), user_id))
-            
+            """,
+                (password_hash, datetime.utcnow().isoformat(), user_id),
+            )
+
             self.connection.commit()
-            
+
         except Exception as e:
             self.connection.rollback()
-            raise DatabaseOperationError(f"Failed to update password hash: {e}", operation="update_password_hash")
-    
+            raise DatabaseOperationError(
+                f"Failed to update password hash: {e}", operation="update_password_hash"
+            )
+
+    async def get_auth_provider(self, provider_id: str) -> Optional[Dict[str, Any]]:
+        """Fetch authentication provider configuration."""
+        try:
+            cursor = self.connection.cursor()
+            cursor.execute(
+                "SELECT * FROM auth_providers WHERE provider_id = ?", (provider_id,)
+            )
+            row = cursor.fetchone()
+            if not row:
+                return None
+            return {
+                "provider_id": row["provider_id"],
+                "tenant_id": row["tenant_id"],
+                "type": row["type"],
+                "config": json.loads(row["config"]),
+                "metadata": json.loads(row["metadata"]),
+                "enabled": bool(row["enabled"]),
+                "created_at": datetime.fromisoformat(row["created_at"]),
+                "updated_at": datetime.fromisoformat(row["updated_at"]),
+            }
+        except Exception as e:
+            raise DatabaseOperationError(
+                f"Failed to get auth provider: {e}", operation="get_auth_provider"
+            )
+
+    async def upsert_auth_provider(
+        self,
+        provider_id: str,
+        provider_type: str,
+        config: Dict[str, Any],
+        metadata: Optional[Dict[str, Any]] = None,
+        tenant_id: str = "default",
+        enabled: bool = True,
+    ) -> None:
+        """Insert or update an authentication provider."""
+        try:
+            cursor = self.connection.cursor()
+            now = datetime.utcnow().isoformat()
+            cursor.execute(
+                """
+                INSERT INTO auth_providers (
+                    provider_id, tenant_id, type, config, metadata, enabled, created_at, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(provider_id) DO UPDATE SET
+                    tenant_id=excluded.tenant_id,
+                    type=excluded.type,
+                    config=excluded.config,
+                    metadata=excluded.metadata,
+                    enabled=excluded.enabled,
+                    updated_at=excluded.updated_at
+                """,
+                (
+                    provider_id,
+                    tenant_id,
+                    provider_type,
+                    json.dumps(config),
+                    json.dumps(metadata or {}),
+                    enabled,
+                    now,
+                    now,
+                ),
+            )
+            self.connection.commit()
+        except Exception as e:
+            self.connection.rollback()
+            raise DatabaseOperationError(
+                f"Failed to upsert auth provider: {e}", operation="upsert_auth_provider"
+            )
+
+    async def get_user_identity(
+        self, provider_id: str, provider_user: str
+    ) -> Optional[Dict[str, Any]]:
+        """Get a user identity mapping for a provider."""
+        try:
+            cursor = self.connection.cursor()
+            cursor.execute(
+                "SELECT * FROM user_identities WHERE provider_id = ? AND provider_user = ?",
+                (provider_id, provider_user),
+            )
+            row = cursor.fetchone()
+            if not row:
+                return None
+            return {
+                "identity_id": row["identity_id"],
+                "user_id": row["user_id"],
+                "provider_id": row["provider_id"],
+                "provider_user": row["provider_user"],
+                "metadata": json.loads(row["metadata"]) if row["metadata"] else {},
+                "created_at": datetime.fromisoformat(row["created_at"]),
+            }
+        except Exception as e:
+            raise DatabaseOperationError(
+                f"Failed to get user identity: {e}", operation="get_user_identity"
+            )
+
+    async def link_user_identity(
+        self,
+        user_id: str,
+        provider_id: str,
+        provider_user: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """Create a mapping between user and external provider identity."""
+        try:
+            existing = await self.get_user_identity(provider_id, provider_user)
+            cursor = self.connection.cursor()
+            if existing:
+                cursor.execute(
+                    "UPDATE user_identities SET user_id = ?, metadata = ? WHERE identity_id = ?",
+                    (
+                        user_id,
+                        json.dumps(metadata or existing["metadata"]),
+                        existing["identity_id"],
+                    ),
+                )
+                self.connection.commit()
+                existing["user_id"] = user_id
+                existing["metadata"] = metadata or existing["metadata"]
+                return existing
+
+            identity_id = str(uuid4())
+            cursor.execute(
+                """
+                INSERT INTO user_identities (
+                    identity_id, user_id, provider_id, provider_user, metadata, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    identity_id,
+                    user_id,
+                    provider_id,
+                    provider_user,
+                    json.dumps(metadata or {}),
+                    datetime.utcnow().isoformat(),
+                ),
+            )
+            self.connection.commit()
+            return {
+                "identity_id": identity_id,
+                "user_id": user_id,
+                "provider_id": provider_id,
+                "provider_user": provider_user,
+                "metadata": metadata or {},
+            }
+        except Exception as e:
+            self.connection.rollback()
+            raise DatabaseOperationError(
+                f"Failed to link user identity: {e}", operation="link_user_identity"
+            )
+
     async def store_password_reset_token(
         self,
         token_id: str,
@@ -343,87 +611,113 @@ class DatabaseClient:
         token_hash: str,
         expires_at: datetime,
         ip_address: str = "unknown",
-        user_agent: str = ""
+        user_agent: str = "",
     ) -> None:
         """Store a password reset token."""
         try:
             cursor = self.connection.cursor()
-            cursor.execute("""
+            cursor.execute(
+                """
                 INSERT INTO auth_password_reset_tokens (
                     token_id, user_id, token_hash, created_at, expires_at, ip_address, user_agent
                 ) VALUES (?, ?, ?, ?, ?, ?, ?)
-            """, (
-                token_id,
-                user_id,
-                token_hash,
-                datetime.utcnow().isoformat(),
-                expires_at.isoformat(),
-                ip_address,
-                user_agent
-            ))
-            
+            """,
+                (
+                    token_id,
+                    user_id,
+                    token_hash,
+                    datetime.utcnow().isoformat(),
+                    expires_at.isoformat(),
+                    ip_address,
+                    user_agent,
+                ),
+            )
+
             self.connection.commit()
-            
+
         except Exception as e:
-            raise DatabaseOperationError(f"Failed to store password reset token: {e}", operation="store_password_reset_token")
-    
+            raise DatabaseOperationError(
+                f"Failed to store password reset token: {e}",
+                operation="store_password_reset_token",
+            )
+
     async def get_password_reset_token(self, token_id: str) -> Optional[Dict[str, Any]]:
         """Get password reset token data."""
         try:
             cursor = self.connection.cursor()
-            cursor.execute("""
-                SELECT * FROM auth_password_reset_tokens 
+            cursor.execute(
+                """
+                SELECT * FROM auth_password_reset_tokens
                 WHERE token_id = ? AND used_at IS NULL
-            """, (token_id,))
+            """,
+                (token_id,),
+            )
             row = cursor.fetchone()
-            
+
             if not row:
                 return None
-            
+
             return {
                 "token_id": row["token_id"],
                 "user_id": row["user_id"],
                 "token_hash": row["token_hash"],
                 "created_at": datetime.fromisoformat(row["created_at"]),
                 "expires_at": datetime.fromisoformat(row["expires_at"]),
-                "used_at": datetime.fromisoformat(row["used_at"]) if row["used_at"] else None,
+                "used_at": datetime.fromisoformat(row["used_at"])
+                if row["used_at"]
+                else None,
                 "ip_address": row["ip_address"],
-                "user_agent": row["user_agent"]
+                "user_agent": row["user_agent"],
             }
-            
+
         except Exception as e:
-            raise DatabaseOperationError(f"Failed to get password reset token: {e}", operation="get_password_reset_token")
-    
+            raise DatabaseOperationError(
+                f"Failed to get password reset token: {e}",
+                operation="get_password_reset_token",
+            )
+
     async def mark_password_reset_token_used(self, token_id: str) -> None:
         """Mark a password reset token as used."""
         try:
             cursor = self.connection.cursor()
-            cursor.execute("""
+            cursor.execute(
+                """
                 UPDATE auth_password_reset_tokens SET used_at = ?
                 WHERE token_id = ?
-            """, (datetime.utcnow().isoformat(), token_id))
-            
+            """,
+                (datetime.utcnow().isoformat(), token_id),
+            )
+
             self.connection.commit()
-            
+
         except Exception as e:
-            raise DatabaseOperationError(f"Failed to mark password reset token as used: {e}", operation="mark_password_reset_token_used")
-    
+            raise DatabaseOperationError(
+                f"Failed to mark password reset token as used: {e}",
+                operation="mark_password_reset_token_used",
+            )
+
     async def cleanup_expired_password_reset_tokens(self) -> int:
         """Clean up expired password reset tokens."""
         try:
             cursor = self.connection.cursor()
-            cursor.execute("""
-                DELETE FROM auth_password_reset_tokens 
+            cursor.execute(
+                """
+                DELETE FROM auth_password_reset_tokens
                 WHERE expires_at < ?
-            """, (datetime.utcnow().isoformat(),))
-            
+            """,
+                (datetime.utcnow().isoformat(),),
+            )
+
             deleted_count = cursor.rowcount
             self.connection.commit()
             return deleted_count
-            
+
         except Exception as e:
-            raise DatabaseOperationError(f"Failed to cleanup expired password reset tokens: {e}", operation="cleanup_expired_password_reset_tokens")
-    
+            raise DatabaseOperationError(
+                f"Failed to cleanup expired password reset tokens: {e}",
+                operation="cleanup_expired_password_reset_tokens",
+            )
+
     async def store_email_verification_token(
         self,
         token_id: str,
@@ -431,125 +725,156 @@ class DatabaseClient:
         token_hash: str,
         expires_at: datetime,
         ip_address: str = "unknown",
-        user_agent: str = ""
+        user_agent: str = "",
     ) -> None:
         """Store an email verification token."""
         try:
             cursor = self.connection.cursor()
-            cursor.execute("""
+            cursor.execute(
+                """
                 INSERT INTO auth_email_verification_tokens (
                     token_id, user_id, token_hash, created_at, expires_at, ip_address, user_agent
                 ) VALUES (?, ?, ?, ?, ?, ?, ?)
-            """, (
-                token_id,
-                user_id,
-                token_hash,
-                datetime.utcnow().isoformat(),
-                expires_at.isoformat(),
-                ip_address,
-                user_agent
-            ))
-            
+            """,
+                (
+                    token_id,
+                    user_id,
+                    token_hash,
+                    datetime.utcnow().isoformat(),
+                    expires_at.isoformat(),
+                    ip_address,
+                    user_agent,
+                ),
+            )
+
             self.connection.commit()
-            
+
         except Exception as e:
-            raise DatabaseOperationError(f"Failed to store email verification token: {e}", operation="store_email_verification_token")
-    
-    async def get_email_verification_token(self, token_id: str) -> Optional[Dict[str, Any]]:
+            raise DatabaseOperationError(
+                f"Failed to store email verification token: {e}",
+                operation="store_email_verification_token",
+            )
+
+    async def get_email_verification_token(
+        self, token_id: str
+    ) -> Optional[Dict[str, Any]]:
         """Get email verification token data."""
         try:
             cursor = self.connection.cursor()
-            cursor.execute("""
-                SELECT * FROM auth_email_verification_tokens 
+            cursor.execute(
+                """
+                SELECT * FROM auth_email_verification_tokens
                 WHERE token_id = ? AND used_at IS NULL
-            """, (token_id,))
+            """,
+                (token_id,),
+            )
             row = cursor.fetchone()
-            
+
             if not row:
                 return None
-            
+
             return {
                 "token_id": row["token_id"],
                 "user_id": row["user_id"],
                 "token_hash": row["token_hash"],
                 "created_at": datetime.fromisoformat(row["created_at"]),
                 "expires_at": datetime.fromisoformat(row["expires_at"]),
-                "used_at": datetime.fromisoformat(row["used_at"]) if row["used_at"] else None,
+                "used_at": datetime.fromisoformat(row["used_at"])
+                if row["used_at"]
+                else None,
                 "ip_address": row["ip_address"],
-                "user_agent": row["user_agent"]
+                "user_agent": row["user_agent"],
             }
-            
+
         except Exception as e:
-            raise DatabaseOperationError(f"Failed to get email verification token: {e}", operation="get_email_verification_token")
-    
+            raise DatabaseOperationError(
+                f"Failed to get email verification token: {e}",
+                operation="get_email_verification_token",
+            )
+
     async def mark_email_verification_token_used(self, token_id: str) -> None:
         """Mark an email verification token as used."""
         try:
             cursor = self.connection.cursor()
-            cursor.execute("""
+            cursor.execute(
+                """
                 UPDATE auth_email_verification_tokens SET used_at = ?
                 WHERE token_id = ?
-            """, (datetime.utcnow().isoformat(), token_id))
-            
+            """,
+                (datetime.utcnow().isoformat(), token_id),
+            )
+
             self.connection.commit()
-            
+
         except Exception as e:
-            raise DatabaseOperationError(f"Failed to mark email verification token as used: {e}", operation="mark_email_verification_token_used")
-    
+            raise DatabaseOperationError(
+                f"Failed to mark email verification token as used: {e}",
+                operation="mark_email_verification_token_used",
+            )
+
     async def cleanup_expired_email_verification_tokens(self) -> int:
         """Clean up expired email verification tokens."""
         try:
             cursor = self.connection.cursor()
-            cursor.execute("""
-                DELETE FROM auth_email_verification_tokens 
+            cursor.execute(
+                """
+                DELETE FROM auth_email_verification_tokens
                 WHERE expires_at < ?
-            """, (datetime.utcnow().isoformat(),))
-            
+            """,
+                (datetime.utcnow().isoformat(),),
+            )
+
             deleted_count = cursor.rowcount
             self.connection.commit()
             return deleted_count
-            
+
         except Exception as e:
-            raise DatabaseOperationError(f"Failed to cleanup expired email verification tokens: {e}", operation="cleanup_expired_email_verification_tokens")
+            raise DatabaseOperationError(
+                f"Failed to cleanup expired email verification tokens: {e}",
+                operation="cleanup_expired_email_verification_tokens",
+            )
 
     async def store_auth_event(self, event: AuthEvent) -> None:
         """Store an authentication event for audit logging."""
         try:
             cursor = self.connection.cursor()
-            cursor.execute("""
+            cursor.execute(
+                """
                 INSERT INTO auth_events (
                     event_id, event_type, timestamp, user_id, email, tenant_id,
                     ip_address, user_agent, request_id, session_token, success,
                     error_message, details, risk_score, security_flags,
                     blocked_by_security, processing_time_ms, service_version
                 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            """, (
-                event.event_id,
-                event.event_type.value,
-                event.timestamp.isoformat(),
-                event.user_id,
-                event.email,
-                event.tenant_id,
-                event.ip_address,
-                event.user_agent,
-                event.request_id,
-                event.session_token,
-                event.success,
-                event.error_message,
-                json.dumps(event.details),
-                event.risk_score,
-                json.dumps(event.security_flags),
-                event.blocked_by_security,
-                event.processing_time_ms,
-                event.service_version
-            ))
-            
+            """,
+                (
+                    event.event_id,
+                    event.event_type.value,
+                    event.timestamp.isoformat(),
+                    event.user_id,
+                    event.email,
+                    event.tenant_id,
+                    event.ip_address,
+                    event.user_agent,
+                    event.request_id,
+                    event.session_token,
+                    event.success,
+                    event.error_message,
+                    json.dumps(event.details),
+                    event.risk_score,
+                    json.dumps(event.security_flags),
+                    event.blocked_by_security,
+                    event.processing_time_ms,
+                    event.service_version,
+                ),
+            )
+
             self.connection.commit()
-            
+
         except Exception as e:
             # Don't let audit logging failures affect authentication
             pass
-    
+
     def _row_to_user_data(self, row: sqlite3.Row) -> UserData:
         """Convert database row to UserData object."""
         return UserData(
@@ -563,34 +888,38 @@ class DatabaseClient:
             is_active=bool(row["is_active"]),
             created_at=datetime.fromisoformat(row["created_at"]),
             updated_at=datetime.fromisoformat(row["updated_at"]),
-            last_login_at=datetime.fromisoformat(row["last_login_at"]) if row["last_login_at"] else None,
+            last_login_at=datetime.fromisoformat(row["last_login_at"])
+            if row["last_login_at"]
+            else None,
             failed_login_attempts=row["failed_login_attempts"],
-            locked_until=datetime.fromisoformat(row["locked_until"]) if row["locked_until"] else None,
+            locked_until=datetime.fromisoformat(row["locked_until"])
+            if row["locked_until"]
+            else None,
             two_factor_enabled=bool(row["two_factor_enabled"]),
-            two_factor_secret=row["two_factor_secret"]
+            two_factor_secret=row["two_factor_secret"],
         )
-    
+
     async def health_check(self) -> bool:
         """Perform a health check on the database connection."""
         try:
             if not self.connection:
                 return False
-            
+
             # Simple query to test connection
             cursor = self.connection.cursor()
             cursor.execute("SELECT 1")
             cursor.fetchone()
             return True
-            
+
         except Exception:
             return False
-    
+
     def close(self) -> None:
         """Close database connection."""
         if self.connection:
             self.connection.close()
             self.connection = None
-    
+
     def __del__(self) -> None:
         """Cleanup database connection on deletion."""
         self.close()

--- a/src/ai_karen_engine/auth/service.py
+++ b/src/ai_karen_engine/auth/service.py
@@ -15,33 +15,33 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from .config import AuthConfig
 from .core import CoreAuthenticator
-from .security import SecurityEnhancer
-from .intelligence import IntelligenceEngine, LoginAttempt
-from .models import UserData, SessionData, AuthEvent, AuthEventType
-from .monitoring import AuthMonitor
 from .exceptions import (
+    AnomalyDetectedError,
     AuthError,
+    ConfigurationError,
     InvalidCredentialsError,
-    UserNotFoundError,
-    UserAlreadyExistsError,
-    SessionExpiredError,
-    SessionNotFoundError,
     RateLimitExceededError,
     SecurityError,
-    AnomalyDetectedError,
-    ConfigurationError,
+    SessionExpiredError,
+    SessionNotFoundError,
+    UserAlreadyExistsError,
+    UserNotFoundError,
 )
+from .intelligence import IntelligenceEngine, LoginAttempt
+from .models import AuthEvent, AuthEventType, SessionData, UserData
+from .monitoring import AuthMonitor
+from .security import SecurityEnhancer
 
 
 class AuthService:
     """
     Unified authentication service that orchestrates all authentication layers.
-    
+
     This is the main interface that all application code should use for
     authentication operations. It provides a clean, consistent API while
     internally coordinating between the core authentication layer, security
     enhancements, and intelligence features based on configuration.
-    
+
     Features:
     - Core authentication (login, session management, user management)
     - Security enhancements (rate limiting, audit logging, session validation)
@@ -49,64 +49,66 @@ class AuthService:
     - Configuration-driven feature enabling/disabling
     - Comprehensive error handling and logging
     """
-    
+
     def __init__(self, config: AuthConfig) -> None:
         """
         Initialize the unified authentication service.
-        
+
         Args:
             config: Authentication configuration that determines which
                    features are enabled and how they are configured
         """
         self.config = config
         self.logger = logging.getLogger(f"{__name__}.AuthService")
-        
+
         # Initialize core authentication layer (always present)
         self.core_auth = CoreAuthenticator(config)
-        
+
         # Initialize security layer if enabled
         self.security_layer: Optional[SecurityEnhancer] = None
         if config.features.enable_security_features:
             self.security_layer = SecurityEnhancer(config)
-        
+
         # Initialize intelligence layer if enabled
         self.intelligence_layer: Optional[IntelligenceEngine] = None
         if config.features.enable_intelligent_auth:
             self.intelligence_layer = IntelligenceEngine(config)
-        
+
         # Initialize monitoring system if enabled
         self.monitor: Optional[AuthMonitor] = None
         if config.monitoring.enable_monitoring:
             self.monitor = AuthMonitor(config)
-        
+
         self._initialized = False
-        self.logger.info(f"AuthService initialized with mode: {config.get_mode_description()}")
-    
+        self.logger.info(
+            f"AuthService initialized with mode: {config.get_mode_description()}"
+        )
+
     async def initialize(self) -> None:
         """Initialize the authentication service and all its components."""
         if self._initialized:
             return
-        
+
         self.logger.info("Initializing AuthService components...")
-        
+
         try:
             # Initialize intelligence layer if present
             if self.intelligence_layer:
                 await self.intelligence_layer.initialize()
                 self.logger.info("Intelligence layer initialized")
-            
+
             # Initialize security layer if present
             if self.security_layer:
                 await self.security_layer.initialize()
                 self.logger.info("Security layer initialized")
-            
+
             self._initialized = True
             self.logger.info("AuthService initialization completed successfully")
-            
+
         except Exception as e:
             self.logger.error(f"Failed to initialize AuthService: {e}")
             raise ConfigurationError(f"AuthService initialization failed: {e}")
-    
+
     async def authenticate_user(
         self,
         email: str,
@@ -116,14 +118,14 @@ class AuthService:
         device_fingerprint: Optional[str] = None,
         geolocation: Optional[Dict[str, Any]] = None,
         request_context: Optional[Dict[str, Any]] = None,
-        **kwargs
+        **kwargs,
     ) -> Optional[UserData]:
         """
         Authenticate a user with email and password.
-        
+
         This method orchestrates the full authentication flow including
         security checks, rate limiting, and intelligence analysis.
-        
+
         Args:
             email: User's email address
             password: User's password
@@ -133,10 +135,10 @@ class AuthService:
             geolocation: Optional geolocation data
             request_context: Additional request context for analysis
             **kwargs: Additional authentication parameters
-            
+
         Returns:
             UserData if authentication successful, None otherwise
-            
+
         Raises:
             InvalidCredentialsError: Invalid email/password combination
             AccountLockedError: Account is locked due to failed attempts
@@ -146,17 +148,15 @@ class AuthService:
         """
         await self.initialize()
         start_time = datetime.utcnow()
-        
+
         try:
             # Step 1: Security layer pre-checks
             if self.security_layer:
                 # Check rate limiting
                 await self.security_layer.check_rate_limit(
-                    ip_address=ip_address,
-                    email=email,
-                    event_type="login_attempt"
+                    ip_address=ip_address, email=email, event_type="login_attempt"
                 )
-            
+
             # Step 2: Intelligence layer analysis (if enabled)
             intelligence_result = None
             if self.intelligence_layer:
@@ -168,61 +168,66 @@ class AuthService:
                     timestamp=datetime.utcnow(),
                     device_fingerprint=device_fingerprint,
                     geolocation=geolocation,
-                    session_context=request_context
+                    session_context=request_context,
                 )
-                
+
                 # Get user data for behavioral analysis
                 existing_user = await self.core_auth.get_user_by_email(email)
-                
+
                 # Get historical events for analysis
                 historical_events = []
                 if existing_user and self.security_layer:
                     historical_events = await self.security_layer.get_user_auth_history(
                         existing_user.user_id,
-                        days=self.config.intelligence.behavioral_window_days
+                        days=self.config.intelligence.behavioral_window_days,
                     )
-                
-                intelligence_result = await self.intelligence_layer.analyze_login_attempt(
-                    login_attempt, existing_user, historical_events
+
+                intelligence_result = (
+                    await self.intelligence_layer.analyze_login_attempt(
+                        login_attempt, existing_user, historical_events
+                    )
                 )
-                
+
                 # Block if intelligence system recommends it
                 if intelligence_result.should_block:
                     await self._log_blocked_attempt(
-                        email, ip_address, user_agent, "intelligence_block",
-                        intelligence_result.to_dict()
+                        email,
+                        ip_address,
+                        user_agent,
+                        "intelligence_block",
+                        intelligence_result.to_dict(),
                     )
                     raise AnomalyDetectedError(
                         message="Login blocked by intelligence system",
                         risk_score=intelligence_result.risk_score,
-                        anomaly_types=intelligence_result.anomaly_result.anomaly_types if intelligence_result.anomaly_result else [],
-                        details=intelligence_result.to_dict()
+                        anomaly_types=intelligence_result.anomaly_result.anomaly_types
+                        if intelligence_result.anomaly_result
+                        else [],
+                        details=intelligence_result.to_dict(),
                     )
-            
+
             # Step 3: Core authentication
             user_data = await self.core_auth.authenticate_user(
                 email=email,
                 password=password,
                 ip_address=ip_address,
                 user_agent=user_agent,
-                **kwargs
+                **kwargs,
             )
-            
+
             # Step 4: Post-authentication security updates
             if self.security_layer and user_data:
                 # Record successful attempt
                 await self.security_layer.record_successful_attempt(
-                    ip_address=ip_address,
-                    email=email,
-                    user_id=user_data.user_id
+                    ip_address=ip_address, email=email, user_id=user_data.user_id
                 )
-                
+
                 # Update intelligence data if available
                 if intelligence_result:
                     await self.security_layer.update_user_intelligence_data(
                         user_data.user_id, intelligence_result
                     )
-            
+
             # Record successful authentication event
             await self._record_auth_event(
                 event_type=AuthEventType.LOGIN_SUCCESS,
@@ -233,26 +238,36 @@ class AuthService:
                 tenant_id=user_data.tenant_id if user_data else None,
                 ip_address=ip_address,
                 user_agent=user_agent,
-                risk_score=intelligence_result.risk_score if intelligence_result else 0.0,
-                security_flags=intelligence_result.security_flags if intelligence_result else []
+                risk_score=intelligence_result.risk_score
+                if intelligence_result
+                else 0.0,
+                security_flags=intelligence_result.security_flags
+                if intelligence_result
+                else [],
             )
-            
+
             # Record performance metric
             processing_time = (datetime.utcnow() - start_time).total_seconds() * 1000
-            await self._record_performance_metric("authenticate_user", processing_time, True)
-            
+            await self._record_performance_metric(
+                "authenticate_user", processing_time, True
+            )
+
             return user_data
-            
-        except (InvalidCredentialsError, RateLimitExceededError, AnomalyDetectedError) as e:
+
+        except (
+            InvalidCredentialsError,
+            RateLimitExceededError,
+            AnomalyDetectedError,
+        ) as e:
             # Record failed attempt for rate limiting and security
             if self.security_layer:
                 await self.security_layer.record_failed_attempt(
                     ip_address=ip_address,
                     email=email,
                     error_type=type(e).__name__,
-                    details=getattr(e, 'details', {})
+                    details=getattr(e, "details", {}),
                 )
-            
+
             # Record failed authentication event
             await self._record_auth_event(
                 event_type=AuthEventType.LOGIN_FAILED,
@@ -262,17 +277,19 @@ class AuthService:
                 ip_address=ip_address,
                 user_agent=user_agent,
                 error_message=str(e),
-                risk_score=getattr(e, 'risk_score', 0.0),
-                security_flags=getattr(e, 'security_flags', []),
-                details=getattr(e, 'details', {})
+                risk_score=getattr(e, "risk_score", 0.0),
+                security_flags=getattr(e, "security_flags", []),
+                details=getattr(e, "details", {}),
             )
-            
+
             # Record performance metric for failed attempt
             processing_time = (datetime.utcnow() - start_time).total_seconds() * 1000
-            await self._record_performance_metric("authenticate_user", processing_time, False)
-            
+            await self._record_performance_metric(
+                "authenticate_user", processing_time, False
+            )
+
             raise
-        
+
         except Exception as e:
             self.logger.error(f"Unexpected error in authenticate_user: {e}")
             # Still record the failed attempt
@@ -281,9 +298,9 @@ class AuthService:
                     ip_address=ip_address,
                     email=email,
                     error_type="system_error",
-                    details={"error": str(e)}
+                    details={"error": str(e)},
                 )
-            
+
             # Record failed authentication event
             await self._record_auth_event(
                 event_type=AuthEventType.LOGIN_FAILED,
@@ -293,15 +310,48 @@ class AuthService:
                 ip_address=ip_address,
                 user_agent=user_agent,
                 error_message=str(e),
-                details={"error_type": "system_error"}
+                details={"error_type": "system_error"},
             )
-            
+
             # Record performance metric for system error
             processing_time = (datetime.utcnow() - start_time).total_seconds() * 1000
-            await self._record_performance_metric("authenticate_user", processing_time, False)
-            
+            await self._record_performance_metric(
+                "authenticate_user", processing_time, False
+            )
+
             raise AuthError(f"Authentication failed due to system error: {e}")
-    
+
+    async def authenticate_external(
+        self,
+        provider_id: str,
+        provider_type: str,
+        provider_user: str,
+        email: Optional[str] = None,
+        full_name: Optional[str] = None,
+        config: Optional[Dict[str, Any]] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        tenant_id: str = "default",
+        **kwargs,
+    ) -> Optional[UserData]:
+        """Authenticate a user via external identity provider."""
+        await self.initialize()
+
+        try:
+            return await self.core_auth.authenticate_external(
+                provider_id=provider_id,
+                provider_type=provider_type,
+                provider_user=provider_user,
+                email=email,
+                full_name=full_name,
+                config=config or {},
+                metadata=metadata or {},
+                tenant_id=tenant_id,
+                **kwargs,
+            )
+        except Exception as e:
+            self.logger.error(f"External authentication error: {e}")
+            raise AuthError(f"External authentication failed: {e}")
+
     async def create_session(
         self,
         user_data: UserData,
@@ -310,11 +360,11 @@ class AuthService:
         device_fingerprint: Optional[str] = None,
         geolocation: Optional[Dict[str, Any]] = None,
         request_context: Optional[Dict[str, Any]] = None,
-        **kwargs
+        **kwargs,
     ) -> SessionData:
         """
         Create a new authentication session for a user.
-        
+
         Args:
             user_data: Authenticated user data
             ip_address: Client IP address
@@ -323,15 +373,15 @@ class AuthService:
             geolocation: Optional geolocation data
             request_context: Additional request context
             **kwargs: Additional session parameters
-            
+
         Returns:
             SessionData with tokens and session information
-            
+
         Raises:
             SecurityError: Session creation blocked by security measures
         """
         await self.initialize()
-        
+
         try:
             # Create session through core authenticator
             session_data = await self.core_auth.create_session(
@@ -339,13 +389,13 @@ class AuthService:
                 ip_address=ip_address,
                 user_agent=user_agent,
                 device_fingerprint=device_fingerprint,
-                **kwargs
+                **kwargs,
             )
-            
+
             # Add geolocation if provided
             if geolocation:
                 session_data.geolocation = geolocation
-            
+
             # Apply security enhancements if enabled
             if self.security_layer:
                 # Validate session security
@@ -353,144 +403,146 @@ class AuthService:
                     session=session_data,
                     current_ip=ip_address,
                     current_user_agent=user_agent,
-                    request_context=request_context
+                    request_context=request_context,
                 )
-                
+
                 # Update session with security information
                 session_data.risk_score = security_result["risk_score"]
                 for flag in security_result["security_flags"]:
                     session_data.add_security_flag(flag)
-                
+
                 # Log session creation
                 await self.security_layer.log_session_event(
-                    AuthEventType.SESSION_CREATED,
-                    session_data,
-                    success=True
+                    AuthEventType.SESSION_CREATED, session_data, success=True
                 )
-            
+
             return session_data
-            
+
         except Exception as e:
             self.logger.error(f"Failed to create session: {e}")
             raise SecurityError(f"Session creation failed: {e}")
-    
+
     async def validate_session(
         self,
         session_token: str,
         ip_address: str = "unknown",
         user_agent: str = "",
         request_context: Optional[Dict[str, Any]] = None,
-        **kwargs
+        **kwargs,
     ) -> Optional[UserData]:
         """
         Validate a session token and return user data if valid.
-        
+
         Args:
             session_token: Session token to validate
             ip_address: Current client IP address
             user_agent: Current client user agent
             request_context: Additional request context
             **kwargs: Additional validation parameters
-            
+
         Returns:
             UserData if session is valid, None otherwise
-            
+
         Raises:
             SessionExpiredError: Session has expired
             SessionNotFoundError: Session not found
             SecurityError: Session validation failed security checks
         """
         await self.initialize()
-        
+
         try:
             # Validate session through core authenticator
             user_data = await self.core_auth.validate_session(session_token, **kwargs)
-            
+
             if not user_data:
                 return None
-            
+
             # Apply security validation if enabled
             if self.security_layer:
                 # Get full session data for security validation
-                session_data = await self.core_auth.session_manager.store.get_session(session_token)
+                session_data = await self.core_auth.session_manager.store.get_session(
+                    session_token
+                )
                 if session_data:
                     # Validate session security
-                    security_result = await self.security_layer.validate_session_security(
-                        session=session_data,
-                        current_ip=ip_address,
-                        current_user_agent=user_agent,
-                        request_context=request_context
+                    security_result = (
+                        await self.security_layer.validate_session_security(
+                            session=session_data,
+                            current_ip=ip_address,
+                            current_user_agent=user_agent,
+                            request_context=request_context,
+                        )
                     )
-                    
+
                     # Check if session should be blocked
                     if not security_result["valid"]:
                         await self.invalidate_session(
-                            session_token, 
-                            reason="security_validation_failed"
+                            session_token, reason="security_validation_failed"
                         )
                         raise SecurityError(
                             message="Session failed security validation",
-                            details=security_result
+                            details=security_result,
                         )
-                    
+
                     # Update session with new security information
                     session_data.risk_score = security_result["risk_score"]
                     for flag in security_result["security_flags"]:
                         session_data.add_security_flag(flag)
-                    
+
                     # Update session in store
-                    await self.core_auth.session_manager.store.update_session(session_data)
-            
+                    await self.core_auth.session_manager.store.update_session(
+                        session_data
+                    )
+
             return user_data
-            
+
         except (SessionExpiredError, SessionNotFoundError):
             raise
         except Exception as e:
             self.logger.error(f"Session validation error: {e}")
             raise SecurityError(f"Session validation failed: {e}")
-    
+
     async def invalidate_session(
-        self,
-        session_token: str,
-        reason: str = "manual",
-        **kwargs
+        self, session_token: str, reason: str = "manual", **kwargs
     ) -> bool:
         """
         Invalidate a session token.
-        
+
         Args:
             session_token: Session token to invalidate
             reason: Reason for invalidation
             **kwargs: Additional parameters
-            
+
         Returns:
             True if session was invalidated, False otherwise
         """
         await self.initialize()
-        
+
         try:
             # Invalidate through core authenticator
             result = await self.core_auth.invalidate_session(
                 session_token, reason=reason, **kwargs
             )
-            
+
             # Log invalidation if security layer is enabled
             if self.security_layer and result:
-                session_data = await self.core_auth.session_manager.store.get_session(session_token)
+                session_data = await self.core_auth.session_manager.store.get_session(
+                    session_token
+                )
                 if session_data:
                     await self.security_layer.log_session_event(
                         AuthEventType.SESSION_INVALIDATED,
                         session_data,
                         success=True,
-                        details={"reason": reason}
+                        details={"reason": reason},
                     )
-            
+
             return result
-            
+
         except Exception as e:
             self.logger.error(f"Session invalidation error: {e}")
             return False
-    
+
     async def create_user(
         self,
         email: str,
@@ -500,11 +552,11 @@ class AuthService:
         roles: Optional[List[str]] = None,
         ip_address: str = "unknown",
         user_agent: str = "",
-        **kwargs
+        **kwargs,
     ) -> UserData:
         """
         Create a new user account.
-        
+
         Args:
             email: User's email address
             password: User's password
@@ -514,25 +566,24 @@ class AuthService:
             ip_address: Client IP address
             user_agent: Client user agent
             **kwargs: Additional user data
-            
+
         Returns:
             UserData for the created user
-            
+
         Raises:
             UserAlreadyExistsError: User with email already exists
             PasswordValidationError: Password doesn't meet requirements
             RateLimitExceededError: Too many user creation attempts
         """
         await self.initialize()
-        
+
         try:
             # Check rate limiting for user creation if security layer enabled
             if self.security_layer:
                 await self.security_layer.check_rate_limit(
-                    ip_address=ip_address,
-                    event_type="user_creation"
+                    ip_address=ip_address, event_type="user_creation"
                 )
-            
+
             # Create user through core authenticator
             user_data = await self.core_auth.create_user(
                 email=email,
@@ -540,9 +591,9 @@ class AuthService:
                 full_name=full_name,
                 tenant_id=tenant_id,
                 roles=roles,
-                **kwargs
+                **kwargs,
             )
-            
+
             # Log user creation if security layer enabled
             if self.security_layer:
                 await self.security_layer.log_auth_event(
@@ -553,12 +604,12 @@ class AuthService:
                         tenant_id=tenant_id,
                         ip_address=ip_address,
                         user_agent=user_agent,
-                        success=True
+                        success=True,
                     )
                 )
-            
+
             return user_data
-            
+
         except (UserAlreadyExistsError, RateLimitExceededError) as e:
             # Log failed attempt
             if self.security_layer:
@@ -569,11 +620,11 @@ class AuthService:
                         ip_address=ip_address,
                         user_agent=user_agent,
                         success=False,
-                        error_message=str(e)
+                        error_message=str(e),
                     )
                 )
             raise
-    
+
     async def update_user_password(
         self,
         user_id: str,
@@ -581,11 +632,11 @@ class AuthService:
         current_password: Optional[str] = None,
         ip_address: str = "unknown",
         user_agent: str = "",
-        **kwargs
+        **kwargs,
     ) -> bool:
         """
         Update a user's password.
-        
+
         Args:
             user_id: User ID
             new_password: New password
@@ -593,26 +644,26 @@ class AuthService:
             ip_address: Client IP address
             user_agent: Client user agent
             **kwargs: Additional parameters
-            
+
         Returns:
             True if password was updated successfully
-            
+
         Raises:
             UserNotFoundError: User not found
             InvalidCredentialsError: Current password is incorrect
             PasswordValidationError: New password doesn't meet requirements
         """
         await self.initialize()
-        
+
         try:
             # Update password through core authenticator
             result = await self.core_auth.update_user_password(
                 user_id=user_id,
                 new_password=new_password,
                 current_password=current_password,
-                **kwargs
+                **kwargs,
             )
-            
+
             # Log password change if security layer enabled
             if self.security_layer and result:
                 user_data = await self.core_auth.get_user_by_id(user_id)
@@ -625,12 +676,12 @@ class AuthService:
                             tenant_id=user_data.tenant_id,
                             ip_address=ip_address,
                             user_agent=user_agent,
-                            success=True
+                            success=True,
                         )
                     )
-            
+
             return result
-            
+
         except Exception as e:
             # Log failed attempt
             if self.security_layer:
@@ -643,79 +694,72 @@ class AuthService:
                         ip_address=ip_address,
                         user_agent=user_agent,
                         success=False,
-                        error_message=str(e)
+                        error_message=str(e),
                     )
                 )
             raise
-    
+
     async def get_user_by_id(self, user_id: str) -> Optional[UserData]:
         """Get user data by user ID."""
         await self.initialize()
         return await self.core_auth.get_user_by_id(user_id)
-    
+
     async def get_user_by_email(self, email: str) -> Optional[UserData]:
         """Get user data by email address."""
         await self.initialize()
         return await self.core_auth.get_user_by_email(email)
-    
+
     async def update_user_preferences(
-        self,
-        user_id: str,
-        preferences: Dict[str, Any],
-        **kwargs
+        self, user_id: str, preferences: Dict[str, Any], **kwargs
     ) -> bool:
         """
         Update user preferences.
-        
+
         Args:
             user_id: User ID
             preferences: New preferences dictionary
             **kwargs: Additional parameters
-            
+
         Returns:
             True if preferences were updated successfully
         """
         await self.initialize()
-        
+
         try:
             user_data = await self.core_auth.get_user_by_id(user_id)
             if not user_data:
                 raise UserNotFoundError(user_id=user_id)
-            
+
             # Update preferences
             user_data.preferences.update(preferences)
             user_data.updated_at = datetime.utcnow()
-            
+
             # Save updated user data
             await self.core_auth.db_client.update_user(user_data)
-            
+
             return True
-            
+
         except Exception as e:
             self.logger.error(f"Failed to update user preferences: {e}")
             raise
-    
+
     async def create_password_reset_token(
-        self,
-        email: str,
-        ip_address: str = "unknown",
-        user_agent: str = "",
-        **kwargs
+        self, email: str, ip_address: str = "unknown", user_agent: str = "", **kwargs
     ) -> Optional[str]:
         """
         Create a password reset token for a user.
-        
+
         Args:
             email: User's email address
             ip_address: Client IP address
             user_agent: Client user agent
             **kwargs: Additional parameters
-            
+
         Returns:
             Password reset token if user exists, None otherwise
         """
         await self.initialize()
-        
+
         try:
             # Check if user exists
             user_data = await self.core_auth.get_user_by_email(email)
@@ -729,27 +773,27 @@ class AuthService:
                             ip_address=ip_address,
                             user_agent=user_agent,
                             success=False,
-                            error_message="User not found"
+                            error_message="User not found",
                         )
                     )
                 return None
-            
+
             # Check rate limiting if security layer enabled
             if self.security_layer:
                 await self.security_layer.check_rate_limit(
                     ip_address=ip_address,
                     email=email,
-                    event_type="password_reset_request"
+                    event_type="password_reset_request",
                 )
-            
+
             # Create reset token with database storage
             reset_token = await self.core_auth.token_manager.create_password_reset_token_with_storage(
                 user_data=user_data,
                 db_client=self.core_auth.db_client,
                 ip_address=ip_address,
-                user_agent=user_agent
+                user_agent=user_agent,
             )
-            
+
             # Log password reset request
             if self.security_layer:
                 await self.security_layer.log_auth_event(
@@ -760,46 +804,45 @@ class AuthService:
                         tenant_id=user_data.tenant_id,
                         ip_address=ip_address,
                         user_agent=user_agent,
-                        success=True
+                        success=True,
                     )
                 )
-            
+
             return reset_token
-            
+
         except RateLimitExceededError:
             raise
         except Exception as e:
             self.logger.error(f"Failed to create password reset token: {e}")
             return None
-    
+
     async def verify_password_reset_token(
         self,
         token: str,
         new_password: str,
         ip_address: str = "unknown",
         user_agent: str = "",
-        **kwargs
+        **kwargs,
     ) -> bool:
         """
         Verify a password reset token and update the password.
-        
+
         Args:
             token: Password reset token
             new_password: New password
             ip_address: Client IP address
             user_agent: Client user agent
             **kwargs: Additional parameters
-            
+
         Returns:
             True if password was reset successfully
         """
         await self.initialize()
-        
+
         try:
             # Verify and use the reset token with database storage
             user_data = await self.core_auth.token_manager.verify_password_reset_token_with_storage(
-                token=token,
-                db_client=self.core_auth.db_client
+                token=token, db_client=self.core_auth.db_client
             )
             if not user_data:
                 # Log failed password reset attempt
@@ -810,20 +853,20 @@ class AuthService:
                             ip_address=ip_address,
                             user_agent=user_agent,
                             success=False,
-                            error_message="Invalid or expired token"
+                            error_message="Invalid or expired token",
                         )
                     )
                 return False
-            
+
             # Update the password (without requiring current password for reset)
             await self.update_user_password(
                 user_id=user_data.user_id,
                 new_password=new_password,
                 current_password=None,  # No current password required for reset
                 ip_address=ip_address,
-                user_agent=user_agent
+                user_agent=user_agent,
             )
-            
+
             # Log successful password reset
             if self.security_layer:
                 await self.security_layer.log_auth_event(
@@ -834,12 +877,12 @@ class AuthService:
                         tenant_id=user_data.tenant_id,
                         ip_address=ip_address,
                         user_agent=user_agent,
-                        success=True
+                        success=True,
                     )
                 )
-            
+
             return True
-            
+
         except Exception as e:
             self.logger.error(f"Password reset verification failed: {e}")
             # Log failed password reset attempt
@@ -850,59 +893,55 @@ class AuthService:
                         ip_address=ip_address,
                         user_agent=user_agent,
                         success=False,
-                        error_message=str(e)
+                        error_message=str(e),
                     )
                 )
             return False
-    
+
     async def create_email_verification_token(
-        self,
-        user_id: str,
-        ip_address: str = "unknown",
-        user_agent: str = "",
-        **kwargs
+        self, user_id: str, ip_address: str = "unknown", user_agent: str = "", **kwargs
     ) -> Optional[str]:
         """
         Create an email verification token for a user.
-        
+
         Args:
             user_id: User ID
             ip_address: Client IP address
             user_agent: Client user agent
             **kwargs: Additional parameters
-            
+
         Returns:
             Email verification token if user exists, None otherwise
         """
         await self.initialize()
-        
+
         try:
             # Get user data
             user_data = await self.core_auth.get_user_by_id(user_id)
             if not user_data:
                 raise UserNotFoundError(user_id=user_id)
-            
+
             # Check if user is already verified
             if user_data.is_verified:
                 self.logger.info(f"User {user_id} is already verified")
                 return None
-            
+
             # Check rate limiting if security layer enabled
             if self.security_layer:
                 await self.security_layer.check_rate_limit(
                     ip_address=ip_address,
                     email=user_data.email,
-                    event_type="email_verification_request"
+                    event_type="email_verification_request",
                 )
-            
+
             # Create verification token with database storage
             verification_token = await self.core_auth.token_manager.create_email_verification_token_with_storage(
                 user_data=user_data,
                 db_client=self.core_auth.db_client,
                 ip_address=ip_address,
-                user_agent=user_agent
+                user_agent=user_agent,
             )
-            
+
             # Log email verification request
             if self.security_layer:
                 await self.security_layer.log_auth_event(
@@ -914,44 +953,39 @@ class AuthService:
                         ip_address=ip_address,
                         user_agent=user_agent,
                         success=True,
-                        details={"action": "email_verification_requested"}
+                        details={"action": "email_verification_requested"},
                     )
                 )
-            
+
             return verification_token
-            
+
         except RateLimitExceededError:
             raise
         except Exception as e:
             self.logger.error(f"Failed to create email verification token: {e}")
             return None
-    
+
     async def verify_email_address(
-        self,
-        token: str,
-        ip_address: str = "unknown",
-        user_agent: str = "",
-        **kwargs
+        self, token: str, ip_address: str = "unknown", user_agent: str = "", **kwargs
     ) -> bool:
         """
         Verify a user's email address using a verification token.
-        
+
         Args:
             token: Email verification token
             ip_address: Client IP address
             user_agent: Client user agent
             **kwargs: Additional parameters
-            
+
         Returns:
             True if email was verified successfully
         """
         await self.initialize()
-        
+
         try:
             # Verify and use the verification token with database storage
             user_data = await self.core_auth.token_manager.verify_email_verification_token_with_storage(
-                token=token,
-                db_client=self.core_auth.db_client
+                token=token, db_client=self.core_auth.db_client
             )
             if not user_data:
                 # Log failed email verification attempt
@@ -963,16 +997,16 @@ class AuthService:
                             user_agent=user_agent,
                             success=False,
                             error_message="Invalid or expired verification token",
-                            details={"action": "email_verification_failed"}
+                            details={"action": "email_verification_failed"},
                         )
                     )
                 return False
-            
+
             # Mark user as verified
             user_data.is_verified = True
             user_data.updated_at = datetime.utcnow()
             await self.core_auth.db_client.update_user(user_data)
-            
+
             # Log successful email verification
             if self.security_layer:
                 await self.security_layer.log_auth_event(
@@ -984,12 +1018,12 @@ class AuthService:
                         ip_address=ip_address,
                         user_agent=user_agent,
                         success=True,
-                        details={"action": "email_verified"}
+                        details={"action": "email_verified"},
                     )
                 )
-            
+
             return True
-            
+
         except Exception as e:
             self.logger.error(f"Email verification failed: {e}")
             # Log failed email verification attempt
@@ -1001,11 +1035,11 @@ class AuthService:
                         user_agent=user_agent,
                         success=False,
                         error_message=str(e),
-                        details={"action": "email_verification_failed"}
+                        details={"action": "email_verification_failed"},
                     )
                 )
             return False
-    
+
     async def update_user_profile(
         self,
         user_id: str,
@@ -1013,11 +1047,11 @@ class AuthService:
         preferences: Optional[Dict[str, Any]] = None,
         ip_address: str = "unknown",
         user_agent: str = "",
-        **kwargs
+        **kwargs,
     ) -> bool:
         """
         Update user profile information.
-        
+
         Args:
             user_id: User ID
             full_name: New full name (optional)
@@ -1025,36 +1059,36 @@ class AuthService:
             ip_address: Client IP address
             user_agent: Client user agent
             **kwargs: Additional profile fields
-            
+
         Returns:
             True if profile was updated successfully
         """
         await self.initialize()
-        
+
         try:
             user_data = await self.core_auth.get_user_by_id(user_id)
             if not user_data:
                 raise UserNotFoundError(user_id=user_id)
-            
+
             # Track what was updated for logging
             updates = {}
-            
+
             # Update full name if provided
             if full_name is not None:
                 user_data.full_name = full_name
                 updates["full_name"] = full_name
-            
+
             # Update preferences if provided
             if preferences is not None:
                 user_data.preferences.update(preferences)
                 updates["preferences"] = list(preferences.keys())
-            
+
             # Update timestamp
             user_data.updated_at = datetime.utcnow()
-            
+
             # Save updated user data
             await self.core_auth.db_client.update_user(user_data)
-            
+
             # Log profile update if security layer enabled
             if self.security_layer:
                 await self.security_layer.log_auth_event(
@@ -1066,12 +1100,12 @@ class AuthService:
                         ip_address=ip_address,
                         user_agent=user_agent,
                         success=True,
-                        details={"updates": updates}
+                        details={"updates": updates},
                     )
                 )
-            
+
             return True
-            
+
         except Exception as e:
             self.logger.error(f"Failed to update user profile: {e}")
             # Log failed profile update
@@ -1083,50 +1117,50 @@ class AuthService:
                         ip_address=ip_address,
                         user_agent=user_agent,
                         success=False,
-                        error_message=str(e)
+                        error_message=str(e),
                     )
                 )
             raise
-    
+
     async def deactivate_user(
         self,
         user_id: str,
         reason: str = "manual",
         ip_address: str = "unknown",
         user_agent: str = "",
-        **kwargs
+        **kwargs,
     ) -> bool:
         """
         Deactivate a user account.
-        
+
         Args:
             user_id: User ID
             reason: Reason for deactivation
             ip_address: Client IP address
             user_agent: Client user agent
             **kwargs: Additional parameters
-            
+
         Returns:
             True if user was deactivated successfully
         """
         await self.initialize()
-        
+
         try:
             user_data = await self.core_auth.get_user_by_id(user_id)
             if not user_data:
                 raise UserNotFoundError(user_id=user_id)
-            
+
             # Deactivate user
             user_data.is_active = False
             user_data.updated_at = datetime.utcnow()
-            
+
             # Save updated user data
             await self.core_auth.db_client.update_user(user_data)
-            
+
             # Invalidate all user sessions
             # Note: This would require additional session management functionality
             # For now, we'll just log the deactivation
-            
+
             # Log user deactivation if security layer enabled
             if self.security_layer:
                 await self.security_layer.log_auth_event(
@@ -1138,12 +1172,12 @@ class AuthService:
                         ip_address=ip_address,
                         user_agent=user_agent,
                         success=True,
-                        details={"reason": reason}
+                        details={"reason": reason},
                     )
                 )
-            
+
             return True
-            
+
         except Exception as e:
             self.logger.error(f"Failed to deactivate user: {e}")
             # Log failed deactivation
@@ -1155,20 +1189,20 @@ class AuthService:
                         ip_address=ip_address,
                         user_agent=user_agent,
                         success=False,
-                        error_message=str(e)
+                        error_message=str(e),
                     )
                 )
             raise
-    
+
     async def get_service_stats(self) -> Dict[str, Any]:
         """
         Get comprehensive service statistics.
-        
+
         Returns:
             Dictionary with service statistics and health information
         """
         await self.initialize()
-        
+
         stats = {
             "service_name": self.config.service_name,
             "service_version": self.config.service_version,
@@ -1181,26 +1215,26 @@ class AuthService:
                 "database_enabled": self.config.features.use_database,
                 "rate_limiting_enabled": self.config.features.enable_rate_limiting,
                 "audit_logging_enabled": self.config.features.enable_audit_logging,
-            }
+            },
         }
-        
+
         # Add security layer stats if available
         if self.security_layer:
             stats["security"] = await self.security_layer.get_stats()
-        
+
         # Add intelligence layer stats if available
         if self.intelligence_layer:
             stats["intelligence"] = await self.intelligence_layer.get_stats()
-        
+
         return stats
-    
+
     async def _log_blocked_attempt(
         self,
         email: str,
         ip_address: str,
         user_agent: str,
         block_reason: str,
-        details: Dict[str, Any]
+        details: Dict[str, Any],
     ) -> None:
         """Log a blocked authentication attempt."""
         if self.security_layer:
@@ -1209,61 +1243,73 @@ class AuthService:
                 ip_address=ip_address,
                 user_agent=user_agent,
                 email=email,
-                details={
-                    "block_reason": block_reason,
-                    **details
-                }
+                details={"block_reason": block_reason, **details},
             )
-    
+
     async def health_check(self) -> Dict[str, Any]:
         """
         Perform a health check of the authentication service.
-        
+
         Returns:
             Dictionary with health status information
         """
         health = {
             "status": "healthy",
             "timestamp": datetime.utcnow().isoformat(),
-            "components": {}
+            "components": {},
         }
-        
+
         try:
             await self.initialize()
-            
+
             # Check core authenticator
             try:
                 # Simple database connectivity check
                 await self.core_auth.db_client.health_check()
                 health["components"]["database"] = {"status": "healthy"}
             except Exception as e:
-                health["components"]["database"] = {"status": "unhealthy", "error": str(e)}
+                health["components"]["database"] = {
+                    "status": "unhealthy",
+                    "error": str(e),
+                }
                 health["status"] = "degraded"
-            
+
             # Check security layer
             if self.security_layer:
                 try:
                     security_stats = await self.security_layer.get_stats()
-                    health["components"]["security"] = {"status": "healthy", "stats": security_stats}
+                    health["components"]["security"] = {
+                        "status": "healthy",
+                        "stats": security_stats,
+                    }
                 except Exception as e:
-                    health["components"]["security"] = {"status": "unhealthy", "error": str(e)}
+                    health["components"]["security"] = {
+                        "status": "unhealthy",
+                        "error": str(e),
+                    }
                     health["status"] = "degraded"
-            
+
             # Check intelligence layer
             if self.intelligence_layer:
                 try:
                     intelligence_stats = await self.intelligence_layer.get_stats()
-                    health["components"]["intelligence"] = {"status": "healthy", "stats": intelligence_stats}
+                    health["components"]["intelligence"] = {
+                        "status": "healthy",
+                        "stats": intelligence_stats,
+                    }
                 except Exception as e:
-                    health["components"]["intelligence"] = {"status": "unhealthy", "error": str(e)}
+                    health["components"]["intelligence"] = {
+                        "status": "unhealthy",
+                        "error": str(e),
+                    }
                     health["status"] = "degraded"
-            
+
         except Exception as e:
             health["status"] = "unhealthy"
             health["error"] = str(e)
-        
+
         return health
-    
+
     async def _record_auth_event(
         self,
         event_type: AuthEventType,
@@ -1279,14 +1325,14 @@ class AuthService:
         risk_score: float = 0.0,
         security_flags: Optional[List[str]] = None,
         details: Optional[Dict[str, Any]] = None,
-        **kwargs
+        **kwargs,
     ) -> None:
         """Record an authentication event for monitoring and logging."""
         # Calculate processing time if start_time provided
         processing_time_ms = 0.0
         if start_time:
             processing_time_ms = (datetime.utcnow() - start_time).total_seconds() * 1000
-        
+
         # Create auth event
         event = AuthEvent(
             event_type=event_type,
@@ -1302,35 +1348,37 @@ class AuthService:
             security_flags=security_flags or [],
             processing_time_ms=processing_time_ms,
             details=details or {},
-            **kwargs
+            **kwargs,
         )
-        
+
         # Log through security layer if available
         if self.security_layer:
             await self.security_layer.log_auth_event(event)
-        
+
         # Record through monitoring system if available
         if self.monitor:
             await self.monitor.record_auth_event(event)
-    
+
     async def _record_performance_metric(
         self,
         operation: str,
         duration_ms: float,
         success: bool = True,
-        tags: Optional[Dict[str, str]] = None
+        tags: Optional[Dict[str, str]] = None,
     ) -> None:
         """Record a performance metric."""
         if self.monitor:
-            await self.monitor.record_performance_metric(operation, duration_ms, success, tags)
-    
+            await self.monitor.record_performance_metric(
+                operation, duration_ms, success, tags
+            )
+
     async def _log_blocked_attempt(
         self,
         email: str,
         ip_address: str,
         user_agent: str,
         reason: str,
-        details: Dict[str, Any]
+        details: Dict[str, Any],
     ) -> None:
         """Log a blocked authentication attempt."""
         await self._record_auth_event(
@@ -1341,42 +1389,42 @@ class AuthService:
             user_agent=user_agent,
             error_message=f"Login blocked: {reason}",
             blocked_by_security=True,
-            details=details
+            details=details,
         )
-    
+
     def get_monitoring_stats(self) -> Dict[str, Any]:
         """Get monitoring statistics."""
         if self.monitor:
             return self.monitor.get_monitoring_stats()
         return {"monitoring_enabled": False}
-    
+
     def get_health_status(self) -> Dict[str, Any]:
         """Get system health status."""
         if self.monitor:
             return self.monitor.get_health_status()
         return {"status": "unknown", "reason": "Monitoring not enabled"}
-    
+
     async def shutdown(self) -> None:
         """Shutdown the authentication service and all components."""
         self.logger.info("Shutting down AuthService...")
-        
+
         try:
             # Shutdown monitoring
             if self.monitor:
                 await self.monitor.shutdown()
-            
+
             # Shutdown intelligence layer
             if self.intelligence_layer:
                 # Intelligence layer doesn't have shutdown method yet, but we can add it later
                 pass
-            
+
             # Shutdown security layer
             if self.security_layer:
                 # Security layer doesn't have shutdown method yet, but we can add it later
                 pass
-            
+
             self.logger.info("AuthService shutdown completed")
-            
+
         except Exception as e:
             self.logger.error(f"Error during AuthService shutdown: {e}")
             raise
@@ -1386,16 +1434,16 @@ class AuthService:
 async def create_auth_service(config: Optional[AuthConfig] = None) -> AuthService:
     """
     Create and initialize an AuthService instance.
-    
+
     Args:
         config: Optional configuration. If not provided, loads from environment.
-        
+
     Returns:
         Initialized AuthService instance
     """
     if config is None:
         config = AuthConfig.load()
-    
+
     service = AuthService(config)
     await service.initialize()
     return service
@@ -1408,18 +1456,18 @@ _global_auth_service: Optional[AuthService] = None
 async def get_auth_service(config: Optional[AuthConfig] = None) -> AuthService:
     """
     Get the global AuthService instance, creating it if necessary.
-    
+
     Args:
         config: Optional configuration for service creation
-        
+
     Returns:
         Global AuthService instance
     """
     global _global_auth_service
-    
+
     if _global_auth_service is None:
         _global_auth_service = await create_auth_service(config)
-    
+
     return _global_auth_service
 
 

--- a/src/ai_karen_engine/database/migrations/003_auth_providers_user_identities.sql
+++ b/src/ai_karen_engine/database/migrations/003_auth_providers_user_identities.sql
@@ -1,0 +1,25 @@
+-- Migration: ensure auth_providers and user_identities tables exist with metadata
+-- Adds tables for external authentication providers and user identities
+
+CREATE TABLE IF NOT EXISTS auth_providers (
+    provider_id TEXT PRIMARY KEY,
+    tenant_id TEXT,
+    type TEXT NOT NULL,
+    config JSONB NOT NULL,
+    metadata JSONB DEFAULT '{}'::jsonb,
+    enabled BOOLEAN DEFAULT TRUE,
+    created_at TIMESTAMP DEFAULT now(),
+    updated_at TIMESTAMP DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS user_identities (
+    identity_id TEXT PRIMARY KEY,
+    user_id TEXT NOT NULL REFERENCES auth_users(user_id) ON DELETE CASCADE,
+    provider_id TEXT NOT NULL REFERENCES auth_providers(provider_id),
+    provider_user TEXT NOT NULL,
+    metadata JSONB,
+    created_at TIMESTAMP DEFAULT now(),
+    UNIQUE (provider_id, provider_user)
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_identity_user ON user_identities(user_id);


### PR DESCRIPTION
## Summary
- add unique constraints and indexes for auth providers and user identities
- support external auth providers and user identities in database client
- implement external identity authentication in core and service
- add migration for auth provider and identity tables

## Testing
- `pre-commit run --files src/ai_karen_engine/database/models/auth_models.py src/ai_karen_engine/database/migrations/003_auth_providers_user_identities.sql src/ai_karen_engine/auth/database.py src/ai_karen_engine/auth/core.py src/ai_karen_engine/auth/service.py` (fails: missing type annotations)
- `pytest` (fails: ImportError: cannot import name 'User' from 'ai_karen_engine.database.models')

------
https://chatgpt.com/codex/tasks/task_e_6895cd66e3108324bd1c0d722688e6b4