### PR TITLE
Add aiohttp dependency and document test setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,17 @@ export MILVUS_PORT=19530
 | Build web UI | `cd ui_launchers/web_ui && npm run build` |
 | Build desktop | `cd ui_launchers/desktop_ui && npm run tauri build` |
 
+### Test Environment Setup
+
+The test suite depends on several third-party libraries, including
+`httpx`, `sqlalchemy`, `asyncpg`, `aiohttp`, `psutil`,
+`prometheus_client`, and `bcrypt`. Install all test dependencies
+before running `pytest`:
+
+```bash
+pip install -r requirements.txt
+```
+
 ### Demo Scripts
 
 When running the example demo scripts directly from the repository, set

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,6 +41,7 @@ fakeredis
 psycopg
 psycopg2-binary
 asyncpg
+aiohttp
 sqlalchemy
 alembic
 chardet


### PR DESCRIPTION
## Summary
- include `aiohttp` in `requirements.txt` alongside existing database and http libraries
- document test environment setup, calling out key third-party dependencies before running pytest

## Testing
- `pre-commit run --files requirements.txt README.md`
- `pytest tests/test_imports.py -q` *(fails: module 'tests.stubs.numpy' has no attribute 'basic')*
- `pytest tests/test_log_utils.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6897dca057ac8324973a10b87ab03380