### PR TITLE
Add auth monitoring exports and tests

### DIFF
--- a/src/ai_karen_engine/auth/__init__.py
+++ b/src/ai_karen_engine/auth/__init__.py
@@ -128,6 +128,8 @@ from .service import (
     get_unified_auth_service,
 )
 
+from ai_karen_engine.auth.monitoring import AuthMonitor, metrics_hook
+
 __version__ = "1.0.0"
 __author__ = "AI Karen Team"
 __description__ = "Unified authentication system for AI Karen"
@@ -171,6 +173,10 @@ __all__ = [
     "get_production_auth_service",
     "get_intelligent_auth_service",
     "get_unified_auth_service",
+
+    # Monitoring
+    "AuthMonitor",
+    "metrics_hook",
     
     # Base exceptions
     "AuthError",

--- a/tests/test_auth_monitoring.py
+++ b/tests/test_auth_monitoring.py
@@ -1,0 +1,49 @@
+import pytest
+
+from ai_karen_engine.auth.config import AuthConfig
+from ai_karen_engine.auth.monitoring import AuthMonitor
+from ai_karen_engine.auth.models import AuthEvent, AuthEventType
+
+
+@pytest.mark.asyncio
+async def test_auth_monitor_records_metrics():
+    config = AuthConfig()
+    monitor = AuthMonitor(config)
+    event = AuthEvent(
+        event_type=AuthEventType.LOGIN_SUCCESS,
+        user_id="user1",
+        email="user@example.com",
+        tenant_id="tenant1",
+        ip_address="127.0.0.1",
+        user_agent="pytest",
+        success=True,
+        processing_time_ms=50,
+    )
+    await monitor.record_auth_event(event)
+    base_tags = {
+        "event_type": "login_success",
+        "success": "true",
+        "tenant_id": "tenant1",
+    }
+    assert monitor.metrics.get_counter("auth.events.total", base_tags) == 1
+    assert monitor.metrics.get_counter("auth.events.success", base_tags) == 1
+    assert len(monitor._recent_events) == 1
+    await monitor.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_auth_monitor_triggers_security_alert():
+    config = AuthConfig()
+    monitor = AuthMonitor(config)
+    event = AuthEvent(
+        event_type=AuthEventType.LOGIN_SUCCESS,
+        user_id="user1",
+        email="user@example.com",
+        ip_address="127.0.0.1",
+        user_agent="pytest",
+        success=True,
+        risk_score=0.95,
+    )
+    await monitor.record_auth_event(event)
+    assert len(monitor.alerts.get_alert_history()) == 1
+    await monitor.shutdown()


### PR DESCRIPTION
## Summary
- Export `AuthMonitor` and `metrics_hook` for centralized authentication monitoring
- Add unit tests to verify metric collection and security alerting

## Testing
- `KARI_DUCKDB_PASSWORD=test KARI_JOB_SIGNING_KEY=foo PYTHONPATH=src pytest tests/test_auth_monitoring.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68974f5ba9cc83248d7d45544a6f18c4