### PR TITLE
chore(db): remove unused extension install history

### DIFF
--- a/DATABASE_TABLE_AUDIT_SUMMARY.md
+++ b/DATABASE_TABLE_AUDIT_SUMMARY.md
@@ -1,0 +1,45 @@
+# Database Table Audit & Consolidation Summary
+
+This document captures the consolidated schema for the AI‑Karen data layer and
+the associated operational guidance.
+
+## Consolidated Schema Overview
+
+The schema groups tables by function:
+
+* **Auth & Identity** – `auth_users`, `auth_sessions`, `auth_providers`,
+  `user_identities`
+* **RBAC / API Keys / Audit** – `roles`, `role_permissions`, `api_keys`,
+  `audit_log`
+* **Chat / Conversations** – `conversations`, `messages`, `message_tools`
+* **Memory** – `memory_items`
+* **Extensions / Hooks** – `extensions`, `extension_usage`, `hooks`,
+  `hook_exec_stats`
+* **LLM Registry / Requests** – `llm_providers`, `llm_requests`
+* **Files / Webhooks** – `files`, `webhooks`
+* **Marketplace** – `marketplace_extensions`, `installed_extensions`
+* **Analytics / Rate Limits** – `usage_counters`, `rate_limits`
+
+The full DDL lives in `database_schema.sql` and mirrors the initial migration
+at `src/ai_karen_engine/database/migrations/001_agui_chat_core.sql`.
+
+## Observability Hooks
+
+* Extension load/unload events, hook failures, and admin actions must emit
+  records to `audit_log`.
+* Runtime counters are exported to Prometheus and aggregated hourly into the
+  `usage_counters` table for trend analysis.
+
+## Scaling & Retention Notes
+
+* Backed by PostgreSQL with optional `pgvector` for `memory_items.embeddings`.
+* Hot path queries on `messages` rely on the
+  `(convo_id, created_at)` index and may be partitioned by month for large
+  tenants.
+* Nightly jobs should archive old rows from `llm_requests`, `extension_usage`,
+  and `audit_log` to cold storage.
+
+---
+
+This audit consolidates the latest schema and operational practices for the
+Evil Twin sign‑off.

--- a/data/migrations/postgres/002_create_extension_tables.sql
+++ b/data/migrations/postgres/002_create_extension_tables.sql
@@ -12,7 +12,7 @@ CREATE TABLE IF NOT EXISTS extension_registry (
     updated_at TIMESTAMP DEFAULT NOW(),
     tenant_id VARCHAR(255), -- NULL for global extensions
     installed_by VARCHAR(255),
-    
+
     CONSTRAINT extension_status_check CHECK (status IN ('inactive', 'loading', 'active', 'error', 'unloading'))
 );
 
@@ -25,7 +25,7 @@ CREATE TABLE IF NOT EXISTS extension_permissions (
     permission VARCHAR(255) NOT NULL,
     granted_at TIMESTAMP DEFAULT NOW(),
     granted_by VARCHAR(255),
-    
+
     FOREIGN KEY (extension_name) REFERENCES extension_registry(name) ON DELETE CASCADE,
     UNIQUE(extension_name, tenant_id, user_id, permission)
 );
@@ -39,7 +39,7 @@ CREATE TABLE IF NOT EXISTS extension_config (
     config_value JSONB NOT NULL,
     updated_at TIMESTAMP DEFAULT NOW(),
     updated_by VARCHAR(255),
-    
+
     FOREIGN KEY (extension_name) REFERENCES extension_registry(name) ON DELETE CASCADE,
     UNIQUE(extension_name, tenant_id, config_key)
 );
@@ -53,7 +53,7 @@ CREATE TABLE IF NOT EXISTS extension_metrics (
     metric_value FLOAT NOT NULL,
     metadata JSONB,
     timestamp TIMESTAMP DEFAULT NOW(),
-    
+
     FOREIGN KEY (extension_name) REFERENCES extension_registry(name) ON DELETE CASCADE
 );
 
@@ -66,7 +66,7 @@ CREATE TABLE IF NOT EXISTS extension_audit_log (
     action VARCHAR(100) NOT NULL,
     details JSONB,
     timestamp TIMESTAMP DEFAULT NOW(),
-    
+
     FOREIGN KEY (extension_name) REFERENCES extension_registry(name) ON DELETE CASCADE
 );
 
@@ -126,14 +126,4 @@ CREATE TABLE IF NOT EXISTS installed_extensions (
     installed_at TIMESTAMP DEFAULT NOW(),
     source TEXT,
     directory TEXT
-);
-
--- Installation history
-CREATE TABLE IF NOT EXISTS extension_install_events (
-    id SERIAL PRIMARY KEY,
-    extension_id TEXT REFERENCES marketplace_extensions(extension_id) ON DELETE SET NULL,
-    action VARCHAR(20) NOT NULL,
-    version TEXT,
-    user_id TEXT REFERENCES auth_users(user_id) ON DELETE SET NULL,
-    occurred_at TIMESTAMP DEFAULT NOW()
 );

--- a/database_schema.sql
+++ b/database_schema.sql
@@ -289,15 +289,6 @@ CREATE TABLE installed_extensions (
   directory     TEXT
 );
 
-CREATE TABLE extension_install_events (
-  id            BIGSERIAL PRIMARY KEY,
-  extension_id  TEXT REFERENCES marketplace_extensions(extension_id) ON DELETE SET NULL,
-  action        TEXT NOT NULL,             -- install|upgrade|remove
-  version       TEXT,
-  user_id       TEXT REFERENCES auth_users(user_id) ON DELETE SET NULL,
-  occurred_at   TIMESTAMP DEFAULT now()
-);
-
 CREATE TABLE usage_counters (
   id           BIGSERIAL PRIMARY KEY,
   tenant_id    TEXT,

--- a/src/ai_karen_engine/database/migrations/001_agui_chat_core.sql
+++ b/src/ai_karen_engine/database/migrations/001_agui_chat_core.sql
@@ -283,15 +283,6 @@ CREATE TABLE installed_extensions (
   directory     TEXT
 );
 
-CREATE TABLE extension_install_events (
-  id            BIGSERIAL PRIMARY KEY,
-  extension_id  TEXT REFERENCES marketplace_extensions(extension_id) ON DELETE SET NULL,
-  action        TEXT NOT NULL,             -- install|upgrade|remove
-  version       TEXT,
-  user_id       TEXT REFERENCES auth_users(user_id) ON DELETE SET NULL,
-  occurred_at   TIMESTAMP DEFAULT now()
-);
-
 CREATE TABLE usage_counters (
   id           BIGSERIAL PRIMARY KEY,
   tenant_id    TEXT,

--- a/src/ai_karen_engine/database/models/__init__.py
+++ b/src/ai_karen_engine/database/models/__init__.py
@@ -398,29 +398,6 @@ class InstalledExtension(Base):
         return f"<InstalledExtension(extension_id={self.extension_id}, version={self.version})>"
 
 
-class ExtensionInstallEvent(Base):
-    """History of extension installation actions."""
-
-    __tablename__ = "extension_install_events"
-
-    id = Column(BigInteger, primary_key=True, autoincrement=True)
-    extension_id = Column(
-        String, ForeignKey("marketplace_extensions.extension_id", ondelete="SET NULL")
-    )
-    action = Column(String, nullable=False)
-    version = Column(String)
-    user_id = Column(
-        String, ForeignKey("auth_users.user_id", ondelete="SET NULL"), nullable=True
-    )
-    occurred_at = Column(DateTime, default=datetime.utcnow)
-
-    extension = relationship("MarketplaceExtension")
-    user = relationship("AuthUser")
-
-    def __repr__(self):
-        return f"<ExtensionInstallEvent(extension_id={self.extension_id}, action={self.action})>"
-
-
 class Hook(Base):
     """Registered hook metadata."""
 


### PR DESCRIPTION
## Summary
- drop extension_install_events table from schema and migrations
- document consolidated database tables and observability guidance

## Testing
- `pre-commit run --files database_schema.sql src/ai_karen_engine/database/migrations/001_agui_chat_core.sql src/ai_karen_engine/database/models/__init__.py data/migrations/postgres/002_create_extension_tables.sql DATABASE_TABLE_AUDIT_SUMMARY.md`

------
https://chatgpt.com/codex/tasks/task_e_68967b77698083248ec5abc77873f8d4