### PR TITLE
fix: stub fastapi Depends when fastapi missing

### DIFF
--- a/src/ai_karen_engine/auth/session.py
+++ b/src/ai_karen_engine/auth/session.py
@@ -653,7 +653,9 @@ try:
 except Exception:  # pragma: no cover
     _FASTAPI_AVAILABLE = False
     # Stubs to avoid NameErrors if imported without FastAPI context
-    Depends = object  # type: ignore
+    def Depends(*_args: Any, **_kwargs: Any) -> None:  # type: ignore
+        """Fallback stub for fastapi.Depends when FastAPI isn't installed."""
+        return None
     HTTPException = Exception  # type: ignore
     Request = object  # type: ignore
     status = type("status", (), {"HTTP_401_UNAUTHORIZED": 401, "HTTP_403_FORBIDDEN": 403})  # type: ignore


### PR DESCRIPTION
## Summary
- provide minimal Depends function fallback in auth session when FastAPI isn't installed

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi.exceptions')*
- `PYTHONPATH=src pytest tests/test_imports.py -q` *(fails: AttributeError: module 'tests.stubs.numpy' has no attribute '__version__')*

------
https://chatgpt.com/codex/tasks/task_e_6895b21aefbc83248c9e7f52d2ce44b3