### PR TITLE
feat: add environment-aware auth configuration loaders

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,27 @@ AI-Karen is a comprehensive, production-ready AI platform designed for enterpris
 
 ---
 
+## Authentication Configuration
+
+The authentication service relies on the `AuthConfig` class for all
+runtime settings. Configuration can be provided in environment-specific
+YAML or JSON files:
+
+```python
+from ai_karen_engine.auth.config import AuthConfig
+
+# Load from a specific file and environment
+config = AuthConfig.from_file("config/auth_config.yaml", "development")
+
+# Or discover the file in the default ``config/`` directory
+config = AuthConfig.from_environment("production")
+```
+
+Example configuration files are provided in `config/auth_config.yaml`
+and `config/auth_config.json`.
+
+---
+
 ## Architecture
 
 ### System Components

--- a/config/auth_config.json
+++ b/config/auth_config.json
@@ -1,0 +1,18 @@
+{
+  "development": {
+    "database": {
+      "database_url": "sqlite:///./dev.db"
+    },
+    "jwt": {
+      "secret_key": "dev-secret"
+    }
+  },
+  "production": {
+    "database": {
+      "database_url": "postgresql+asyncpg://user:password@db.example.com/prod"
+    },
+    "jwt": {
+      "secret_key": "prod-secret"
+    }
+  }
+}

--- a/config/auth_config.yaml
+++ b/config/auth_config.yaml
@@ -1,0 +1,14 @@
+# Example authentication configuration
+# Contains settings for development and production environments
+
+development:
+  database:
+    database_url: "sqlite:///./dev.db"
+  jwt:
+    secret_key: "dev-secret"
+
+production:
+  database:
+    database_url: "postgresql+asyncpg://user:password@db.example.com/prod"
+  jwt:
+    secret_key: "prod-secret"

--- a/tests/test_auth_config_loading.py
+++ b/tests/test_auth_config_loading.py
@@ -1,0 +1,57 @@
+from pathlib import Path
+
+import pytest
+import yaml
+
+from ai_karen_engine.auth.config import AuthConfig
+
+
+def write_config(path: Path, data):
+    path.write_text(yaml.safe_dump(data))
+    return path
+
+
+def test_from_file_selects_environment(tmp_path):
+    data = {
+        "development": {
+            "database": {"database_url": "sqlite:///./dev.db"},
+            "jwt": {"secret_key": "dev-secret"},
+        },
+        "production": {
+            "database": {"database_url": "postgresql://user:pass@db/prod"},
+            "jwt": {"secret_key": "prod-secret"},
+        },
+    }
+    cfg_path = write_config(tmp_path / "auth.yaml", data)
+    cfg = AuthConfig.from_file(cfg_path, "development")
+    assert cfg.environment == "development"
+    assert cfg.database.database_url.startswith("sqlite")
+    assert cfg.jwt.secret_key == "dev-secret"
+
+
+def test_from_environment_discovers_file(tmp_path):
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    (config_dir / "auth_config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "development": {
+                    "database": {"database_url": "sqlite:///./dev.db"},
+                    "jwt": {"secret_key": "dev-secret"},
+                }
+            }
+        )
+    )
+    cfg = AuthConfig.from_environment("development", config_dir=config_dir)
+    assert cfg.database.database_url.endswith("dev.db")
+
+
+def test_production_requires_secret(tmp_path):
+    data = {
+        "production": {
+            "database": {"database_url": "postgresql://user:pass@db/prod"}
+        }
+    }
+    cfg_path = write_config(tmp_path / "auth.yaml", data)
+    with pytest.raises(ValueError):
+        AuthConfig.from_file(cfg_path, "production")


### PR DESCRIPTION
## Summary
- load auth config from YAML/JSON files by environment with `AuthConfig.from_file`
- add `AuthConfig.from_environment` for config discovery
- document configuration helpers and provide example files
- test environment-specific config loading and validation

## Testing
- `KARI_DUCKDB_PASSWORD=test KARI_JOB_SIGNING_KEY=test PYTHONPATH=src pytest tests/test_auth_config_loading.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68975bc264188324a20fcd2b300cc02d