### PR TITLE
feat: replace memory entries with vector-backed memory items

### DIFF
--- a/data/migrations/postgres/009_create_memory_items_table.sql
+++ b/data/migrations/postgres/009_create_memory_items_table.sql
@@ -1,0 +1,18 @@
+-- 009_create_memory_items_table.sql
+-- Creates memory_items table with vector embeddings and metadata
+
+CREATE EXTENSION IF NOT EXISTS vector;
+
+CREATE TABLE IF NOT EXISTS memory_items (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    scope TEXT NOT NULL,
+    kind TEXT NOT NULL,
+    content TEXT NOT NULL,
+    embedding VECTOR(768),
+    metadata JSONB DEFAULT '{}'::JSONB,
+    created_at TIMESTAMP WITHOUT TIME ZONE DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_memory_items_scope_kind ON memory_items(scope, kind);
+-- Optional vector index for similarity search
+CREATE INDEX IF NOT EXISTS idx_memory_items_embedding ON memory_items USING ivfflat (embedding vector_l2_ops);

--- a/src/ai_karen_engine/clients/database/postgres_client.py
+++ b/src/ai_karen_engine/clients/database/postgres_client.py
@@ -335,15 +335,16 @@ class PostgresClient:
                 # Use tenant-specific schema
                 data_json = json.dumps(result)
                 sql = """
-                    INSERT INTO memory_entries (vector_id, user_id, session_id, content, query, result, timestamp)
-                    VALUES (%s, %s, %s, %s, %s, %s, %s)
-                    ON CONFLICT (vector_id) DO UPDATE SET
-                    user_id=EXCLUDED.user_id, session_id=EXCLUDED.session_id,
-                    content=EXCLUDED.content, query=EXCLUDED.query, result=EXCLUDED.result, timestamp=EXCLUDED.timestamp
+                    INSERT INTO memory_items (id, scope, kind, content, metadata, created_at)
+                    VALUES (%s, %s, %s, %s, %s, to_timestamp(%s))
+                    ON CONFLICT (id) DO UPDATE SET
+                    scope=EXCLUDED.scope, kind=EXCLUDED.kind,
+                    content=EXCLUDED.content, metadata=EXCLUDED.metadata,
+                    created_at=EXCLUDED.created_at
                 """
                 self.multitenant_client.execute_tenant_query(
-                    sql, tenant_id, 
-                    [str(vector_id), user_id, session_id, query, query, data_json, timestamp]
+                    sql, tenant_id,
+                    [str(vector_id), user_id, session_id, query, data_json, timestamp]
                 )
                 return
             except Exception as e:

--- a/src/ai_karen_engine/database/__init__.py
+++ b/src/ai_karen_engine/database/__init__.py
@@ -11,6 +11,7 @@ from ai_karen_engine.database.models import (
     Base,
     Tenant,
     TenantConversation,
+    TenantMemoryItem,
     TenantMemoryEntry,
     User,
 )
@@ -52,6 +53,7 @@ __all__ = [
     "Tenant",
     "User",
     "TenantConversation",
+    "TenantMemoryItem",
     "TenantMemoryEntry",
     "AuditLog",
     "MultiTenantPostgresClient",

--- a/src/ai_karen_engine/database/migrations.py
+++ b/src/ai_karen_engine/database/migrations.py
@@ -369,7 +369,7 @@ else:
             # Check tables
             expected_tables = [
                 "conversations",
-                "memory_entries",
+                "memory_items",
                 "plugin_executions",
                 "audit_log",
             ]

--- a/src/ai_karen_engine/database/models/__init__.py
+++ b/src/ai_karen_engine/database/models/__init__.py
@@ -16,6 +16,7 @@ from sqlalchemy import (
     Integer,
     String,
     Text,
+    Float,
     desc,
 )
 from sqlalchemy.dialects.postgresql import ARRAY, JSONB
@@ -145,57 +146,28 @@ class TenantConversation(Base):
         self.ai_insights.update(insights_data)
 
 
-class TenantMemoryEntry(Base):
-    """Base model for tenant-specific memory entries."""
+class TenantMemoryItem(Base):
+    """Base model for tenant-specific memory items."""
 
-    __tablename__ = "memory_entries"
+    __tablename__ = "memory_items"
 
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    vector_id = Column(String(255), nullable=False)
-    user_id = Column(UUID(as_uuid=True), nullable=False)
-    session_id = Column(String(255))
+    scope = Column(String(255), nullable=False)
+    kind = Column(String(255), nullable=False)
     content = Column(Text, nullable=False)
-    query = Column(Text)
-    result = Column(JSON)
-    embedding_id = Column(String(255))
-    memory_metadata = Column(JSON, default={})
-    ttl = Column(DateTime)
-    timestamp = Column(Integer, default=0)
+    embedding = Column(ARRAY(Float), nullable=True)
+    metadata = Column(JSON, default={})
     created_at = Column(DateTime, default=datetime.utcnow)
-    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
-
-    # Web UI integration fields
-    ui_source = Column(String(50))  # Source UI (web, streamlit, desktop)
-    conversation_id = Column(UUID(as_uuid=True))  # Link to conversation
-    memory_type = Column(
-        String(50), default="general"
-    )  # Type of memory (fact, preference, context)
-    tags = Column(ARRAY(String), default=[])  # Memory tags for categorization
-    importance_score = Column(Integer, default=5)  # Importance score (1-10)
-    access_count = Column(Integer, default=0)  # How many times this memory was accessed
-    last_accessed = Column(DateTime)  # When this memory was last accessed
-    ai_generated = Column(
-        Boolean, default=False
-    )  # Whether this memory was AI-generated
-    user_confirmed = Column(Boolean, default=True)  # Whether user confirmed this memory
 
     __table_args__ = (
-        Index("idx_memory_vector", "vector_id"),
-        Index("idx_memory_user", "user_id"),
-        Index("idx_memory_session", "session_id"),
-        Index("idx_memory_created", "created_at"),
-        Index("idx_memory_ttl", "ttl"),
-        Index("idx_memory_ui_source", "ui_source"),
-        Index("idx_memory_conversation", "conversation_id"),
-        Index("idx_memory_type", "memory_type"),
-        Index("idx_memory_tags", "tags"),
-        Index("idx_memory_importance", "importance_score"),
-        Index("idx_memory_user_conversation", "user_id", "conversation_id"),
-        Index("idx_memory_user_type", "user_id", "memory_type"),
+        Index("idx_memory_items_scope_kind", "scope", "kind"),
     )
 
     def __repr__(self):
-        return f"<TenantMemoryEntry(id={self.id}, vector_id='{self.vector_id}', user_id={self.user_id})>"
+        return f"<TenantMemoryItem(id={self.id}, scope='{self.scope}', kind='{self.kind}')>"
+
+# Backwards compatibility alias
+TenantMemoryEntry = TenantMemoryItem
 
 
 class TenantMessage(Base):

--- a/src/ai_karen_engine/database/tenant_manager.py
+++ b/src/ai_karen_engine/database/tenant_manager.py
@@ -49,21 +49,21 @@ class TenantConfig:
             "basic": {
                 "max_users": 5,
                 "max_conversations": 100,
-                "max_memory_entries": 1000,
+                "max_memory_items": 1000,
                 "max_plugins": 10,
                 "storage_mb": 100
             },
             "pro": {
                 "max_users": 50,
                 "max_conversations": 1000,
-                "max_memory_entries": 10000,
+                "max_memory_items": 10000,
                 "max_plugins": 50,
                 "storage_mb": 1000
             },
             "enterprise": {
                 "max_users": -1,  # unlimited
                 "max_conversations": -1,
-                "max_memory_entries": -1,
+                "max_memory_items": -1,
                 "max_plugins": -1,
                 "storage_mb": -1
             }
@@ -77,7 +77,7 @@ class TenantStats:
     tenant_id: str
     user_count: int
     conversation_count: int
-    memory_entry_count: int
+    memory_item_count: int
     plugin_execution_count: int
     storage_used_mb: float
     last_activity: Optional[datetime]
@@ -89,7 +89,7 @@ class TenantStats:
             "tenant_id": self.tenant_id,
             "user_count": self.user_count,
             "conversation_count": self.conversation_count,
-            "memory_entry_count": self.memory_entry_count,
+            "memory_item_count": self.memory_item_count,
             "plugin_execution_count": self.plugin_execution_count,
             "storage_used_mb": self.storage_used_mb,
             "last_activity": self.last_activity.isoformat() if self.last_activity else None,
@@ -357,7 +357,7 @@ class TenantManager:
                 queries = {
                     "user_count": f"SELECT COUNT(*) FROM users WHERE tenant_id = '{tenant_id}'",
                     "conversation_count": f"SELECT COUNT(*) FROM {schema_name}.conversations",
-                    "memory_entry_count": f"SELECT COUNT(*) FROM {schema_name}.memory_entries",
+                    "memory_item_count": f"SELECT COUNT(*) FROM {schema_name}.memory_items",
                     "plugin_execution_count": f"SELECT COUNT(*) FROM {schema_name}.plugin_executions"
                 }
                 
@@ -382,7 +382,7 @@ class TenantManager:
                     SELECT MAX(created_at) FROM (
                         SELECT created_at FROM {schema_name}.conversations
                         UNION ALL
-                        SELECT created_at FROM {schema_name}.memory_entries
+                        SELECT created_at FROM {schema_name}.memory_items
                         UNION ALL
                         SELECT created_at FROM {schema_name}.plugin_executions
                     ) activities
@@ -394,7 +394,7 @@ class TenantManager:
                     tenant_id=tenant_id_str,
                     user_count=stats_data["user_count"],
                     conversation_count=stats_data["conversation_count"],
-                    memory_entry_count=stats_data["memory_entry_count"],
+                    memory_item_count=stats_data["memory_item_count"],
                     plugin_execution_count=stats_data["plugin_execution_count"],
                     storage_used_mb=storage_used_mb,
                     last_activity=last_activity,
@@ -471,7 +471,7 @@ class TenantManager:
         resource_map = {
             "users": ("user_count", "max_users"),
             "conversations": ("conversation_count", "max_conversations"),
-            "memory_entries": ("memory_entry_count", "max_memory_entries"),
+            "memory_items": ("memory_item_count", "max_memory_items"),
             "storage": ("storage_used_mb", "storage_mb")
         }
         

--- a/tests/test_memory_entries.py
+++ b/tests/test_memory_entries.py
@@ -2,7 +2,7 @@ import pytest
 
 try:
     from sqlalchemy import create_engine, inspect
-    from src.ai_karen_engine.database.models import Base, TenantMemoryEntry
+    from src.ai_karen_engine.database.models import Base, TenantMemoryItem
     SQLALCHEMY_AVAILABLE = True
 except Exception as e:
     SQLALCHEMY_AVAILABLE = False
@@ -12,7 +12,7 @@ except Exception as e:
 @pytest.mark.skipif(not SQLALCHEMY_AVAILABLE, reason="SQLAlchemy not available")
 def test_memory_entries_table_creation():
     engine = create_engine("sqlite:///:memory:")
-    Base.metadata.create_all(engine, tables=[TenantMemoryEntry.__table__])
+    Base.metadata.create_all(engine, tables=[TenantMemoryItem.__table__])
     inspector = inspect(engine)
-    assert "memory_entries" in inspector.get_table_names()
+    assert "memory_items" in inspector.get_table_names()
 


### PR DESCRIPTION
## Summary
- add `memory_items` table with 768-dim vector column and metadata JSON
- switch memory manager and helpers to use `memory_items` and new scope/kind fields
- provide migration and tenant stats support for memory items

## Testing
- `pytest tests/test_memory_entries.py -q` *(fails: ModuleNotFoundError: No module named 'ai_karen_engine')*

------
https://chatgpt.com/codex/tasks/task_e_6895f2c039d88324b7ac5eef745846d3