### PR TITLE
feat: generate default encryption key

### DIFF
--- a/src/ai_karen_engine/automation_manager/encryption_utils.py
+++ b/src/ai_karen_engine/automation_manager/encryption_utils.py
@@ -2,12 +2,16 @@ from __future__ import annotations
 
 from cryptography.fernet import Fernet
 
+import logging
 import os
 
 
 ENCRYPTION_KEY = os.getenv("KARI_JOB_ENC_KEY")
 if not ENCRYPTION_KEY:
-    raise RuntimeError("KARI_JOB_ENC_KEY must be set in the environment!")
+    ENCRYPTION_KEY = Fernet.generate_key()
+    logging.getLogger(__name__).warning(
+        "KARI_JOB_ENC_KEY not set; generated ephemeral key"
+    )
 
 _fernet = Fernet(
     ENCRYPTION_KEY.encode() if isinstance(ENCRYPTION_KEY, str) else ENCRYPTION_KEY


### PR DESCRIPTION
## Summary
- fallback to generated encryption key when `KARI_JOB_ENC_KEY` env var is missing
- log warning if key is not set

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'ai_karen_engine')*

------
https://chatgpt.com/codex/tasks/task_e_68964cda34908324a4ae1a592af61674