### PR TITLE
docs: expand auth service guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -609,6 +609,9 @@ See [LICENSE.md](LICENSE.md) and [LICENSE-commercial.txt](LICENSE-commercial.txt
 - [Database Documentation](docker/database/README.md) - Multi-database setup
 - [Plugin Documentation](plugin_marketplace/README.md) - Plugin development guide
 - [Extension Documentation](extensions/README.md) - Extension system overview
+- [Auth Service](docs/auth_service.md) - Core authentication service overview
+- [Auth Service Deployment Guide](docs/auth_service_deployment.md) - Environment setup and configuration loading
+- [Auth Service Migration Guide](docs/auth_service_migration.md) - Removal of legacy security modules
 
 ### Architecture Guides
 - [API Reference](docs/api_reference.md) - Complete API documentation

--- a/docs/auth_service.md
+++ b/docs/auth_service.md
@@ -1,6 +1,6 @@
 # Auth Service
 
-The Auth Service centralizes authentication, session management, and security checks for Kari. It provides a single interface used by routes, middleware, and extensions.
+The Auth Service centralizes authentication, session management, and security checks for Kari. It provides a single interface used by routes, middleware, and extensions. Deployment steps are covered in the [Auth Service Deployment Guide](auth_service_deployment.md), and removal of legacy modules is detailed in the [Auth Service Migration Guide](auth_service_migration.md).
 
 ## API Usage
 
@@ -48,6 +48,44 @@ await service.invalidate_session(session.session_id)
 - **Intelligence Layer** – integrate behavioral analysis or adaptive learning engines.
 - **Metrics Hook** – receive callbacks for login attempts and session activity.
 - **Custom Authenticators** – swap out the core authenticator or session store for alternative implementations.
+
+## AuthMonitor
+
+`AuthMonitor` provides real-time visibility into authentication activity. It records every login attempt,
+session validation, and security event with rich context such as user identifiers and IP addresses. The
+monitor runs asynchronously and can be attached to `AuthService` by default, or injected into custom
+deployments for advanced monitoring workflows.
+
+```python
+from ai_karen_engine.auth.monitoring import AuthMonitor
+
+monitor = AuthMonitor(config)
+service = AuthService(config, monitor=monitor)
+```
+
+AuthMonitor supports configurable log levels and structured output, making it suitable for production
+deployments that require audit trails and incident investigation.
+
+## Metrics Exposure
+
+Authentication metrics are emitted through a `metrics_hook` and surfaced alongside the platform's
+standard observability endpoints. When the API server is running, counters such as
+`auth_login_success_total` and `auth_login_failure_total` appear under `/metrics` and are available for
+Prometheus scraping. The retention window and aggregation interval can be tuned with
+`AUTH_METRICS_RETENTION_HOURS` and `AUTH_METRICS_AGGREGATION_INTERVAL`.
+
+## Structured Logging
+
+The service emits JSON-formatted logs that capture event metadata including user IDs, IP addresses,
+and processing time. Logging behavior is controlled through environment variables:
+
+- `AUTH_STRUCTURED_LOG_FORMAT` – set to `json` or `text`.
+- `AUTH_LOG_SUCCESSFUL_LOGINS` – log successful authentications.
+- `AUTH_LOG_FAILED_LOGINS` – capture failed attempts.
+- `AUTH_LOG_SECURITY_EVENTS` – record security-related events.
+
+Structured logging integrates with centralized log processors and allows filtering by fields such as
+`event_type`, `success`, or `risk_score` for faster debugging.
 
 ## Migration Guide
 

--- a/docs/auth_service_deployment.md
+++ b/docs/auth_service_deployment.md
@@ -1,0 +1,37 @@
+# Auth Service Deployment Guide
+
+## Environment Setup
+
+1. **Install Dependencies**
+   - Ensure Python 3.10+ is installed.
+   - Install required packages:
+     ```bash
+     pip install -r requirements.txt
+     ```
+2. **Configure Environment Variables**
+   - Set authentication settings such as `AUTH_SECRET_KEY` and database connection details.
+   - Optional: copy `.env.example` to `.env` and populate values.
+3. **Provision Backing Services**
+   - Start PostgreSQL and Redis if using non-memory session backends.
+   - Confirm services are reachable before launching the API.
+
+## Configuration Loading
+
+`AuthService` relies on `AuthConfig` for runtime settings. Configuration can be loaded from
+environment variables or discovered in configuration files.
+
+```python
+from ai_karen_engine.auth.config import AuthConfig
+
+# Load configuration for the current environment
+config = AuthConfig.from_environment("production")
+
+# Or load explicitly from a file
+config = AuthConfig.from_file("config/auth_config.yaml", "development")
+```
+
+Place configuration files under the `config/` directory and ensure the appropriate environment is
+specified. When the service starts (`python start_server.py`), `AuthService` automatically picks up
+the resolved configuration and initializes session storage, monitoring, and security settings.
+
+For a complete list of options see [auth_config.md](auth_config.md).

--- a/docs/auth_service_migration.md
+++ b/docs/auth_service_migration.md
@@ -1,0 +1,29 @@
+# Auth Service Migration Guide
+
+## Removing Legacy Security Modules
+
+The unified Auth Service replaces multiple legacy security components. The following modules and
+compatibility layers have been removed:
+
+- Deprecated `auth_client` helpers and factory functions
+- Standalone rate limiter implementations
+- `security.compat` shims and other transitional utilities
+
+## Migration Steps
+
+1. **Drop Old Imports**
+   Remove references to legacy modules and import `AuthService` instead:
+   ```python
+   from ai_karen_engine.auth.service import AuthService, get_auth_service
+   ```
+2. **Use Built-in Security Features**
+   The new service includes rate limiting, session validation, and monitoring through
+   `AuthMonitor`. No external security modules are required.
+3. **Clean Configuration**
+   Replace deprecated environment variables (e.g., `AUTH_ENABLE_RATE_LIMITER`) with their
+   modern equivalents (`AUTH_ENABLE_RATE_LIMITING`).
+
+## Verification
+
+After migration, run your test suite and ensure authentication flows succeed. Structured logs and
+metrics from `AuthMonitor` should confirm that legacy modules are no longer in use.


### PR DESCRIPTION
## Summary
- document AuthMonitor, metrics, and structured logging
- add auth service deployment guide
- add migration guide for legacy security module removal

## Testing
- `pytest test_auth_service.py -q` *(fails: Can't connect to display ":0")*

------
https://chatgpt.com/codex/tasks/task_e_68979e9d71b48324997d4927aae190dc