### PR TITLE
Add persistent file metadata and webhook dispatch

### DIFF
--- a/src/ai_karen_engine/api_routes/enhanced_file_attachment_routes.py
+++ b/src/ai_karen_engine/api_routes/enhanced_file_attachment_routes.py
@@ -244,7 +244,8 @@ async def enhanced_list_files(
         # Get all files from service
         all_files = []
 
-        for file_id, metadata in file_service._file_metadata.items():
+        files_dict = await file_service.list_files()
+        for file_id, metadata in files_dict.items():
             # Apply filters
             if file_type and metadata.file_type != file_type:
                 continue
@@ -423,7 +424,7 @@ async def enhanced_process_multimedia(
             )
 
         # Get file metadata to determine media type
-        metadata = file_service._file_metadata.get(file_id)
+        metadata = await file_service.get_metadata(file_id)
         if not metadata:
             error_response = create_service_error_response(
                 service_name="enhanced_multimedia",
@@ -511,10 +512,11 @@ async def get_file_statistics_dashboard():
     """Get comprehensive file statistics for AG-UI dashboard."""
     try:
         # Get storage stats
-        storage_stats = file_service.get_storage_stats()
+        storage_stats = await file_service.get_storage_stats()
 
         # Calculate additional statistics
-        all_files = list(file_service._file_metadata.values())
+        files_dict = await file_service.list_files()
+        all_files = list(files_dict.values())
 
         # Processing status distribution
         status_distribution = {}

--- a/src/ai_karen_engine/api_routes/file_attachment_routes.py
+++ b/src/ai_karen_engine/api_routes/file_attachment_routes.py
@@ -244,7 +244,7 @@ async def download_file(file_id: str):
             )
 
         # Get file metadata for proper response
-        metadata = file_service.list_files().get(file_id)
+        metadata = await file_service.get_metadata(file_id)
         if not metadata:
             filename = f"file_{file_id}"
             mime_type = "application/octet-stream"
@@ -346,7 +346,7 @@ async def process_multimedia(file_id: str, request: MultimediaProcessingRequest)
             )
 
         # Get file metadata to determine media type
-        metadata = file_service.list_files().get(file_id)
+        metadata = await file_service.get_metadata(file_id)
         if not metadata:
             error_response = create_service_error_response(
                 service_name="multimedia",
@@ -435,7 +435,8 @@ async def list_files(
         # Get all files from service
         all_files = []
 
-        for file_id, metadata in file_service.list_files().items():
+        files_dict = await file_service.list_files()
+        for file_id, metadata in files_dict.items():
             # Apply filters
             if file_type and metadata.file_type != file_type:
                 continue
@@ -556,7 +557,7 @@ async def get_multimedia_capabilities():
 async def get_file_storage_stats():
     """Get file storage statistics."""
     try:
-        stats = file_service.get_storage_stats()
+        stats = await file_service.get_storage_stats()
 
         return {"storage_stats": stats, "service_status": "operational"}
 

--- a/src/ai_karen_engine/services/webhook_service.py
+++ b/src/ai_karen_engine/services/webhook_service.py
@@ -1,0 +1,53 @@
+"""Utilities for dispatching registered webhooks."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Optional
+
+import httpx
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ai_karen_engine.database import get_postgres_session
+from ai_karen_engine.database.models import Webhook
+
+logger = logging.getLogger(__name__)
+
+
+async def dispatch_webhook(
+    event: str,
+    payload: Dict[str, Any],
+    session: Optional[AsyncSession] = None,
+    http_client: Optional[httpx.AsyncClient] = None,
+) -> None:
+    """Dispatch an event to all enabled webhooks subscribed to it."""
+    close_client = False
+    if http_client is None:
+        http_client = httpx.AsyncClient()
+        close_client = True
+
+    async def _dispatch(db_session: AsyncSession) -> None:
+        result = await db_session.execute(
+            select(Webhook).where(Webhook.enabled.is_(True))
+        )
+        for hook in result.scalars():
+            events = hook.events or []
+            if event not in events:
+                continue
+            try:
+                await http_client.post(hook.url, json={"event": event, "payload": payload})
+            except Exception as exc:  # pragma: no cover - network issues
+                logger.warning(
+                    "Webhook dispatch failed", exc_info=True, extra={"webhook_id": hook.webhook_id}
+                )
+
+    try:
+        if session is not None:
+            await _dispatch(session)
+        else:  # pragma: no cover - depends on external DB availability
+            async with get_postgres_session() as db_session:
+                await _dispatch(db_session)
+    finally:
+        if close_client:
+            await http_client.aclose()

--- a/tests/test_enhanced_file_handling.py
+++ b/tests/test_enhanced_file_handling.py
@@ -516,20 +516,23 @@ class TestEnhancedFileRoutes:
             "hook_results": {"plugin_analysis": {"test": "data"}},
             "features": {"has_thumbnail": True}
         })
-        mock._file_metadata = {
+        file_dict = {
             "test_123": FileMetadata(
                 filename="test.jpg",
                 original_filename="test_image.jpg",
                 file_size=1024,
                 mime_type="image/jpeg",
                 file_type=FileType.IMAGE,
-                file_hash="hash123"
+                file_hash="hash123",
             )
         }
-        mock.get_storage_stats = Mock(return_value={
+        mock.list_files = AsyncMock(return_value=file_dict)
+        mock.get_storage_stats = AsyncMock(return_value={
             "total_files": 5,
             "total_size_mb": 10.5,
-            "files_by_type": {"image": 3, "document": 2}
+            "files_by_type": {"image": 3, "document": 2},
+            "files_by_status": {"processing": 5},
+            "total_size_bytes": 0,
         })
         return mock
     

--- a/tests/test_webhook_dispatcher.py
+++ b/tests/test_webhook_dispatcher.py
@@ -1,0 +1,40 @@
+import hashlib
+import pytest
+import httpx
+from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker
+
+from ai_karen_engine.database.models import Base, Webhook
+from ai_karen_engine.services.webhook_service import dispatch_webhook
+
+
+@pytest.mark.asyncio
+async def test_dispatch_webhook_respects_enabled_and_events():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+
+    async with Session() as session:
+        hook1 = Webhook(webhook_id="1", url="https://example.com/h1", events=["file.uploaded"], enabled=True)
+        hook2 = Webhook(webhook_id="2", url="https://example.com/h2", events=["file.uploaded"], enabled=False)
+        hook3 = Webhook(webhook_id="3", url="https://example.com/h3", events=["other.event"], enabled=True)
+        session.add_all([hook1, hook2, hook3])
+        await session.commit()
+
+        received = []
+
+        async def handler(request):
+            received.append(str(request.url))
+            return httpx.Response(200)
+
+        transport = httpx.MockTransport(handler)
+        async with httpx.AsyncClient(transport=transport) as client:
+            await dispatch_webhook("file.uploaded", {"x": 1}, session=session, http_client=client)
+
+        assert received == ["https://example.com/h1"]
+
+
+def test_webhook_secret_hashing():
+    hook = Webhook(url="https://example.com", events=["a"], enabled=True)
+    hook.secret = "topsecret"
+    assert hook.secret == hashlib.sha256("topsecret".encode()).hexdigest()


### PR DESCRIPTION
## Summary
- implement SQLAlchemy models for files and webhooks
- persist file metadata with SHA-256 hashes and dispatch webhooks on upload
- update file routes to use database-backed metadata and add webhook dispatcher

## Testing
- `pytest -q` *(fails: ModuleNotFoundError due to service initialization requirements)*

------
https://chatgpt.com/codex/tasks/task_e_6896159a1f20832488d7e1b32dd04fd3