### PR TITLE
Developer API placeholder metrics test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,16 +20,16 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Scheduler and reasoning engine cleanup
 
- 
 
- 
- 
+
+
+
 ## [0.4.2] - 2025-06-22
 ### Added
 - ChatHub with slash commands, short-term NeuroVault memory and metrics
 - Expanded feature guide and memory docs with ChatHub details
 
- 
+
 ## [0.4.3] - 2025-06-22
 ### Added
 - LLM registry and `llm_manager` plugin with `/models` API
@@ -43,7 +43,7 @@ All notable changes to this project will be documented in this file.
 - MeshPlanner Neo4j integration and plugin chaining
 - Documentation updates for mesh_arch and event_bus
 
- 
+
 
 ## [0.3.0] - 2025-05-10
 - EchoCore integration with reflection tokens
@@ -53,3 +53,7 @@ All notable changes to this project will be documented in this file.
 
 ## [0.1.0] - 2025-03-01
 - Initial skeleton with FastAPI and example plugin
+
+## [0.4.5] - 2025-08-08
+### Fixed
+- Developer API no longer requires a database connection and falls back to placeholder metrics when no `db_client` is provided.

--- a/tests/developer_api/test_no_db.py
+++ b/tests/developer_api/test_no_db.py
@@ -1,0 +1,26 @@
+import sys
+from unittest.mock import MagicMock
+
+sys.modules["pyautogui"] = MagicMock()
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from ui_launchers.backend.developer_api import get_current_user, setup_developer_api
+
+
+def test_developer_api_runs_without_db_client() -> None:
+    app = FastAPI()
+    setup_developer_api(app)
+    client = TestClient(app)
+
+    mock_user = MagicMock()
+    mock_user.user_id = "test"
+    mock_user.roles = ["admin"]
+    app.dependency_overrides[get_current_user] = lambda: mock_user
+
+    response = client.get("/api/developer/chat-metrics")
+    assert response.status_code == 200
+    data = response.json()
+    assert "metrics" in data
+    assert "summary" in data


### PR DESCRIPTION
## Summary
- test developer API without DB client fallback
- document that developer API uses placeholder metrics when DB is absent

## Testing
- `pre-commit run --files CHANGELOG.md tests/developer_api/test_no_db.py` (fails: mypy cannot find fastapi stubs and reports numerous existing type errors)
- `PYTHONPATH=src:. pytest tests/developer_api/test_no_db.py -q --confcutdir=tests/developer_api`

------
https://chatgpt.com/codex/tasks/task_e_6895b21aefbc83248c9e7f52d2ce44b3