### PR TITLE
feat: support dynamic encryption key injection

### DIFF
--- a/src/ai_karen_engine/automation_manager/encryption_utils.py
+++ b/src/ai_karen_engine/automation_manager/encryption_utils.py
@@ -1,21 +1,49 @@
 from __future__ import annotations
 
-from cryptography.fernet import Fernet
-
 import logging
 import os
 
+from cryptography.fernet import Fernet
+
+
+log = logging.getLogger(__name__)
 
 ENCRYPTION_KEY = os.getenv("KARI_JOB_ENC_KEY")
 if not ENCRYPTION_KEY:
     ENCRYPTION_KEY = Fernet.generate_key()
-    logging.getLogger(__name__).warning(
-        "KARI_JOB_ENC_KEY not set; generated ephemeral key"
+    log.warning(
+        "KARI_JOB_ENC_KEY not set; generated ephemeral key for development." \
+        " Provide a persistent key in production.",
     )
 
 _fernet = Fernet(
     ENCRYPTION_KEY.encode() if isinstance(ENCRYPTION_KEY, str) else ENCRYPTION_KEY
 )
+
+
+def set_encryption_key(key: bytes | str) -> None:
+    """Inject a persistent Fernet key.
+
+    This allows production deployments to supply a stable key from a
+    dedicated secrets manager. The provided ``key`` must be a valid
+    URL-safe base64 encoded 32-byte key as required by :class:`Fernet`.
+
+    Args:
+        key: The key to use for encryption/decryption.
+
+    Raises:
+        ValueError: If ``key`` is missing or invalid.
+    """
+
+    global _fernet, ENCRYPTION_KEY
+    if not key:
+        raise ValueError("Encryption key must be provided")
+    key_bytes = key.encode() if isinstance(key, str) else key
+    try:
+        _fernet = Fernet(key_bytes)
+    except Exception as exc:  # pragma: no cover - cryptography defines the exception
+        raise ValueError("Invalid Fernet key") from exc
+    ENCRYPTION_KEY = key_bytes
 
 
 def encrypt_data(data: bytes | str) -> bytes:

--- a/tests/test_encryption_utils.py
+++ b/tests/test_encryption_utils.py
@@ -1,0 +1,30 @@
+import importlib
+import logging
+
+import pytest
+
+
+def _reload_module(monkeypatch):
+    import ai_karen_engine.automation_manager.encryption_utils as eu
+    importlib.reload(eu)
+    return eu
+
+
+def test_development_fallback(monkeypatch, caplog):
+    monkeypatch.delenv("KARI_JOB_ENC_KEY", raising=False)
+    caplog.set_level(
+        logging.WARNING,
+        logger="ai_karen_engine.automation_manager.encryption_utils",
+    )
+    eu = _reload_module(monkeypatch)
+    assert eu.ENCRYPTION_KEY
+    assert "ephemeral key" in caplog.text
+    token = eu.encrypt_data("secret")
+    assert eu.decrypt_data(token) == "secret"
+
+
+def test_set_encryption_key_invalid(monkeypatch):
+    monkeypatch.delenv("KARI_JOB_ENC_KEY", raising=False)
+    eu = _reload_module(monkeypatch)
+    with pytest.raises(ValueError):
+        eu.set_encryption_key("invalid")


### PR DESCRIPTION
## Summary
- allow automation encryption to fall back to ephemeral key in development
- add hook to inject persistent encryption keys
- test development fallback and invalid key injection

## Testing
- `pytest tests/test_encryption_utils.py -q` *(fails: ImportError/KeyboardInterrupt during conftest loading)*

------
https://chatgpt.com/codex/tasks/task_e_689670cc5da483249c135bd0ce8ecfb5