### PR TITLE
Initialize auth DB schema at service startup

### DIFF
--- a/src/ai_karen_engine/auth/core.py
+++ b/src/ai_karen_engine/auth/core.py
@@ -128,7 +128,7 @@ class CoreAuthenticator:
         """Initialize core authenticator components."""
         if self._initialized:
             return
-        await self.db_client.initialize_schema()
+        await self.db_client._ensure_schema()
         self.session_manager._start_cleanup_task()
         self._initialized = True
 

--- a/src/ai_karen_engine/auth/service.py
+++ b/src/ai_karen_engine/auth/service.py
@@ -89,8 +89,11 @@ class AuthService:
             return
 
         self.logger.info("Initializing AuthService components...")
-
         try:
+            # Ensure database schema is initialized before other components
+            await self.core_auth.db_client.initialize_schema()
+            self.logger.info("Database schema initialized")
+
             # Initialize core authentication layer
             await self.core_auth.initialize()
             self.logger.info("Core authentication layer initialized")
@@ -109,8 +112,8 @@ class AuthService:
             self.logger.info("AuthService initialization completed successfully")
 
         except Exception as e:
-            self.logger.error(f"Failed to initialize AuthService: {e}")
-            raise ConfigurationError(f"AuthService initialization failed: {e}")
+            self.logger.exception("Failed to initialize AuthService: %s", e)
+            raise ConfigurationError(f"AuthService initialization failed: {e}") from e
 
     async def authenticate_user(
         self,


### PR DESCRIPTION
## Summary
- ensure AuthService initializes the database schema before other components
- prevent duplicate schema setup by using `_ensure_schema` in core authenticator

## Testing
- `pre-commit run --files src/ai_karen_engine/auth/service.py src/ai_karen_engine/auth/core.py` *(fails: mypy reported missing type annotations across repository)*
- `KARI_DUCKDB_PASSWORD=testing KARI_JOB_SIGNING_KEY=testing PYTHONPATH=src pytest` *(fails: multiple import and environment errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6897951e72f48324988a32ea041db13c