### PR TITLE
feat: migrate conversations to message tables

### DIFF
--- a/data/migrations/postgres/011_add_messages_table.sql
+++ b/data/migrations/postgres/011_add_messages_table.sql
@@ -1,0 +1,43 @@
+-- Create messages and message_tools tables
+CREATE TABLE IF NOT EXISTS messages (
+    id UUID PRIMARY KEY,
+    conversation_id UUID NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
+    role TEXT NOT NULL,
+    content TEXT NOT NULL,
+    metadata JSONB DEFAULT '{}'::jsonb,
+    function_call JSONB,
+    function_response JSONB,
+    created_at TIMESTAMP DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_messages_convo_time ON messages(conversation_id, created_at);
+
+CREATE TABLE IF NOT EXISTS message_tools (
+    id BIGSERIAL PRIMARY KEY,
+    message_id UUID NOT NULL REFERENCES messages(id) ON DELETE CASCADE,
+    tool_name TEXT NOT NULL,
+    arguments JSONB,
+    result JSONB,
+    latency_ms INT,
+    status TEXT,
+    created_at TIMESTAMP DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_message_tools_message ON message_tools(message_id);
+
+-- Backfill existing conversation messages into messages table
+INSERT INTO messages (id, conversation_id, role, content, metadata, function_call, function_response, created_at)
+SELECT
+    (msg->>'id')::uuid,
+    c.id,
+    msg->>'role',
+    msg->>'content',
+    COALESCE(msg->'metadata', '{}'),
+    msg->'function_call',
+    msg->'function_response',
+    (msg->>'timestamp')::timestamp
+FROM conversations c
+CROSS JOIN LATERAL jsonb_array_elements(COALESCE(c.messages::jsonb, '[]'::jsonb)) AS msg;
+
+-- Remove old messages column
+ALTER TABLE conversations DROP COLUMN IF EXISTS messages;

--- a/docker/database/migrations/postgres/008_add_messages_table.sql
+++ b/docker/database/migrations/postgres/008_add_messages_table.sql
@@ -1,0 +1,43 @@
+-- Create messages and message_tools tables
+CREATE TABLE IF NOT EXISTS messages (
+    id UUID PRIMARY KEY,
+    conversation_id UUID NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
+    role TEXT NOT NULL,
+    content TEXT NOT NULL,
+    metadata JSONB DEFAULT '{}'::jsonb,
+    function_call JSONB,
+    function_response JSONB,
+    created_at TIMESTAMP DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_messages_convo_time ON messages(conversation_id, created_at);
+
+CREATE TABLE IF NOT EXISTS message_tools (
+    id BIGSERIAL PRIMARY KEY,
+    message_id UUID NOT NULL REFERENCES messages(id) ON DELETE CASCADE,
+    tool_name TEXT NOT NULL,
+    arguments JSONB,
+    result JSONB,
+    latency_ms INT,
+    status TEXT,
+    created_at TIMESTAMP DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_message_tools_message ON message_tools(message_id);
+
+-- Backfill existing conversation messages into messages table
+INSERT INTO messages (id, conversation_id, role, content, metadata, function_call, function_response, created_at)
+SELECT
+    (msg->>'id')::uuid,
+    c.id,
+    msg->>'role',
+    msg->>'content',
+    COALESCE(msg->'metadata', '{}'),
+    msg->'function_call',
+    msg->'function_response',
+    (msg->>'timestamp')::timestamp
+FROM conversations c
+CROSS JOIN LATERAL jsonb_array_elements(COALESCE(c.messages::jsonb, '[]'::jsonb)) AS msg;
+
+-- Remove old messages column
+ALTER TABLE conversations DROP COLUMN IF EXISTS messages;

--- a/src/ai_karen_engine/chat/enhanced_conversation_manager.py
+++ b/src/ai_karen_engine/chat/enhanced_conversation_manager.py
@@ -3,45 +3,46 @@ Enhanced ConversationManager with advanced features for production-ready chat sy
 Supports branching, templates, folders, search, and comprehensive conversation management.
 """
 
-import asyncio
-import json
 import logging
 import time
 import uuid
-from datetime import datetime, timedelta
-from typing import Dict, List, Optional, Any, Union, Tuple
-from dataclasses import dataclass
-from pathlib import Path
+from datetime import datetime
+from typing import Any, Dict, List, Optional, Union
 
-from sqlalchemy import text, select, insert, update, delete, func, and_, or_
-from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import selectinload
+from sqlalchemy import func, select, update
 
-from ai_karen_engine.database.client import MultiTenantPostgresClient
-from ai_karen_engine.database.models import TenantConversation, AuthUser
 from ai_karen_engine.chat.conversation_models import (
-    Conversation, ChatMessage, ConversationFolder, ConversationTemplate,
-    ConversationFilters, ConversationSearchResult, ConversationExportOptions,
-    ConversationImportOptions, ConversationBranch, ConversationStats,
-    QuickAction, MessageRole, MessageType, ConversationStatus
+    ChatMessage,
+    Conversation,
+    ConversationExportOptions,
+    ConversationFilters,
+    ConversationFolder,
+    ConversationSearchResult,
+    ConversationStats,
+    ConversationStatus,
+    ConversationTemplate,
+    MessageRole,
+    MessageType,
 )
+from ai_karen_engine.database.client import MultiTenantPostgresClient
+from ai_karen_engine.database.models import TenantConversation, TenantMessage
 
 logger = logging.getLogger(__name__)
 
 
 class ConversationSearchService:
     """Service for searching conversations with full-text and semantic search."""
-    
+
     def __init__(self, distilbert_service=None):
         self.distilbert_service = distilbert_service
-        
+
     async def hybrid_search(
         self,
         user_id: str,
         text_query: str,
         embedding_query: Optional[List[float]] = None,
         filters: Optional[ConversationFilters] = None,
-        limit: int = 20
+        limit: int = 20,
     ) -> List[ConversationSearchResult]:
         """Perform hybrid search combining text and semantic similarity."""
         # This would integrate with full-text search and vector search
@@ -51,12 +52,12 @@ class ConversationSearchService:
 
 class ConversationExportService:
     """Service for exporting conversations in various formats."""
-    
+
     async def export_conversation(
         self,
         conversation: Conversation,
         messages: List[ChatMessage],
-        options: ConversationExportOptions
+        options: ConversationExportOptions,
     ) -> Dict[str, Any]:
         """Export conversation in specified format."""
         if options.format == "json":
@@ -69,12 +70,12 @@ class ConversationExportService:
             return await self._export_html(conversation, messages, options)
         else:
             raise ValueError(f"Unsupported export format: {options.format}")
-    
+
     async def _export_json(
         self,
         conversation: Conversation,
         messages: List[ChatMessage],
-        options: ConversationExportOptions
+        options: ConversationExportOptions,
     ) -> Dict[str, Any]:
         """Export as JSON format."""
         export_data = {
@@ -83,58 +84,57 @@ class ConversationExportService:
             "export_metadata": {
                 "exported_at": datetime.utcnow().isoformat(),
                 "format": "json",
-                "version": "1.0"
-            }
+                "version": "1.0",
+            },
         }
-        
+
         if not options.include_metadata:
             # Remove metadata fields
             export_data["conversation"].pop("metadata", None)
             for msg in export_data["messages"]:
                 msg.pop("metadata", None)
-        
+
         return export_data
-    
+
     async def _export_markdown(
         self,
         conversation: Conversation,
         messages: List[ChatMessage],
-        options: ConversationExportOptions
+        options: ConversationExportOptions,
     ) -> Dict[str, Any]:
         """Export as Markdown format."""
         md_content = f"# {conversation.title}\n\n"
-        
+
         if conversation.description:
             md_content += f"{conversation.description}\n\n"
-        
+
         if options.include_metadata:
             md_content += f"**Created:** {conversation.created_at}\n"
             md_content += f"**Messages:** {len(messages)}\n"
             if conversation.tags:
                 md_content += f"**Tags:** {', '.join(conversation.tags)}\n"
             md_content += "\n---\n\n"
-        
+
         for msg in messages:
             if not options.include_system_messages and msg.role == MessageRole.SYSTEM:
                 continue
-                
-            role_emoji = {"user": "👤", "assistant": "🤖", "system": "⚙️"}.get(msg.role.value, "")
+
+            role_emoji = {"user": "👤", "assistant": "🤖", "system": "⚙️"}.get(
+                msg.role.value, ""
+            )
             md_content += f"## {role_emoji} {msg.role.value.title()}\n\n"
             md_content += f"{msg.content}\n\n"
-            
+
             if options.include_metadata and msg.created_at:
                 md_content += f"*{msg.created_at}*\n\n"
-        
-        return {
-            "content": md_content,
-            "filename": f"{conversation.title}.md"
-        }
-    
+
+        return {"content": md_content, "filename": f"{conversation.title}.md"}
+
     async def _export_pdf(
         self,
         conversation: Conversation,
         messages: List[ChatMessage],
-        options: ConversationExportOptions
+        options: ConversationExportOptions,
     ) -> Dict[str, Any]:
         """Export as PDF format."""
         # This would use a PDF generation library like reportlab
@@ -142,14 +142,14 @@ class ConversationExportService:
         return {
             "content": b"PDF content placeholder",
             "filename": f"{conversation.title}.pdf",
-            "content_type": "application/pdf"
+            "content_type": "application/pdf",
         }
-    
+
     async def _export_html(
         self,
         conversation: Conversation,
         messages: List[ChatMessage],
-        options: ConversationExportOptions
+        options: ConversationExportOptions,
     ) -> Dict[str, Any]:
         """Export as HTML format."""
         html_content = f"""
@@ -169,14 +169,14 @@ class ConversationExportService:
         <body>
             <h1>{conversation.title}</h1>
         """
-        
+
         if conversation.description:
             html_content += f"<p>{conversation.description}</p>"
-        
+
         for msg in messages:
             if not options.include_system_messages and msg.role == MessageRole.SYSTEM:
                 continue
-                
+
             html_content += f"""
             <div class="message {msg.role.value}">
                 <strong>{msg.role.value.title()}:</strong>
@@ -184,39 +184,36 @@ class ConversationExportService:
                 {f'<div class="timestamp">{msg.created_at}</div>' if options.include_metadata else ''}
             </div>
             """
-        
+
         html_content += "</body></html>"
-        
-        return {
-            "content": html_content,
-            "filename": f"{conversation.title}.html"
-        }
+
+        return {"content": html_content, "filename": f"{conversation.title}.html"}
 
 
 class EnhancedConversationManager:
     """Enhanced conversation manager with advanced features."""
-    
+
     def __init__(
         self,
         db_client: MultiTenantPostgresClient,
         distilbert_service=None,
-        file_storage=None
+        file_storage=None,
     ):
         """Initialize enhanced conversation manager."""
         self.db_client = db_client
         self.distilbert_service = distilbert_service
         self.file_storage = file_storage
-        
+
         # Services
         self.search_service = ConversationSearchService(db_client, distilbert_service)
         self.export_service = ConversationExportService()
-        
+
         # Configuration
         self.max_context_messages = 50
         self.auto_title_threshold = 3
         self.summary_interval_messages = 100
         self.inactive_threshold_days = 30
-        
+
         # Performance tracking
         self.metrics = {
             "conversations_created": 0,
@@ -224,11 +221,11 @@ class EnhancedConversationManager:
             "templates_used": 0,
             "searches_performed": 0,
             "exports_completed": 0,
-            "avg_response_time": 0.0
+            "avg_response_time": 0.0,
         }
-    
+
     # CRUD Operations
-    
+
     async def create_conversation(
         self,
         tenant_id: Union[str, uuid.UUID],
@@ -239,14 +236,14 @@ class EnhancedConversationManager:
         template_id: Optional[str] = None,
         tags: Optional[List[str]] = None,
         initial_message: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> Conversation:
         """Create a new conversation with advanced features."""
         start_time = time.time()
-        
+
         try:
             conversation_id = str(uuid.uuid4())
-            
+
             # Apply template if specified
             template_data = None
             if template_id:
@@ -255,11 +252,13 @@ class EnhancedConversationManager:
                     if not title:
                         title = f"New {template_data.name}"
                     self.metrics["templates_used"] += 1
-            
+
             # Generate title if not provided
             if not title:
-                title = await self._generate_conversation_title(user_id, initial_message)
-            
+                title = await self._generate_conversation_title(
+                    user_id, initial_message
+                )
+
             # Create conversation object
             conversation = Conversation(
                 id=conversation_id,
@@ -269,9 +268,9 @@ class EnhancedConversationManager:
                 folder_id=folder_id,
                 template_id=template_id,
                 tags=tags or [],
-                metadata=metadata or {}
+                metadata=metadata or {},
             )
-            
+
             # Store in database
             async with self.db_client.get_async_session() as session:
                 db_conversation = TenantConversation(
@@ -287,13 +286,13 @@ class EnhancedConversationManager:
                         "description": description,
                         "status": conversation.status.value,
                         "is_favorite": conversation.is_favorite,
-                        "priority": conversation.priority
-                    }
+                        "priority": conversation.priority,
+                    },
                 )
-                
+
                 session.add(db_conversation)
                 await session.commit()
-            
+
             # Add initial messages from template
             if template_data and template_data.initial_messages:
                 for template_msg in template_data.initial_messages:
@@ -303,54 +302,61 @@ class EnhancedConversationManager:
                         role=template_msg.role,
                         content=template_msg.content,
                         message_type=template_msg.message_type,
-                        metadata=template_msg.metadata
+                        metadata=template_msg.metadata,
                     )
-            
+
             # Add initial user message if provided
             if initial_message:
                 await self.add_message(
                     tenant_id=tenant_id,
                     conversation_id=conversation_id,
                     role=MessageRole.USER,
-                    content=initial_message
+                    content=initial_message,
                 )
-            
+
             self.metrics["conversations_created"] += 1
-            
+
             response_time = time.time() - start_time
             self.metrics["avg_response_time"] = (
                 self.metrics["avg_response_time"] * 0.9 + response_time * 0.1
             )
-            
+
             logger.info(f"Created conversation {conversation_id} for user {user_id}")
             return conversation
-            
+
         except Exception as e:
             logger.error(f"Failed to create conversation: {e}")
             raise
-    
+
     async def get_conversation(
         self,
         tenant_id: Union[str, uuid.UUID],
         conversation_id: str,
         include_messages: bool = True,
-        include_branches: bool = False
+        include_branches: bool = False,
     ) -> Optional[Conversation]:
         """Get conversation by ID with enhanced features."""
         try:
             async with self.db_client.get_async_session() as session:
                 result = await session.execute(
-                    select(TenantConversation)
-                    .where(TenantConversation.id == uuid.UUID(conversation_id))
+                    select(TenantConversation).where(
+                        TenantConversation.id == uuid.UUID(conversation_id)
+                    )
                 )
-                
+
                 db_conversation = result.scalar_one_or_none()
                 if not db_conversation:
                     return None
-                
+
                 # Convert to enhanced conversation object
                 metadata = db_conversation.conversation_metadata or {}
-                
+
+                msg_count_result = await session.execute(
+                    select(func.count())
+                    .select_from(TenantMessage)
+                    .where(TenantMessage.conversation_id == db_conversation.id)
+                )
+
                 conversation = Conversation(
                     id=str(db_conversation.id),
                     user_id=str(db_conversation.user_id),
@@ -365,21 +371,21 @@ class EnhancedConversationManager:
                     parent_conversation_id=metadata.get("parent_conversation_id"),
                     branch_point_message_id=metadata.get("branch_point_message_id"),
                     child_branches=metadata.get("child_branches", []),
-                    message_count=len(db_conversation.messages or []),
+                    message_count=msg_count_result.scalar() or 0,
                     created_at=db_conversation.created_at,
                     updated_at=db_conversation.updated_at,
-                    metadata=metadata
+                    metadata=metadata,
                 )
-                
+
                 # Update last accessed time
                 await self._update_last_accessed(conversation_id)
-                
+
                 return conversation
-                
+
         except Exception as e:
             logger.error(f"Failed to get conversation {conversation_id}: {e}")
             return None
-    
+
     async def add_message(
         self,
         tenant_id: Union[str, uuid.UUID],
@@ -389,7 +395,7 @@ class EnhancedConversationManager:
         message_type: MessageType = MessageType.TEXT,
         metadata: Optional[Dict[str, Any]] = None,
         parent_message_id: Optional[str] = None,
-        attachments: Optional[List[str]] = None
+        attachments: Optional[List[str]] = None,
     ) -> Optional[ChatMessage]:
         """Add a message to conversation with enhanced features."""
         try:
@@ -401,52 +407,60 @@ class EnhancedConversationManager:
                 message_type=message_type,
                 metadata=metadata or {},
                 parent_message_id=parent_message_id,
-                attachments=attachments or []
+                attachments=attachments or [],
             )
-            
+
             # Update conversation in database
             async with self.db_client.get_async_session() as session:
                 result = await session.execute(
-                    select(TenantConversation)
-                    .where(TenantConversation.id == uuid.UUID(conversation_id))
+                    select(TenantConversation).where(
+                        TenantConversation.id == uuid.UUID(conversation_id)
+                    )
                 )
-                
+
                 db_conversation = result.scalar_one_or_none()
                 if not db_conversation:
                     logger.error(f"Conversation {conversation_id} not found")
                     return None
-                
-                # Add message to conversation
-                current_messages = db_conversation.messages or []
-                current_messages.append(message.model_dump())
-                
-                # Update conversation
+
+                db_message = TenantMessage(
+                    id=uuid.UUID(message.id),
+                    conversation_id=db_conversation.id,
+                    role=message.role.value,
+                    content=message.content,
+                    message_metadata=message.metadata,
+                    function_call=getattr(message, "function_call", None),
+                    function_response=getattr(message, "function_response", None),
+                    created_at=message.created_at or datetime.utcnow(),
+                )
+                session.add(db_message)
+
                 await session.execute(
                     update(TenantConversation)
-                    .where(TenantConversation.id == uuid.UUID(conversation_id))
-                    .values(
-                        messages=current_messages,
-                        updated_at=datetime.utcnow()
-                    )
+                    .where(TenantConversation.id == db_conversation.id)
+                    .values(updated_at=datetime.utcnow())
                 )
+
                 await session.commit()
-            
+
             logger.debug(f"Added message to conversation {conversation_id}")
             return message
-            
+
         except Exception as e:
-            logger.error(f"Failed to add message to conversation {conversation_id}: {e}")
+            logger.error(
+                f"Failed to add message to conversation {conversation_id}: {e}"
+            )
             return None
-    
+
     # Advanced Features
-    
+
     async def branch_conversation(
         self,
         tenant_id: Union[str, uuid.UUID],
         conversation_id: str,
         from_message_id: str,
         user_id: str,
-        branch_title: Optional[str] = None
+        branch_title: Optional[str] = None,
     ) -> Optional[Conversation]:
         """Create a new conversation branch from a specific message."""
         try:
@@ -456,16 +470,16 @@ class EnhancedConversationManager:
             )
             if not original_conversation:
                 return None
-            
+
             # Get messages up to branch point
             messages = await self.get_conversation_messages(
                 tenant_id, conversation_id, up_to_message_id=from_message_id
             )
-            
+
             # Create branch title
             if not branch_title:
                 branch_title = f"{original_conversation.title} (Branch)"
-            
+
             # Create new conversation
             branch_conversation = await self.create_conversation(
                 tenant_id=tenant_id,
@@ -476,10 +490,10 @@ class EnhancedConversationManager:
                 metadata={
                     "parent_conversation_id": conversation_id,
                     "branch_point_message_id": from_message_id,
-                    "is_branch": True
-                }
+                    "is_branch": True,
+                },
             )
-            
+
             # Copy messages up to branch point
             for message in messages:
                 await self.add_message(
@@ -489,44 +503,62 @@ class EnhancedConversationManager:
                     content=message.content,
                     message_type=message.message_type,
                     metadata=message.metadata,
-                    attachments=message.attachments
+                    attachments=message.attachments,
                 )
-            
+
             # Update parent conversation to track this branch
             await self._add_child_branch(conversation_id, branch_conversation.id)
-            
+
             self.metrics["conversations_branched"] += 1
-            
-            logger.info(f"Created branch {branch_conversation.id} from {conversation_id}")
+
+            logger.info(
+                f"Created branch {branch_conversation.id} from {conversation_id}"
+            )
             return branch_conversation
-            
+
         except Exception as e:
             logger.error(f"Failed to branch conversation {conversation_id}: {e}")
             return None
-    
+
     async def get_conversation_messages(
         self,
         tenant_id: Union[str, uuid.UUID],
         conversation_id: str,
         up_to_message_id: Optional[str] = None,
         limit: Optional[int] = None,
-        offset: int = 0
+        offset: int = 0,
     ) -> List[ChatMessage]:
         """Get messages from a conversation with filtering options."""
         try:
             async with self.db_client.get_async_session() as session:
                 result = await session.execute(
-                    select(TenantConversation)
-                    .where(TenantConversation.id == uuid.UUID(conversation_id))
+                    select(TenantConversation).where(
+                        TenantConversation.id == uuid.UUID(conversation_id)
+                    )
                 )
-                
+
                 db_conversation = result.scalar_one_or_none()
                 if not db_conversation:
                     return []
-                
-                messages_data = db_conversation.messages or []
-                messages = [ChatMessage(**msg_data) for msg_data in messages_data]
-                
+
+                msg_result = await session.execute(
+                    select(TenantMessage)
+                    .where(TenantMessage.conversation_id == db_conversation.id)
+                    .order_by(TenantMessage.created_at.asc())
+                )
+                db_messages = msg_result.scalars().all()
+                messages = [
+                    ChatMessage(
+                        id=str(m.id),
+                        conversation_id=str(m.conversation_id),
+                        role=MessageRole(m.role),
+                        content=m.content,
+                        created_at=m.created_at,
+                        metadata=m.message_metadata or {},
+                    )
+                    for m in db_messages
+                ]
+
                 # Filter up to specific message if requested
                 if up_to_message_id:
                     filtered_messages = []
@@ -535,21 +567,23 @@ class EnhancedConversationManager:
                         if msg.id == up_to_message_id:
                             break
                     messages = filtered_messages
-                
+
                 # Apply pagination
                 if offset > 0:
                     messages = messages[offset:]
                 if limit:
                     messages = messages[:limit]
-                
+
                 return messages
-                
+
         except Exception as e:
-            logger.error(f"Failed to get messages for conversation {conversation_id}: {e}")
+            logger.error(
+                f"Failed to get messages for conversation {conversation_id}: {e}"
+            )
             return []
-    
+
     # Folder Management
-    
+
     async def create_folder(
         self,
         tenant_id: Union[str, uuid.UUID],
@@ -558,7 +592,7 @@ class EnhancedConversationManager:
         description: Optional[str] = None,
         parent_folder_id: Optional[str] = None,
         color: Optional[str] = None,
-        icon: Optional[str] = None
+        icon: Optional[str] = None,
     ) -> ConversationFolder:
         """Create a new conversation folder."""
         folder = ConversationFolder(
@@ -567,55 +601,57 @@ class EnhancedConversationManager:
             description=description,
             parent_folder_id=parent_folder_id,
             color=color,
-            icon=icon
+            icon=icon,
         )
-        
+
         # Store in database (would need to extend schema)
         # For now, storing in conversation metadata
-        
+
         logger.info(f"Created folder {folder.id} for user {user_id}")
         return folder
-    
+
     async def move_to_folder(
         self,
         tenant_id: Union[str, uuid.UUID],
         conversation_id: str,
-        folder_id: Optional[str]
+        folder_id: Optional[str],
     ) -> bool:
         """Move conversation to a folder."""
         try:
             async with self.db_client.get_async_session() as session:
                 result = await session.execute(
-                    select(TenantConversation)
-                    .where(TenantConversation.id == uuid.UUID(conversation_id))
+                    select(TenantConversation).where(
+                        TenantConversation.id == uuid.UUID(conversation_id)
+                    )
                 )
-                
+
                 db_conversation = result.scalar_one_or_none()
                 if not db_conversation:
                     return False
-                
+
                 # Update metadata
                 metadata = db_conversation.conversation_metadata or {}
                 metadata["folder_id"] = folder_id
-                
+
                 await session.execute(
                     update(TenantConversation)
                     .where(TenantConversation.id == uuid.UUID(conversation_id))
                     .values(
-                        conversation_metadata=metadata,
-                        updated_at=datetime.utcnow()
+                        conversation_metadata=metadata, updated_at=datetime.utcnow()
                     )
                 )
                 await session.commit()
-                
+
                 return True
-                
+
         except Exception as e:
-            logger.error(f"Failed to move conversation {conversation_id} to folder: {e}")
+            logger.error(
+                f"Failed to move conversation {conversation_id} to folder: {e}"
+            )
             return False
-    
+
     # Template Management
-    
+
     async def create_template(
         self,
         user_id: Optional[str],
@@ -624,7 +660,7 @@ class EnhancedConversationManager:
         category: str = "general",
         initial_messages: Optional[List[ChatMessage]] = None,
         tags: Optional[List[str]] = None,
-        is_public: bool = False
+        is_public: bool = False,
     ) -> ConversationTemplate:
         """Create a new conversation template."""
         template = ConversationTemplate(
@@ -634,32 +670,32 @@ class EnhancedConversationManager:
             category=category,
             initial_messages=initial_messages or [],
             tags=tags or [],
-            is_public=is_public
+            is_public=is_public,
         )
-        
+
         # Store in database (would need to extend schema)
-        
+
         logger.info(f"Created template {template.id}")
         return template
-    
+
     async def get_template(self, template_id: str) -> Optional[ConversationTemplate]:
         """Get a conversation template by ID."""
         # This would fetch from database
         # For now, returning None
         return None
-    
+
     async def list_templates(
         self,
         user_id: Optional[str] = None,
         category: Optional[str] = None,
-        is_public: Optional[bool] = None
+        is_public: Optional[bool] = None,
     ) -> List[ConversationTemplate]:
         """List available conversation templates."""
         # This would fetch from database with filters
         return []
-    
+
     # Search and Filtering
-    
+
     async def search_conversations(
         self,
         tenant_id: Union[str, uuid.UUID],
@@ -667,32 +703,32 @@ class EnhancedConversationManager:
         query: str,
         filters: Optional[ConversationFilters] = None,
         limit: int = 20,
-        offset: int = 0
+        offset: int = 0,
     ) -> List[ConversationSearchResult]:
         """Search conversations with full-text and semantic search."""
         try:
             self.metrics["searches_performed"] += 1
-            
+
             # Generate query embedding for semantic search if available
             query_embedding = None
             if self.distilbert_service:
                 query_embedding = await self.distilbert_service.get_embeddings(query)
-            
+
             # Perform hybrid search
             results = await self.search_service.hybrid_search(
                 user_id=user_id,
                 text_query=query,
                 embedding_query=query_embedding,
                 filters=filters,
-                limit=limit
+                limit=limit,
             )
-            
+
             return results
-            
+
         except Exception as e:
             logger.error(f"Failed to search conversations: {e}")
             return []
-    
+
     async def list_conversations(
         self,
         tenant_id: Union[str, uuid.UUID],
@@ -701,48 +737,51 @@ class EnhancedConversationManager:
         sort_by: str = "updated_at",
         sort_order: str = "desc",
         limit: int = 50,
-        offset: int = 0
+        offset: int = 0,
     ) -> List[Conversation]:
         """List conversations with advanced filtering and sorting."""
         try:
             async with self.db_client.get_async_session() as session:
-                query = (
-                    select(TenantConversation)
-                    .where(TenantConversation.user_id == uuid.UUID(user_id))
+                query = select(TenantConversation).where(
+                    TenantConversation.user_id == uuid.UUID(user_id)
                 )
-                
+
                 # Apply filters
                 if filters:
                     if filters.status:
                         # Filter by status in metadata
                         pass  # Would need JSON query
-                    
+
                     if filters.is_favorite is not None:
                         # Filter by favorite status in metadata
                         pass  # Would need JSON query
-                    
+
                     if filters.folder_ids:
                         # Filter by folder IDs in metadata
                         pass  # Would need JSON query
-                    
+
                     if filters.tags:
                         # Filter by tags in metadata
                         pass  # Would need JSON query
-                    
+
                     if filters.date_from:
-                        query = query.where(TenantConversation.created_at >= filters.date_from)
-                    
+                        query = query.where(
+                            TenantConversation.created_at >= filters.date_from
+                        )
+
                     if filters.date_to:
-                        query = query.where(TenantConversation.created_at <= filters.date_to)
-                    
+                        query = query.where(
+                            TenantConversation.created_at <= filters.date_to
+                        )
+
                     if filters.min_messages:
                         # Would need to filter by message count
                         pass
-                    
+
                     if filters.max_messages:
                         # Would need to filter by message count
                         pass
-                
+
                 # Apply sorting
                 if sort_by == "created_at":
                     if sort_order == "desc":
@@ -759,17 +798,17 @@ class EnhancedConversationManager:
                         query = query.order_by(TenantConversation.title.desc())
                     else:
                         query = query.order_by(TenantConversation.title.asc())
-                
+
                 # Apply pagination
                 query = query.limit(limit).offset(offset)
-                
+
                 result = await session.execute(query)
                 db_conversations = result.scalars().all()
-                
+
                 conversations = []
                 for db_conv in db_conversations:
                     metadata = db_conv.conversation_metadata or {}
-                    
+
                     conversation = Conversation(
                         id=str(db_conv.id),
                         user_id=str(db_conv.user_id),
@@ -780,100 +819,111 @@ class EnhancedConversationManager:
                         tags=metadata.get("tags", []),
                         is_favorite=metadata.get("is_favorite", False),
                         priority=metadata.get("priority", 0),
-                        message_count=len(db_conv.messages or []),
+                        message_count=(
+                            await session.execute(
+                                select(func.count())
+                                .select_from(TenantMessage)
+                                .where(TenantMessage.conversation_id == db_conv.id)
+                            )
+                        ).scalar()
+                        or 0,
                         created_at=db_conv.created_at,
                         updated_at=db_conv.updated_at,
-                        metadata=metadata
+                        metadata=metadata,
                     )
                     conversations.append(conversation)
-                
+
                 return conversations
-                
+
         except Exception as e:
             logger.error(f"Failed to list conversations for user {user_id}: {e}")
             return []
-    
+
     # Export/Import
-    
+
     async def export_conversation(
         self,
         tenant_id: Union[str, uuid.UUID],
         conversation_id: str,
         user_id: str,
-        options: ConversationExportOptions
+        options: ConversationExportOptions,
     ) -> Dict[str, Any]:
         """Export conversation in specified format."""
         try:
             conversation = await self.get_conversation(tenant_id, conversation_id)
             if not conversation:
                 raise ValueError(f"Conversation {conversation_id} not found")
-            
+
             messages = await self.get_conversation_messages(tenant_id, conversation_id)
-            
+
             result = await self.export_service.export_conversation(
                 conversation, messages, options
             )
-            
+
             # Update export count
             await self._increment_export_count(conversation_id)
-            
+
             self.metrics["exports_completed"] += 1
-            
+
             return result
-            
+
         except Exception as e:
             logger.error(f"Failed to export conversation {conversation_id}: {e}")
             raise
-    
+
     # Utility Methods
-    
+
     async def _generate_conversation_title(
-        self,
-        user_id: str,
-        initial_message: Optional[str] = None
+        self, user_id: str, initial_message: Optional[str] = None
     ) -> str:
         """Generate a conversation title."""
         if initial_message:
             # Simple title generation from first message
-            title = initial_message[:50] + "..." if len(initial_message) > 50 else initial_message
+            title = (
+                initial_message[:50] + "..."
+                if len(initial_message) > 50
+                else initial_message
+            )
             return title
         else:
             return f"New Conversation - {datetime.utcnow().strftime('%Y-%m-%d %H:%M')}"
-    
+
     async def _update_last_accessed(self, conversation_id: str):
         """Update the last accessed timestamp for a conversation."""
         try:
             async with self.db_client.get_async_session() as session:
                 result = await session.execute(
-                    select(TenantConversation)
-                    .where(TenantConversation.id == uuid.UUID(conversation_id))
+                    select(TenantConversation).where(
+                        TenantConversation.id == uuid.UUID(conversation_id)
+                    )
                 )
-                
+
                 db_conversation = result.scalar_one_or_none()
                 if db_conversation:
                     metadata = db_conversation.conversation_metadata or {}
                     metadata["last_accessed_at"] = datetime.utcnow().isoformat()
                     metadata["view_count"] = metadata.get("view_count", 0) + 1
-                    
+
                     await session.execute(
                         update(TenantConversation)
                         .where(TenantConversation.id == uuid.UUID(conversation_id))
                         .values(conversation_metadata=metadata)
                     )
                     await session.commit()
-                    
+
         except Exception as e:
             logger.warning(f"Failed to update last accessed for {conversation_id}: {e}")
-    
+
     async def _add_child_branch(self, parent_id: str, branch_id: str):
         """Add a child branch to parent conversation."""
         try:
             async with self.db_client.get_async_session() as session:
                 result = await session.execute(
-                    select(TenantConversation)
-                    .where(TenantConversation.id == uuid.UUID(parent_id))
+                    select(TenantConversation).where(
+                        TenantConversation.id == uuid.UUID(parent_id)
+                    )
                 )
-                
+
                 db_conversation = result.scalar_one_or_none()
                 if db_conversation:
                     metadata = db_conversation.conversation_metadata or {}
@@ -881,117 +931,130 @@ class EnhancedConversationManager:
                     if branch_id not in child_branches:
                         child_branches.append(branch_id)
                         metadata["child_branches"] = child_branches
-                    
+
                     await session.execute(
                         update(TenantConversation)
                         .where(TenantConversation.id == uuid.UUID(parent_id))
                         .values(conversation_metadata=metadata)
                     )
                     await session.commit()
-                    
+
         except Exception as e:
-            logger.warning(f"Failed to add child branch {branch_id} to {parent_id}: {e}")
-    
+            logger.warning(
+                f"Failed to add child branch {branch_id} to {parent_id}: {e}"
+            )
+
     async def _increment_export_count(self, conversation_id: str):
         """Increment the export count for a conversation."""
         try:
             async with self.db_client.get_async_session() as session:
                 result = await session.execute(
-                    select(TenantConversation)
-                    .where(TenantConversation.id == uuid.UUID(conversation_id))
+                    select(TenantConversation).where(
+                        TenantConversation.id == uuid.UUID(conversation_id)
+                    )
                 )
-                
+
                 db_conversation = result.scalar_one_or_none()
                 if db_conversation:
                     metadata = db_conversation.conversation_metadata or {}
                     metadata["export_count"] = metadata.get("export_count", 0) + 1
-                    
+
                     await session.execute(
                         update(TenantConversation)
                         .where(TenantConversation.id == uuid.UUID(conversation_id))
                         .values(conversation_metadata=metadata)
                     )
                     await session.commit()
-                    
+
         except Exception as e:
-            logger.warning(f"Failed to increment export count for {conversation_id}: {e}")
-    
+            logger.warning(
+                f"Failed to increment export count for {conversation_id}: {e}"
+            )
+
     # Statistics and Analytics
-    
+
     async def get_conversation_stats(
-        self,
-        tenant_id: Union[str, uuid.UUID],
-        user_id: str
+        self, tenant_id: Union[str, uuid.UUID], user_id: str
     ) -> ConversationStats:
         """Get comprehensive conversation statistics."""
         try:
             async with self.db_client.get_async_session() as session:
                 # Get all conversations for user
                 result = await session.execute(
-                    select(TenantConversation)
-                    .where(TenantConversation.user_id == uuid.UUID(user_id))
+                    select(TenantConversation).where(
+                        TenantConversation.user_id == uuid.UUID(user_id)
+                    )
                 )
-                
+
                 conversations = result.scalars().all()
-                
+
                 stats = ConversationStats()
                 stats.total_conversations = len(conversations)
-                
+
                 total_messages = 0
                 folders = {}
                 tags = {}
                 templates = {}
                 recent_activity = {}
-                
+
                 for conv in conversations:
                     metadata = conv.conversation_metadata or {}
-                    
+
                     # Count by status
                     status = metadata.get("status", "active")
                     if status == "active":
                         stats.active_conversations += 1
                     elif status == "archived":
                         stats.archived_conversations += 1
-                    
+
                     # Count favorites
                     if metadata.get("is_favorite", False):
                         stats.favorite_conversations += 1
-                    
+
                     # Count messages
-                    message_count = len(conv.messages or [])
+                    message_count = (
+                        await session.execute(
+                            select(func.count())
+                            .select_from(TenantMessage)
+                            .where(TenantMessage.conversation_id == conv.id)
+                        )
+                    ).scalar() or 0
                     total_messages += message_count
-                    
+
                     # Count by folder
                     folder_id = metadata.get("folder_id", "none")
                     folders[folder_id] = folders.get(folder_id, 0) + 1
-                    
+
                     # Count by tags
                     conv_tags = metadata.get("tags", [])
                     for tag in conv_tags:
                         tags[tag] = tags.get(tag, 0) + 1
-                    
+
                     # Count by template
                     template_id = metadata.get("template_id", "none")
                     templates[template_id] = templates.get(template_id, 0) + 1
-                    
+
                     # Recent activity (last 30 days)
                     if conv.updated_at:
                         date_key = conv.updated_at.strftime("%Y-%m-%d")
                         if (datetime.utcnow() - conv.updated_at).days <= 30:
-                            recent_activity[date_key] = recent_activity.get(date_key, 0) + 1
-                
+                            recent_activity[date_key] = (
+                                recent_activity.get(date_key, 0) + 1
+                            )
+
                 stats.total_messages = total_messages
                 stats.avg_messages_per_conversation = (
-                    total_messages / stats.total_conversations 
-                    if stats.total_conversations > 0 else 0.0
+                    total_messages / stats.total_conversations
+                    if stats.total_conversations > 0
+                    else 0.0
                 )
                 stats.conversations_by_folder = folders
                 stats.conversations_by_tag = tags
                 stats.conversations_by_template = templates
                 stats.recent_activity = recent_activity
-                
+
                 return stats
-                
+
         except Exception as e:
             logger.error(f"Failed to get conversation stats: {e}")
             return ConversationStats()

--- a/src/ai_karen_engine/database/conversation_manager.py
+++ b/src/ai_karen_engine/database/conversation_manager.py
@@ -4,30 +4,27 @@ Handles multi-tenant conversations with advanced features like context managemen
 conversation summarization, and intelligent memory integration.
 """
 
-import asyncio
-import json
 import logging
 import time
 import uuid
-from datetime import datetime, timedelta
-from typing import Dict, List, Optional, Any, Union, Tuple
 from dataclasses import dataclass, field
+from datetime import datetime, timedelta
 from enum import Enum
+from typing import Any, Dict, List, Optional, Union
 
-from sqlalchemy import text, select, insert, update, delete, func
-from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import selectinload
+from sqlalchemy import delete, func, select, update
 
-from ai_karen_engine.database.client import MultiTenantPostgresClient
-from ai_karen_engine.database.models import TenantConversation, AuthUser
-from ai_karen_engine.database.memory_manager import MemoryManager, MemoryQuery
 from ai_karen_engine.core.embedding_manager import EmbeddingManager
+from ai_karen_engine.database.client import MultiTenantPostgresClient
+from ai_karen_engine.database.memory_manager import MemoryManager, MemoryQuery
+from ai_karen_engine.database.models import TenantConversation, TenantMessage
 
 logger = logging.getLogger(__name__)
 
 
 class MessageRole(Enum):
     """Message roles in conversation."""
+
     USER = "user"
     ASSISTANT = "assistant"
     SYSTEM = "system"
@@ -37,6 +34,7 @@ class MessageRole(Enum):
 @dataclass
 class Message:
     """Represents a conversation message."""
+
     id: str
     role: MessageRole
     content: str
@@ -44,7 +42,7 @@ class Message:
     metadata: Dict[str, Any] = field(default_factory=dict)
     function_call: Optional[Dict[str, Any]] = None
     function_response: Optional[Dict[str, Any]] = None
-    
+
     def to_dict(self) -> Dict[str, Any]:
         """Convert to dictionary for serialization."""
         return {
@@ -54,9 +52,9 @@ class Message:
             "timestamp": self.timestamp.isoformat(),
             "metadata": self.metadata,
             "function_call": self.function_call,
-            "function_response": self.function_response
+            "function_response": self.function_response,
         }
-    
+
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "Message":
         """Create from dictionary."""
@@ -67,13 +65,14 @@ class Message:
             timestamp=datetime.fromisoformat(data["timestamp"]),
             metadata=data.get("metadata", {}),
             function_call=data.get("function_call"),
-            function_response=data.get("function_response")
+            function_response=data.get("function_response"),
         )
 
 
 @dataclass
 class Conversation:
     """Represents a complete conversation."""
+
     id: str
     user_id: str
     title: Optional[str]
@@ -82,7 +81,7 @@ class Conversation:
     is_active: bool = True
     created_at: datetime = field(default_factory=datetime.utcnow)
     updated_at: datetime = field(default_factory=datetime.utcnow)
-    
+
     def to_dict(self) -> Dict[str, Any]:
         """Convert to dictionary for serialization."""
         return {
@@ -95,47 +94,51 @@ class Conversation:
             "created_at": self.created_at.isoformat(),
             "updated_at": self.updated_at.isoformat(),
             "message_count": len(self.messages),
-            "last_message_at": self.messages[-1].timestamp.isoformat() if self.messages else None
+            "last_message_at": self.messages[-1].timestamp.isoformat()
+            if self.messages
+            else None,
         }
-    
+
     def get_context_window(self, max_messages: int = 20) -> List[Message]:
         """Get recent messages for context window."""
         return self.messages[-max_messages:] if self.messages else []
-    
+
     def get_summary_text(self) -> str:
         """Get a text summary of the conversation."""
         if not self.messages:
             return "Empty conversation"
-        
+
         user_messages = [m for m in self.messages if m.role == MessageRole.USER]
-        assistant_messages = [m for m in self.messages if m.role == MessageRole.ASSISTANT]
-        
+        assistant_messages = [
+            m for m in self.messages if m.role == MessageRole.ASSISTANT
+        ]
+
         summary_parts = []
         if self.title:
             summary_parts.append(f"Title: {self.title}")
-        
+
         summary_parts.append(f"Messages: {len(self.messages)}")
         summary_parts.append(f"User messages: {len(user_messages)}")
         summary_parts.append(f"Assistant messages: {len(assistant_messages)}")
-        
+
         if self.messages:
             summary_parts.append(f"Started: {self.messages[0].timestamp}")
             summary_parts.append(f"Last activity: {self.messages[-1].timestamp}")
-        
+
         return " | ".join(summary_parts)
 
 
 class ConversationManager:
     """Production-grade conversation management system."""
-    
+
     def __init__(
         self,
         db_client: MultiTenantPostgresClient,
         memory_manager: Optional[MemoryManager] = None,
-        embedding_manager: Optional[EmbeddingManager] = None
+        embedding_manager: Optional[EmbeddingManager] = None,
     ):
         """Initialize conversation manager.
-        
+
         Args:
             db_client: Database client
             memory_manager: Memory manager for context integration
@@ -144,79 +147,92 @@ class ConversationManager:
         self.db_client = db_client
         self.memory_manager = memory_manager
         self.embedding_manager = embedding_manager
-        
+
         # Configuration
         self.max_context_messages = 50
         self.auto_title_threshold = 3  # Auto-generate title after N messages
         self.summary_interval_messages = 100  # Summarize every N messages
         self.inactive_threshold_days = 30  # Mark as inactive after N days
-        
+
         # Performance tracking
         self.metrics = {
             "conversations_created": 0,
             "messages_added": 0,
             "conversations_retrieved": 0,
             "summaries_generated": 0,
-            "avg_response_time": 0.0
+            "avg_response_time": 0.0,
         }
-    
+
     async def create_conversation(
         self,
         tenant_id: Union[str, uuid.UUID],
         user_id: str,
         title: Optional[str] = None,
         initial_message: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> Conversation:
         """Create a new conversation.
-        
+
         Args:
             tenant_id: Tenant ID
             user_id: User ID
             title: Conversation title
             initial_message: Initial user message
             metadata: Additional metadata
-            
+
         Returns:
             Created conversation
         """
         start_time = time.time()
-        
+
         try:
             conversation_id = str(uuid.uuid4())
-            messages = []
-            
-            # Add initial message if provided
-            if initial_message:
-                message = Message(
-                    id=str(uuid.uuid4()),
-                    role=MessageRole.USER,
-                    content=initial_message,
-                    timestamp=datetime.utcnow()
-                )
-                messages.append(message)
-            
+            messages: List[Message] = []
+
             conversation = Conversation(
                 id=conversation_id,
                 user_id=user_id,
                 title=title,
                 messages=messages,
-                metadata=metadata or {}
+                metadata=metadata or {},
             )
-            
+
             # Store in database
             async with self.db_client.get_async_session() as session:
                 db_conversation = TenantConversation(
                     id=uuid.UUID(conversation_id),
                     user_id=uuid.UUID(user_id),
                     title=title,
-                    messages=[msg.to_dict() for msg in messages],
-                    conversation_metadata=metadata or {}
+                    conversation_metadata=metadata or {},
                 )
-                
+
                 session.add(db_conversation)
+                await session.flush()
+
+                # Add initial message if provided
+                if initial_message:
+                    message = Message(
+                        id=str(uuid.uuid4()),
+                        role=MessageRole.USER,
+                        content=initial_message,
+                        timestamp=datetime.utcnow(),
+                    )
+                    messages.append(message)
+
+                    db_message = TenantMessage(
+                        id=uuid.UUID(message.id),
+                        conversation_id=db_conversation.id,
+                        role=message.role.value,
+                        content=message.content,
+                        message_metadata=message.metadata,
+                        function_call=message.function_call,
+                        function_response=message.function_response,
+                        created_at=message.timestamp,
+                    )
+                    session.add(db_message)
+
                 await session.commit()
-            
+
             # Store initial message in memory if available
             if initial_message and self.memory_manager:
                 await self.memory_manager.store_memory(
@@ -224,56 +240,75 @@ class ConversationManager:
                     content=initial_message,
                     user_id=user_id,
                     session_id=conversation_id,
-                    metadata={"type": "conversation_start", "conversation_id": conversation_id}
+                    metadata={
+                        "type": "conversation_start",
+                        "conversation_id": conversation_id,
+                    },
                 )
-            
+
             self.metrics["conversations_created"] += 1
-            
+
             response_time = time.time() - start_time
             self.metrics["avg_response_time"] = (
                 self.metrics["avg_response_time"] * 0.9 + response_time * 0.1
             )
-            
+
             logger.info(f"Created conversation {conversation_id} for user {user_id}")
             return conversation
-            
+
         except Exception as e:
             logger.error(f"Failed to create conversation: {e}")
             raise
-    
+
     async def get_conversation(
         self,
         tenant_id: Union[str, uuid.UUID],
         conversation_id: str,
-        include_context: bool = True
+        include_context: bool = True,
     ) -> Optional[Conversation]:
         """Get conversation by ID.
-        
+
         Args:
             tenant_id: Tenant ID
             conversation_id: Conversation ID
             include_context: Whether to include memory context
-            
+
         Returns:
             Conversation if found
         """
         try:
             async with self.db_client.get_async_session() as session:
                 result = await session.execute(
-                    select(TenantConversation)
-                    .where(TenantConversation.id == uuid.UUID(conversation_id))
+                    select(TenantConversation).where(
+                        TenantConversation.id == uuid.UUID(conversation_id)
+                    )
                 )
-                
+
                 db_conversation = result.scalar_one_or_none()
                 if not db_conversation:
                     return None
-                
-                # Convert to conversation object
+
+                # Load messages
+                msg_result = await session.execute(
+                    select(TenantMessage)
+                    .where(TenantMessage.conversation_id == db_conversation.id)
+                    .order_by(TenantMessage.created_at.asc())
+                )
+                db_messages = msg_result.scalars().all()
+
                 messages = [
-                    Message.from_dict(msg_data)
-                    for msg_data in (db_conversation.messages or [])
+                    Message(
+                        id=str(m.id),
+                        role=MessageRole(m.role),
+                        content=m.content,
+                        timestamp=m.created_at,
+                        metadata=m.message_metadata or {},
+                        function_call=m.function_call,
+                        function_response=m.function_response,
+                    )
+                    for m in db_messages
                 ]
-                
+
                 conversation = Conversation(
                     id=str(db_conversation.id),
                     user_id=str(db_conversation.user_id),
@@ -282,20 +317,20 @@ class ConversationManager:
                     metadata=db_conversation.conversation_metadata or {},
                     is_active=db_conversation.is_active,
                     created_at=db_conversation.created_at,
-                    updated_at=db_conversation.updated_at
+                    updated_at=db_conversation.updated_at,
                 )
-                
+
                 # Add memory context if requested
                 if include_context and self.memory_manager and messages:
                     await self._add_memory_context(tenant_id, conversation)
-                
+
                 self.metrics["conversations_retrieved"] += 1
                 return conversation
-                
+
         except Exception as e:
             logger.error(f"Failed to get conversation {conversation_id}: {e}")
             return None
-    
+
     async def add_message(
         self,
         tenant_id: Union[str, uuid.UUID],
@@ -304,10 +339,10 @@ class ConversationManager:
         content: str,
         metadata: Optional[Dict[str, Any]] = None,
         function_call: Optional[Dict[str, Any]] = None,
-        function_response: Optional[Dict[str, Any]] = None
+        function_response: Optional[Dict[str, Any]] = None,
     ) -> Optional[Message]:
         """Add a message to conversation.
-        
+
         Args:
             tenant_id: Tenant ID
             conversation_id: Conversation ID
@@ -316,7 +351,7 @@ class ConversationManager:
             metadata: Message metadata
             function_call: Function call data
             function_response: Function response data
-            
+
         Returns:
             Added message
         """
@@ -328,43 +363,59 @@ class ConversationManager:
                 timestamp=datetime.utcnow(),
                 metadata=metadata or {},
                 function_call=function_call,
-                function_response=function_response
+                function_response=function_response,
             )
-            
+
             # Update conversation in database
             user_id_for_memory = None
             conversation_title = None
+            current_message_count = 0
             async with self.db_client.get_async_session() as session:
                 # Get current conversation
                 result = await session.execute(
-                    select(TenantConversation)
-                    .where(TenantConversation.id == uuid.UUID(conversation_id))
+                    select(TenantConversation).where(
+                        TenantConversation.id == uuid.UUID(conversation_id)
+                    )
                 )
-                
+
                 db_conversation = result.scalar_one_or_none()
                 if not db_conversation:
                     logger.error(f"Conversation {conversation_id} not found")
                     return None
-                
+
                 # Capture values we need outside the session
                 user_id_for_memory = db_conversation.user_id
                 conversation_title = db_conversation.title
-                
-                # Add message to conversation
-                current_messages = db_conversation.messages or []
-                current_messages.append(message.to_dict())
-                
-                # Update conversation
+
+                db_message = TenantMessage(
+                    id=uuid.UUID(message.id),
+                    conversation_id=db_conversation.id,
+                    role=message.role.value,
+                    content=message.content,
+                    message_metadata=message.metadata,
+                    function_call=message.function_call,
+                    function_response=message.function_response,
+                    created_at=message.timestamp,
+                )
+                session.add(db_message)
+
                 await session.execute(
                     update(TenantConversation)
-                    .where(TenantConversation.id == uuid.UUID(conversation_id))
-                    .values(
-                        messages=current_messages,
-                        updated_at=datetime.utcnow()
-                    )
+                    .where(TenantConversation.id == db_conversation.id)
+                    .values(updated_at=datetime.utcnow())
                 )
+
+                await session.flush()
+
+                count_result = await session.execute(
+                    select(func.count())
+                    .select_from(TenantMessage)
+                    .where(TenantMessage.conversation_id == db_conversation.id)
+                )
+                current_message_count = count_result.scalar()
+
                 await session.commit()
-            
+
             # Store in memory if it's a user message
             if role == MessageRole.USER and self.memory_manager and user_id_for_memory:
                 await self.memory_manager.store_memory(
@@ -375,44 +426,49 @@ class ConversationManager:
                     metadata={
                         "type": "user_message",
                         "conversation_id": conversation_id,
-                        "message_id": message.id
-                    }
+                        "message_id": message.id,
+                    },
                 )
-            
+
             # Auto-generate title if needed
-            if len(current_messages) == self.auto_title_threshold and not conversation_title:
+            if (
+                current_message_count == self.auto_title_threshold
+                and not conversation_title
+            ):
                 await self._auto_generate_title(tenant_id, conversation_id)
-            
+
             # Generate summary if needed
-            if len(current_messages) % self.summary_interval_messages == 0:
+            if current_message_count % self.summary_interval_messages == 0:
                 await self._generate_conversation_summary(tenant_id, conversation_id)
-            
+
             self.metrics["messages_added"] += 1
-            
+
             logger.debug(f"Added message to conversation {conversation_id}")
             return message
-            
+
         except Exception as e:
-            logger.error(f"Failed to add message to conversation {conversation_id}: {e}")
+            logger.error(
+                f"Failed to add message to conversation {conversation_id}: {e}"
+            )
             return None
-    
+
     async def list_conversations(
         self,
         tenant_id: Union[str, uuid.UUID],
         user_id: str,
         active_only: bool = True,
         limit: int = 50,
-        offset: int = 0
+        offset: int = 0,
     ) -> List[Conversation]:
         """List conversations for a user.
-        
+
         Args:
             tenant_id: Tenant ID
             user_id: User ID
             active_only: Only return active conversations
             limit: Maximum number of conversations
             offset: Number of conversations to skip
-            
+
         Returns:
             List of conversations
         """
@@ -423,22 +479,36 @@ class ConversationManager:
                     .where(TenantConversation.user_id == uuid.UUID(user_id))
                     .order_by(TenantConversation.updated_at.desc())
                 )
-                
+
                 if active_only:
-                    query = query.where(TenantConversation.is_active == True)
-                
+                    query = query.where(TenantConversation.is_active.is_(True))
+
                 query = query.limit(limit).offset(offset)
-                
+
                 result = await session.execute(query)
                 db_conversations = result.scalars().all()
-                
+
                 conversations = []
                 for db_conv in db_conversations:
+                    msg_result = await session.execute(
+                        select(TenantMessage)
+                        .where(TenantMessage.conversation_id == db_conv.id)
+                        .order_by(TenantMessage.created_at.asc())
+                    )
+                    db_msgs = msg_result.scalars().all()
                     messages = [
-                        Message.from_dict(msg_data)
-                        for msg_data in (db_conv.messages or [])
+                        Message(
+                            id=str(m.id),
+                            role=MessageRole(m.role),
+                            content=m.content,
+                            timestamp=m.created_at,
+                            metadata=m.message_metadata or {},
+                            function_call=m.function_call,
+                            function_response=m.function_response,
+                        )
+                        for m in db_msgs
                     ]
-                    
+
                     conversation = Conversation(
                         id=str(db_conv.id),
                         user_id=str(db_conv.user_id),
@@ -447,46 +517,46 @@ class ConversationManager:
                         metadata=db_conv.conversation_metadata or {},
                         is_active=db_conv.is_active,
                         created_at=db_conv.created_at,
-                        updated_at=db_conv.updated_at
+                        updated_at=db_conv.updated_at,
                     )
                     conversations.append(conversation)
-                
+
                 return conversations
-                
+
         except Exception as e:
             logger.error(f"Failed to list conversations for user {user_id}: {e}")
             return []
-    
+
     async def update_conversation(
         self,
         tenant_id: Union[str, uuid.UUID],
         conversation_id: str,
         title: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
-        is_active: Optional[bool] = None
+        is_active: Optional[bool] = None,
     ) -> bool:
         """Update conversation properties.
-        
+
         Args:
             tenant_id: Tenant ID
             conversation_id: Conversation ID
             title: New title
             metadata: New metadata
             is_active: Active status
-            
+
         Returns:
             True if successful
         """
         try:
             updates = {"updated_at": datetime.utcnow()}
-            
+
             if title is not None:
                 updates["title"] = title
             if metadata is not None:
                 updates["conversation_metadata"] = metadata
             if is_active is not None:
                 updates["is_active"] = is_active
-            
+
             async with self.db_client.get_async_session() as session:
                 await session.execute(
                     update(TenantConversation)
@@ -494,113 +564,114 @@ class ConversationManager:
                     .values(**updates)
                 )
                 await session.commit()
-            
+
             logger.info(f"Updated conversation {conversation_id}")
             return True
-            
+
         except Exception as e:
             logger.error(f"Failed to update conversation {conversation_id}: {e}")
             return False
-    
+
     async def delete_conversation(
-        self,
-        tenant_id: Union[str, uuid.UUID],
-        conversation_id: str
+        self, tenant_id: Union[str, uuid.UUID], conversation_id: str
     ) -> bool:
         """Delete a conversation.
-        
+
         Args:
             tenant_id: Tenant ID
             conversation_id: Conversation ID
-            
+
         Returns:
             True if successful
         """
         try:
             async with self.db_client.get_async_session() as session:
                 await session.execute(
-                    delete(TenantConversation)
-                    .where(TenantConversation.id == uuid.UUID(conversation_id))
+                    delete(TenantConversation).where(
+                        TenantConversation.id == uuid.UUID(conversation_id)
+                    )
                 )
                 await session.commit()
-            
+
             # Clean up related memories
             if self.memory_manager:
                 # This would require implementing a method to delete memories by session_id
                 pass
-            
+
             logger.info(f"Deleted conversation {conversation_id}")
             return True
-            
+
         except Exception as e:
             logger.error(f"Failed to delete conversation {conversation_id}: {e}")
             return False
-    
+
     async def get_conversation_context(
         self,
         tenant_id: Union[str, uuid.UUID],
         conversation_id: str,
         query_text: str,
-        max_context_items: int = 5
+        max_context_items: int = 5,
     ) -> List[Dict[str, Any]]:
         """Get relevant context for conversation from memory.
-        
+
         Args:
             tenant_id: Tenant ID
             conversation_id: Conversation ID
             query_text: Text to find context for
             max_context_items: Maximum context items to return
-            
+
         Returns:
             List of context items
         """
         if not self.memory_manager:
             return []
-        
+
         try:
             # Get conversation to find user_id
-            conversation = await self.get_conversation(tenant_id, conversation_id, include_context=False)
+            conversation = await self.get_conversation(
+                tenant_id, conversation_id, include_context=False
+            )
             if not conversation:
                 return []
-            
+
             # Query memory for relevant context
             memory_query = MemoryQuery(
                 text=query_text,
                 user_id=conversation.user_id,
                 top_k=max_context_items,
-                similarity_threshold=0.7
+                similarity_threshold=0.7,
             )
-            
+
             memories = await self.memory_manager.query_memories(tenant_id, memory_query)
-            
+
             # Convert to context format
             context_items = []
             for memory in memories:
-                context_items.append({
-                    "content": memory.content,
-                    "timestamp": memory.timestamp,
-                    "similarity_score": memory.similarity_score,
-                    "metadata": memory.metadata,
-                    "source": "memory"
-                })
-            
+                context_items.append(
+                    {
+                        "content": memory.content,
+                        "timestamp": memory.timestamp,
+                        "similarity_score": memory.similarity_score,
+                        "metadata": memory.metadata,
+                        "source": "memory",
+                    }
+                )
+
             return context_items
-            
+
         except Exception as e:
             logger.error(f"Failed to get conversation context: {e}")
             return []
-    
+
     async def get_conversation_stats(
-        self,
-        tenant_id: Union[str, uuid.UUID],
-        user_id: Optional[str] = None
+        self, tenant_id: Union[str, uuid.UUID], user_id: Optional[str] = None
     ) -> Dict[str, Any]:
         """Get conversation statistics.
-        
+
         Args:
             tenant_id: Tenant ID
             user_id: Optional user ID to filter by
-            
+
         Returns:
             Conversation statistics
         """
@@ -609,56 +680,77 @@ class ConversationManager:
                 # Base query
                 base_query = select(TenantConversation)
                 if user_id:
-                    base_query = base_query.where(TenantConversation.user_id == uuid.UUID(user_id))
-                
+                    base_query = base_query.where(
+                        TenantConversation.user_id == uuid.UUID(user_id)
+                    )
+
                 # Total conversations
                 total_result = await session.execute(
                     select(func.count()).select_from(base_query.subquery())
                 )
                 total_conversations = total_result.scalar()
-                
+
                 # Active conversations
                 active_result = await session.execute(
                     select(func.count()).select_from(
-                        base_query.where(TenantConversation.is_active == True).subquery()
+                        base_query.where(
+                            TenantConversation.is_active.is_(True)
+                        ).subquery()
                     )
                 )
                 active_conversations = active_result.scalar()
-                
+
                 # Recent conversations (last 7 days)
                 recent_cutoff = datetime.utcnow() - timedelta(days=7)
                 recent_result = await session.execute(
                     select(func.count()).select_from(
-                        base_query.where(TenantConversation.updated_at > recent_cutoff).subquery()
+                        base_query.where(
+                            TenantConversation.updated_at > recent_cutoff
+                        ).subquery()
                     )
                 )
                 recent_conversations = recent_result.scalar()
-                
+
                 # Average messages per conversation
-                all_conversations = await session.execute(base_query)
-                conversations = all_conversations.scalars().all()
-                
-                total_messages = sum(len(conv.messages or []) for conv in conversations)
-                avg_messages = total_messages / total_conversations if total_conversations > 0 else 0
-                
+                msg_query = (
+                    select(func.count())
+                    .select_from(TenantMessage)
+                    .join(
+                        TenantConversation,
+                        TenantMessage.conversation_id == TenantConversation.id,
+                    )
+                )
+                if user_id:
+                    msg_query = msg_query.where(
+                        TenantConversation.user_id == uuid.UUID(user_id)
+                    )
+                total_messages = (await session.execute(msg_query)).scalar()
+                avg_messages = (
+                    total_messages / total_conversations
+                    if total_conversations > 0
+                    else 0
+                )
+
                 return {
                     "total_conversations": total_conversations,
                     "active_conversations": active_conversations,
                     "recent_conversations_7d": recent_conversations,
                     "total_messages": total_messages,
                     "avg_messages_per_conversation": round(avg_messages, 2),
-                    "metrics": self.metrics.copy()
+                    "metrics": self.metrics.copy(),
                 }
-                
+
         except Exception as e:
             logger.error(f"Failed to get conversation stats: {e}")
             return {"error": str(e)}
-    
-    async def _add_memory_context(self, tenant_id: Union[str, uuid.UUID], conversation: Conversation):
+
+    async def _add_memory_context(
+        self, tenant_id: Union[str, uuid.UUID], conversation: Conversation
+    ):
         """Add relevant memory context to conversation."""
         if not self.memory_manager or not conversation.messages:
             return
-        
+
         try:
             # Get the last user message for context
             last_user_message = None
@@ -666,119 +758,137 @@ class ConversationManager:
                 if msg.role == MessageRole.USER:
                     last_user_message = msg
                     break
-            
+
             if not last_user_message:
                 return
-            
+
             # Query for relevant memories
             memory_query = MemoryQuery(
                 text=last_user_message.content,
                 user_id=conversation.user_id,
                 top_k=3,
-                similarity_threshold=0.75
+                similarity_threshold=0.75,
             )
-            
+
             memories = await self.memory_manager.query_memories(tenant_id, memory_query)
-            
+
             # Add context to conversation metadata
             if memories:
                 conversation.metadata["memory_context"] = [
                     {
                         "content": memory.content,
                         "similarity_score": memory.similarity_score,
-                        "timestamp": memory.timestamp
+                        "timestamp": memory.timestamp,
                     }
                     for memory in memories
                 ]
-                
+
         except Exception as e:
             logger.warning(f"Failed to add memory context: {e}")
-    
-    async def _auto_generate_title(self, tenant_id: Union[str, uuid.UUID], conversation_id: str):
+
+    async def _auto_generate_title(
+        self, tenant_id: Union[str, uuid.UUID], conversation_id: str
+    ):
         """Auto-generate conversation title based on content."""
         try:
-            conversation = await self.get_conversation(tenant_id, conversation_id, include_context=False)
+            conversation = await self.get_conversation(
+                tenant_id, conversation_id, include_context=False
+            )
             if not conversation or not conversation.messages:
                 return
-            
+
             # Get first few user messages
             user_messages = [
-                msg.content for msg in conversation.messages[:5]
+                msg.content
+                for msg in conversation.messages[:5]
                 if msg.role == MessageRole.USER
             ]
-            
+
             if not user_messages:
                 return
-            
+
             # Simple title generation (in production, use LLM)
             first_message = user_messages[0]
-            title = first_message[:50] + "..." if len(first_message) > 50 else first_message
-            
+            title = (
+                first_message[:50] + "..." if len(first_message) > 50 else first_message
+            )
+
             # Update conversation title
             await self.update_conversation(tenant_id, conversation_id, title=title)
-            
-            logger.info(f"Auto-generated title for conversation {conversation_id}: {title}")
-            
+
+            logger.info(
+                f"Auto-generated title for conversation {conversation_id}: {title}"
+            )
+
         except Exception as e:
             logger.error(f"Failed to auto-generate title: {e}")
-    
-    async def _generate_conversation_summary(self, tenant_id: Union[str, uuid.UUID], conversation_id: str):
+
+    async def _generate_conversation_summary(
+        self, tenant_id: Union[str, uuid.UUID], conversation_id: str
+    ):
         """Generate conversation summary for long conversations."""
         try:
-            conversation = await self.get_conversation(tenant_id, conversation_id, include_context=False)
-            if not conversation or len(conversation.messages) < self.summary_interval_messages:
+            conversation = await self.get_conversation(
+                tenant_id, conversation_id, include_context=False
+            )
+            if (
+                not conversation
+                or len(conversation.messages) < self.summary_interval_messages
+            ):
                 return
-            
+
             # Generate summary (in production, use LLM)
             summary = f"Conversation with {len(conversation.messages)} messages"
-            
+
             # Store summary in metadata
             metadata = conversation.metadata.copy()
             metadata["summary"] = summary
             metadata["summary_generated_at"] = datetime.utcnow().isoformat()
-            
-            await self.update_conversation(tenant_id, conversation_id, metadata=metadata)
-            
+
+            await self.update_conversation(
+                tenant_id, conversation_id, metadata=metadata
+            )
+
             self.metrics["summaries_generated"] += 1
             logger.info(f"Generated summary for conversation {conversation_id}")
-            
+
         except Exception as e:
             logger.error(f"Failed to generate conversation summary: {e}")
-    
+
     async def cleanup_inactive_conversations(
-        self,
-        tenant_id: Union[str, uuid.UUID],
-        days_inactive: int = None
+        self, tenant_id: Union[str, uuid.UUID], days_inactive: int = None
     ) -> int:
         """Mark old conversations as inactive.
-        
+
         Args:
             tenant_id: Tenant ID
             days_inactive: Days of inactivity threshold
-            
+
         Returns:
             Number of conversations marked inactive
         """
         days_inactive = days_inactive or self.inactive_threshold_days
         cutoff_date = datetime.utcnow() - timedelta(days=days_inactive)
-        
+
         try:
             async with self.db_client.get_async_session() as session:
                 result = await session.execute(
                     update(TenantConversation)
                     .where(
                         TenantConversation.updated_at < cutoff_date,
-                        TenantConversation.is_active == True
+                        TenantConversation.is_active.is_(True),
                     )
                     .values(is_active=False, updated_at=datetime.utcnow())
                 )
-                
+
                 await session.commit()
                 count = result.rowcount
-                
-                logger.info(f"Marked {count} conversations as inactive for tenant {tenant_id}")
+
+                logger.info(
+                    f"Marked {count} conversations as inactive for tenant {tenant_id}"
+                )
                 return count
-                
+
         except Exception as e:
             logger.error(f"Failed to cleanup inactive conversations: {e}")
             return 0

--- a/src/ai_karen_engine/database/migrations/005_messages_table.sql
+++ b/src/ai_karen_engine/database/migrations/005_messages_table.sql
@@ -1,0 +1,43 @@
+-- Create messages and message_tools tables
+CREATE TABLE IF NOT EXISTS messages (
+    id UUID PRIMARY KEY,
+    conversation_id UUID NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
+    role TEXT NOT NULL,
+    content TEXT NOT NULL,
+    metadata JSONB DEFAULT '{}'::jsonb,
+    function_call JSONB,
+    function_response JSONB,
+    created_at TIMESTAMP DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_messages_convo_time ON messages(conversation_id, created_at);
+
+CREATE TABLE IF NOT EXISTS message_tools (
+    id BIGSERIAL PRIMARY KEY,
+    message_id UUID NOT NULL REFERENCES messages(id) ON DELETE CASCADE,
+    tool_name TEXT NOT NULL,
+    arguments JSONB,
+    result JSONB,
+    latency_ms INT,
+    status TEXT,
+    created_at TIMESTAMP DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_message_tools_message ON message_tools(message_id);
+
+-- Backfill existing conversation messages into messages table
+INSERT INTO messages (id, conversation_id, role, content, metadata, function_call, function_response, created_at)
+SELECT
+    (msg->>'id')::uuid,
+    c.id,
+    msg->>'role',
+    msg->>'content',
+    COALESCE(msg->'metadata', '{}'),
+    msg->'function_call',
+    msg->'function_response',
+    (msg->>'timestamp')::timestamp
+FROM conversations c
+CROSS JOIN LATERAL jsonb_array_elements(COALESCE(c.messages::jsonb, '[]'::jsonb)) AS msg;
+
+-- Remove old messages column
+ALTER TABLE conversations DROP COLUMN IF EXISTS messages;


### PR DESCRIPTION
## Summary
- introduce normalized `messages` and `message_tools` tables with indexes
- rewrite conversation management to read and write individual message rows
- add SQL migrations to backfill existing conversation data and drop legacy JSON column

## Testing
- `pre-commit run --files database_schema.sql src/ai_karen_engine/database/models/__init__.py src/ai_karen_engine/database/conversation_manager.py src/ai_karen_engine/chat/enhanced_conversation_manager.py src/ai_karen_engine/database/migrations/005_messages_table.sql docker/database/migrations/postgres/008_add_messages_table.sql data/migrations/postgres/011_add_messages_table.sql` *(fails: mypy missing modules and annotations)*

------
https://chatgpt.com/codex/tasks/task_e_6895ebdcb31483248cd78f86d8c1335e