### PR TITLE
Add extension monitoring and health tracking

### DIFF
--- a/src/ai_karen_engine/api_routes/extensions.py
+++ b/src/ai_karen_engine/api_routes/extensions.py
@@ -167,4 +167,16 @@ async def get_registry_summary(user: Dict[str, Any] = Depends(get_current_user))
     return extension_manager.registry.to_dict()
 
 
+@router.get("/extensions/health")
+async def get_extensions_health(user: Dict[str, Any] = Depends(get_current_user)):
+    """Get overall health summary for extensions."""
+    extension_manager = get_extension_manager()
+    if not extension_manager:
+        raise HTTPException(
+            status_code=503,
+            detail="Extension manager not initialized",
+        )
+    return extension_manager.get_health_summary()
+
+
 __all__ = ["router"]

--- a/src/ai_karen_engine/core/health_monitor.py
+++ b/src/ai_karen_engine/core/health_monitor.py
@@ -512,6 +512,21 @@ async def setup_default_health_checks() -> None:
             return {"status": "healthy", "message": "Memory Service OK"}
         except Exception as e:
             return {"status": "unhealthy", "message": f"Memory Service error: {str(e)}"}
+
+    async def check_extensions():
+        try:
+            from ai_karen_engine.extensions import get_extension_manager
+            manager = get_extension_manager()
+            if not manager:
+                return {"status": "unhealthy", "message": "Extension manager not initialized"}
+            summary = manager.get_health_summary()
+            return {
+                "status": summary.get("overall_status", "healthy"),
+                "message": "Extension system health",
+                "details": summary,
+            }
+        except Exception as e:
+            return {"status": "unhealthy", "message": f"Extension system error: {str(e)}"}
     
     # Register health checks
     monitor.register_health_check("database", check_database, interval=30, critical=True)
@@ -519,5 +534,6 @@ async def setup_default_health_checks() -> None:
     monitor.register_health_check("vector_db", check_vector_db, interval=60, critical=True)
     monitor.register_health_check("ai_orchestrator", check_ai_orchestrator, interval=30, critical=True)
     monitor.register_health_check("memory_service", check_memory_service, interval=30, critical=True)
+    monitor.register_health_check("extensions", check_extensions, interval=30, critical=False)
     
     logger.info("Default health checks configured")

--- a/src/ai_karen_engine/database/migrations/006_extension_metrics.sql
+++ b/src/ai_karen_engine/database/migrations/006_extension_metrics.sql
@@ -1,0 +1,56 @@
+-- Extension and hook monitoring tables
+
+CREATE TABLE IF NOT EXISTS extensions (
+  name         TEXT PRIMARY KEY,
+  version      TEXT NOT NULL,
+  category     TEXT,
+  capabilities JSONB,
+  directory    TEXT,
+  status       TEXT NOT NULL,
+  error_msg    TEXT,
+  loaded_at    TIMESTAMP,
+  updated_at   TIMESTAMP DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS extension_usage (
+  id              BIGSERIAL PRIMARY KEY,
+  name            TEXT REFERENCES extensions(name) ON DELETE CASCADE,
+  memory_mb       NUMERIC(10,2),
+  cpu_percent     NUMERIC(5,2),
+  disk_mb         NUMERIC(12,2),
+  network_sent    BIGINT,
+  network_recv    BIGINT,
+  uptime_seconds  BIGINT,
+  sampled_at      TIMESTAMP DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_ext_usage_name_time ON extension_usage(name, sampled_at DESC);
+
+CREATE TABLE IF NOT EXISTS hooks (
+  hook_id      TEXT PRIMARY KEY,
+  hook_type    TEXT NOT NULL,
+  source_type  TEXT NOT NULL,
+  source_name  TEXT,
+  priority     INT DEFAULT 50,
+  enabled      BOOLEAN DEFAULT TRUE,
+  conditions   JSONB,
+  registered_at TIMESTAMP DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_hooks_type ON hooks(hook_type);
+CREATE INDEX IF NOT EXISTS idx_hooks_enabled ON hooks(enabled);
+
+CREATE TABLE IF NOT EXISTS hook_exec_stats (
+  id           BIGSERIAL PRIMARY KEY,
+  hook_type    TEXT,
+  source_name  TEXT,
+  executions   BIGINT DEFAULT 0,
+  successes    BIGINT DEFAULT 0,
+  errors       BIGINT DEFAULT 0,
+  timeouts     BIGINT DEFAULT 0,
+  avg_duration_ms INT DEFAULT 0,
+  window_start TIMESTAMP,
+  window_end   TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_hook_exec_stats_type_window ON hook_exec_stats(hook_type, window_start);

--- a/src/ai_karen_engine/database/models/__init__.py
+++ b/src/ai_karen_engine/database/models/__init__.py
@@ -302,6 +302,52 @@ class AuditLog(Base):
         return f"<AuditLog(event_id={self.event_id}, action='{self.action}', tenant_id={self.tenant_id})>"
 
 
+class Extension(Base):
+    """Registered extension metadata."""
+
+    __tablename__ = "extensions"
+
+    name = Column(String, primary_key=True)
+    version = Column(String, nullable=False)
+    category = Column(String)
+    capabilities = Column(JSONB)
+    directory = Column(String)
+    status = Column(String, nullable=False)
+    error_msg = Column(Text)
+    loaded_at = Column(DateTime)
+    updated_at = Column(DateTime, default=datetime.utcnow)
+
+    usage = relationship("ExtensionUsage", back_populates="extension")
+
+    def __repr__(self):
+        return f"<Extension(name={self.name}, status='{self.status}')>"
+
+
+class ExtensionUsage(Base):
+    """Sampled resource usage metrics for extensions."""
+
+    __tablename__ = "extension_usage"
+
+    id = Column(BigInteger, primary_key=True, autoincrement=True)
+    name = Column(String, ForeignKey("extensions.name", ondelete="CASCADE"))
+    memory_mb = Column(Float)
+    cpu_percent = Column(Float)
+    disk_mb = Column(Float)
+    network_sent = Column(BigInteger)
+    network_recv = Column(BigInteger)
+    uptime_seconds = Column(BigInteger)
+    sampled_at = Column(DateTime, default=datetime.utcnow)
+
+    extension = relationship("Extension", back_populates="usage")
+
+    __table_args__ = (
+        Index("idx_ext_usage_name_time", "name", desc("sampled_at")),
+    )
+
+    def __repr__(self):
+        return f"<ExtensionUsage(name={self.name}, sampled_at={self.sampled_at})>"
+
+
 class Hook(Base):
     """Registered hook metadata."""
 


### PR DESCRIPTION
## Summary
- add Extension and ExtensionUsage models plus migration for monitoring tables
- persist extension metadata and resource usage, record hook execution stats per source
- expose extension health via new health check and API endpoint

## Testing
- `python -m py_compile src/ai_karen_engine/database/models/__init__.py src/ai_karen_engine/extensions/manager.py src/ai_karen_engine/extensions/resource_monitor.py src/ai_karen_engine/hooks/hook_manager.py src/ai_karen_engine/api_routes/extensions.py src/ai_karen_engine/core/health_monitor.py`
- `pytest tests/test_resource_monitor.py tests/test_plugin_manager_hooks.py` *(fails: ModuleNotFoundError: No module named 'ai_karen_engine')*

------
https://chatgpt.com/codex/tasks/task_e_68960169ba808324b700736a9535234f