### PR TITLE
feat(auth): pluggable rate limiter backend with Redis support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -37,6 +37,7 @@ bs4
 plotly
 seaborn
 redis
+fakeredis
 psycopg
 psycopg2-binary
 asyncpg

--- a/src/ai_karen_engine/auth/config.py
+++ b/src/ai_karen_engine/auth/config.py
@@ -217,6 +217,8 @@ class SecurityConfig:
     lockout_duration_minutes: int = 15
     rate_limit_window_minutes: int = 15
     rate_limit_max_requests: int = 10
+    rate_limit_storage: str = "memory"  # "memory" or "redis"
+    rate_limit_redis_url: Optional[str] = None
 
     # Password security
     min_password_length: int = 8
@@ -255,6 +257,13 @@ class SecurityConfig:
             ),
             rate_limit_max_requests=_env_int(
                 os.getenv("AUTH_RATE_LIMIT_MAX_REQUESTS"), cls().rate_limit_max_requests
+            ),
+            rate_limit_storage=os.getenv(
+                "AUTH_RATE_LIMIT_STORAGE", cls().rate_limit_storage
+            ),
+            rate_limit_redis_url=(
+                os.getenv("AUTH_RATE_LIMIT_REDIS_URL")
+                or os.getenv("REDIS_URL")
             ),
             min_password_length=_env_int(
                 os.getenv("AUTH_MIN_PASSWORD_LENGTH"), cls().min_password_length

--- a/src/ai_karen_engine/auth/monitoring.py
+++ b/src/ai_karen_engine/auth/monitoring.py
@@ -688,6 +688,8 @@ class AuthMonitor:
             handler = logging.StreamHandler()
             handler.setFormatter(StructuredFormatter())
             self.logger.addHandler(handler)
+        # Prevent duplicate logs from propagating to root logger
+        self.logger.propagate = False
     
     async def record_auth_event(self, event: AuthEvent) -> None:
         """Record an authentication event for monitoring."""

--- a/src/ai_karen_engine/auth/rate_limit_store.py
+++ b/src/ai_karen_engine/auth/rate_limit_store.py
@@ -1,0 +1,133 @@
+"""Storage backends for the rate limiter."""
+
+from __future__ import annotations
+
+import time
+from collections import defaultdict
+from typing import Any, Dict, List, Optional
+
+try:  # pragma: no cover - optional dependency
+    import redis.asyncio as redis_asyncio  # type: ignore
+except Exception:  # pragma: no cover
+    redis_asyncio = None  # type: ignore
+
+
+class RateLimitStore:
+    """Abstract rate limit storage backend."""
+
+    async def add_attempt(self, identifier: str, timestamp: float, window_seconds: int) -> None:
+        raise NotImplementedError
+
+    async def get_recent_attempts(self, identifier: str, cutoff: float) -> List[float]:
+        raise NotImplementedError
+
+    async def set_lockout(self, identifier: str, until: float) -> None:
+        raise NotImplementedError
+
+    async def get_lockout(self, identifier: str) -> Optional[float]:
+        raise NotImplementedError
+
+    async def clear(self, identifier: str) -> None:
+        raise NotImplementedError
+
+    async def cleanup(self, current_time: float, cutoff: float) -> None:
+        raise NotImplementedError
+
+    def stats(self, current_time: float) -> Dict[str, Any]:
+        raise NotImplementedError
+
+
+class InMemoryRateLimitStore(RateLimitStore):
+    """Simple in-memory store for development and testing."""
+
+    def __init__(self) -> None:
+        self._attempts: Dict[str, List[float]] = defaultdict(list)
+        self._lockouts: Dict[str, float] = {}
+
+    async def add_attempt(self, identifier: str, timestamp: float, window_seconds: int) -> None:
+        self._attempts[identifier].append(timestamp)
+
+    async def get_recent_attempts(self, identifier: str, cutoff: float) -> List[float]:
+        return [ts for ts in self._attempts.get(identifier, []) if ts > cutoff]
+
+    async def set_lockout(self, identifier: str, until: float) -> None:
+        self._lockouts[identifier] = until
+
+    async def get_lockout(self, identifier: str) -> Optional[float]:
+        return self._lockouts.get(identifier)
+
+    async def clear(self, identifier: str) -> None:
+        self._attempts.pop(identifier, None)
+        self._lockouts.pop(identifier, None)
+
+    async def cleanup(self, current_time: float, cutoff: float) -> None:
+        for ident in list(self._attempts.keys()):
+            self._attempts[ident] = [ts for ts in self._attempts[ident] if ts > cutoff]
+            if not self._attempts[ident]:
+                del self._attempts[ident]
+        for ident in list(self._lockouts.keys()):
+            if self._lockouts[ident] < current_time:
+                del self._lockouts[ident]
+
+    def stats(self, current_time: float) -> Dict[str, Any]:
+        active_lockouts = sum(1 for t in self._lockouts.values() if t > current_time)
+        return {
+            "total_identifiers_tracked": len(self._attempts),
+            "active_lockouts": active_lockouts,
+            "total_lockouts": len(self._lockouts),
+        }
+
+
+class RedisRateLimitStore(RateLimitStore):
+    """Redis-backed rate limit store for distributed environments."""
+
+    def __init__(self, client: "redis_asyncio.Redis") -> None:  # pragma: no cover - runtime check
+        if redis_asyncio is None:
+            raise RuntimeError("redis module is required for RedisRateLimitStore")
+        self.client = client
+
+    @staticmethod
+    def _attempts_key(identifier: str) -> str:
+        return f"rl:attempts:{identifier}"
+
+    @staticmethod
+    def _lockout_key(identifier: str) -> str:
+        return f"rl:lockout:{identifier}"
+
+    async def add_attempt(self, identifier: str, timestamp: float, window_seconds: int) -> None:
+        key = self._attempts_key(identifier)
+        # Use timestamp as both member and score
+        await self.client.zadd(key, {str(timestamp): timestamp})
+        await self.client.expire(key, int(window_seconds * 2))
+
+    async def get_recent_attempts(self, identifier: str, cutoff: float) -> List[float]:
+        key = self._attempts_key(identifier)
+        await self.client.zremrangebyscore(key, "-inf", cutoff)
+        data = await self.client.zrange(key, 0, -1, withscores=True)
+        return [float(score) for _, score in data]
+
+    async def set_lockout(self, identifier: str, until: float) -> None:
+        key = self._lockout_key(identifier)
+        ttl = max(1, int(until - time.time()))
+        await self.client.set(key, until, ex=ttl)
+
+    async def get_lockout(self, identifier: str) -> Optional[float]:
+        key = self._lockout_key(identifier)
+        value = await self.client.get(key)
+        return float(value) if value is not None else None
+
+    async def clear(self, identifier: str) -> None:
+        await self.client.delete(self._attempts_key(identifier), self._lockout_key(identifier))
+
+    async def cleanup(self, current_time: float, cutoff: float) -> None:
+        # Redis handles expiration; nothing needed
+        return None
+
+    def stats(self, current_time: float) -> Dict[str, Any]:
+        # Collecting stats from Redis synchronously isn't straightforward;
+        # return basic placeholders to satisfy interface.
+        return {
+            "total_identifiers_tracked": 0,
+            "active_lockouts": 0,
+            "total_lockouts": 0,
+        }

--- a/tests/test_rate_limiter.py
+++ b/tests/test_rate_limiter.py
@@ -1,0 +1,47 @@
+import pytest
+
+from ai_karen_engine.auth.config import AuthConfig
+from ai_karen_engine.auth.exceptions import RateLimitExceededError
+from ai_karen_engine.auth.security import RateLimiter
+from ai_karen_engine.auth.rate_limit_store import RedisRateLimitStore
+
+try:
+    import fakeredis.aioredis as fakeredis
+except Exception:  # pragma: no cover
+    fakeredis = None
+
+
+@pytest.mark.asyncio
+async def test_rate_limiter_memory_backend():
+    config = AuthConfig()
+    config.security.rate_limit_max_requests = 2
+    config.security.rate_limit_window_minutes = 1
+    limiter = RateLimiter(config)
+    ip = "127.0.0.1"
+    await limiter.check_rate_limit(ip)
+    await limiter.record_attempt(ip)
+    await limiter.check_rate_limit(ip)
+    await limiter.record_attempt(ip)
+    with pytest.raises(RateLimitExceededError):
+        await limiter.check_rate_limit(ip)
+
+
+@pytest.mark.asyncio
+async def test_rate_limiter_redis_backend():
+    if fakeredis is None:
+        pytest.skip("fakeredis not available")
+    config = AuthConfig()
+    config.security.rate_limit_max_requests = 2
+    config.security.rate_limit_window_minutes = 1
+    config.security.rate_limit_storage = "redis"
+    fake_client = fakeredis.FakeRedis(decode_responses=True)
+    store = RedisRateLimitStore(fake_client)
+    limiter = RateLimiter(config, store=store)
+    ip = "192.168.1.1"
+    await limiter.check_rate_limit(ip)
+    await limiter.record_attempt(ip)
+    await limiter.check_rate_limit(ip)
+    await limiter.record_attempt(ip)
+    with pytest.raises(RateLimitExceededError):
+        await limiter.check_rate_limit(ip)
+    await fake_client.close()


### PR DESCRIPTION
## Summary
- add rate limit storage backends (memory, Redis)
- expose rate limit backend settings in `AuthConfig.security`
- prevent duplicate AuthMonitor logs
- cover rate limit behavior in memory and Redis modes

## Testing
- `pip install fakeredis`
- `KARI_DUCKDB_PASSWORD=test KARI_JOB_SIGNING_KEY=test PYTHONPATH=src pytest tests/test_rate_limiter.py tests/test_auth_monitoring.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68975acf6548832490849a83ac90d17b