### PR TITLE
feat: initialize pgcrypto extension

### DIFF
--- a/src/ai_karen_engine/auth/database.py
+++ b/src/ai_karen_engine/auth/database.py
@@ -86,6 +86,13 @@ class AuthDatabaseClient:
         """Initialize PostgreSQL schema with authentication tables."""
         try:
             async with self.engine.begin() as conn:
+                try:
+                    await conn.execute(text("CREATE EXTENSION IF NOT EXISTS pgcrypto"))
+                except Exception as e:
+                    self.logger.warning(
+                        "Failed to create pgcrypto extension: %s", e
+                    )
+
                 # Create users table
                 await conn.execute(
                     text(


### PR DESCRIPTION
## Summary
- ensure pgcrypto extension exists when initializing auth database schema
- warn on failure to create pgcrypto extension

## Testing
- `KARI_DUCKDB_PASSWORD=testpass PYTHONPATH=src pytest tests/test_postgres_client.py::test_simple_connection -q` *(fails: KARI_JOB_SIGNING_KEY must be set in the environment!)*

------
https://chatgpt.com/codex/tasks/task_e_68979d43ed9c8324bcc95a3dd1ad9339