### PR TITLE
Add graceful shutdown routines for auth layers

### DIFF
--- a/src/ai_karen_engine/auth/intelligence.py
+++ b/src/ai_karen_engine/auth/intelligence.py
@@ -7,15 +7,13 @@ behavioral analysis, and risk scoring for the consolidated authentication servic
 
 from __future__ import annotations
 
-import asyncio
 import logging
-from datetime import datetime, timedelta
-from typing import Any, Dict, List, Optional, Tuple
 from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Dict, List, Optional, Tuple
 
 from .config import AuthConfig
-from .models import UserData, SessionData, AuthEvent, AuthEventType
-from .exceptions import AnomalyDetectedError, SecurityError
+from .models import AuthEvent, AuthEventType, UserData
 
 logger = logging.getLogger(__name__)
 
@@ -23,7 +21,7 @@ logger = logging.getLogger(__name__)
 @dataclass
 class LoginAttempt:
     """Data structure for login attempt analysis."""
-    
+
     user_id: Optional[str]
     email: str
     ip_address: str
@@ -32,7 +30,7 @@ class LoginAttempt:
     device_fingerprint: Optional[str] = None
     geolocation: Optional[Dict[str, Any]] = None
     session_context: Optional[Dict[str, Any]] = None
-    
+
     def to_dict(self) -> Dict[str, Any]:
         """Convert to dictionary for serialization."""
         return {
@@ -50,15 +48,17 @@ class LoginAttempt:
 @dataclass
 class BehavioralPattern:
     """User behavioral pattern data."""
-    
+
     user_id: str
     typical_login_hours: List[int] = field(default_factory=list)
     typical_locations: List[Dict[str, Any]] = field(default_factory=list)
     typical_devices: List[str] = field(default_factory=list)
-    login_frequency: Dict[str, int] = field(default_factory=dict)  # day_of_week -> count
+    login_frequency: Dict[str, int] = field(
+        default_factory=dict
+    )  # day_of_week -> count
     average_session_duration: float = 0.0
     last_updated: datetime = field(default_factory=datetime.utcnow)
-    
+
     def to_dict(self) -> Dict[str, Any]:
         """Convert to dictionary for serialization."""
         return {
@@ -75,13 +75,13 @@ class BehavioralPattern:
 @dataclass
 class AnomalyResult:
     """Result of anomaly detection analysis."""
-    
+
     is_anomaly: bool
     anomaly_score: float  # 0.0 to 1.0
     anomaly_types: List[str] = field(default_factory=list)
     confidence: float = 0.0
     details: Dict[str, Any] = field(default_factory=dict)
-    
+
     def to_dict(self) -> Dict[str, Any]:
         """Convert to dictionary for serialization."""
         return {
@@ -96,7 +96,7 @@ class AnomalyResult:
 @dataclass
 class IntelligenceResult:
     """Result of intelligence analysis for authentication attempt."""
-    
+
     risk_score: float  # 0.0 to 1.0
     risk_level: str  # "low", "medium", "high"
     should_block: bool
@@ -104,14 +104,16 @@ class IntelligenceResult:
     behavioral_analysis: Optional[Dict[str, Any]] = None
     recommendations: List[str] = field(default_factory=list)
     processing_time_ms: float = 0.0
-    
+
     def to_dict(self) -> Dict[str, Any]:
         """Convert to dictionary for serialization."""
         return {
             "risk_score": self.risk_score,
             "risk_level": self.risk_level,
             "should_block": self.should_block,
-            "anomaly_result": self.anomaly_result.to_dict() if self.anomaly_result else None,
+            "anomaly_result": self.anomaly_result.to_dict()
+            if self.anomaly_result
+            else None,
             "behavioral_analysis": self.behavioral_analysis,
             "recommendations": self.recommendations,
             "processing_time_ms": self.processing_time_ms,
@@ -120,23 +122,21 @@ class IntelligenceResult:
 
 class AnomalyDetector:
     """Anomaly detection component for authentication attempts."""
-    
+
     def __init__(self, config: AuthConfig) -> None:
         """Initialize anomaly detector with configuration."""
         self.config = config
         self.logger = logging.getLogger(f"{__name__}.AnomalyDetector")
-    
+
     async def detect_anomalies(
-        self,
-        attempt: LoginAttempt,
-        user_pattern: Optional[BehavioralPattern] = None
+        self, attempt: LoginAttempt, user_pattern: Optional[BehavioralPattern] = None
     ) -> AnomalyResult:
         """Detect anomalies in a login attempt."""
         start_time = datetime.utcnow()
         anomaly_types = []
         anomaly_score = 0.0
         details = {}
-        
+
         try:
             # Time-based anomaly detection
             time_anomaly = self._detect_time_anomaly(attempt, user_pattern)
@@ -144,210 +144,241 @@ class AnomalyDetector:
                 anomaly_types.append("unusual_time")
                 anomaly_score = max(anomaly_score, time_anomaly[1])
                 details["time_analysis"] = time_anomaly[2]
-            
+
             # Location-based anomaly detection
             location_anomaly = self._detect_location_anomaly(attempt, user_pattern)
             if location_anomaly[0]:
                 anomaly_types.append("unusual_location")
                 anomaly_score = max(anomaly_score, location_anomaly[1])
                 details["location_analysis"] = location_anomaly[2]
-            
+
             # Device-based anomaly detection
             device_anomaly = self._detect_device_anomaly(attempt, user_pattern)
             if device_anomaly[0]:
                 anomaly_types.append("unusual_device")
                 anomaly_score = max(anomaly_score, device_anomaly[1])
                 details["device_analysis"] = device_anomaly[2]
-            
+
             # Frequency-based anomaly detection
             frequency_anomaly = self._detect_frequency_anomaly(attempt, user_pattern)
             if frequency_anomaly[0]:
                 anomaly_types.append("unusual_frequency")
                 anomaly_score = max(anomaly_score, frequency_anomaly[1])
                 details["frequency_analysis"] = frequency_anomaly[2]
-            
+
             is_anomaly = len(anomaly_types) > 0
-            confidence = min(1.0, anomaly_score * len(anomaly_types) / 4.0)  # Normalize by max possible anomaly types
-            
+            confidence = min(
+                1.0, anomaly_score * len(anomaly_types) / 4.0
+            )  # Normalize by max possible anomaly types
+
             processing_time = (datetime.utcnow() - start_time).total_seconds() * 1000
             details["processing_time_ms"] = processing_time
-            
+
             return AnomalyResult(
                 is_anomaly=is_anomaly,
                 anomaly_score=anomaly_score,
                 anomaly_types=anomaly_types,
                 confidence=confidence,
-                details=details
+                details=details,
             )
-            
+
         except Exception as e:
             self.logger.error(f"Error in anomaly detection: {e}")
             return AnomalyResult(
-                is_anomaly=False,
-                anomaly_score=0.0,
-                details={"error": str(e)}
+                is_anomaly=False, anomaly_score=0.0, details={"error": str(e)}
             )
-    
+
     def _detect_time_anomaly(
-        self,
-        attempt: LoginAttempt,
-        user_pattern: Optional[BehavioralPattern]
+        self, attempt: LoginAttempt, user_pattern: Optional[BehavioralPattern]
     ) -> Tuple[bool, float, Dict[str, Any]]:
         """Detect time-based anomalies."""
         if not user_pattern or not user_pattern.typical_login_hours:
             return False, 0.0, {"reason": "no_historical_data"}
-        
+
         current_hour = attempt.timestamp.hour
         typical_hours = set(user_pattern.typical_login_hours)
-        
+
         if current_hour in typical_hours:
             return False, 0.0, {"current_hour": current_hour, "is_typical": True}
-        
+
         # Calculate distance to nearest typical hour
-        distances = [min(abs(current_hour - h), 24 - abs(current_hour - h)) for h in typical_hours]
+        distances = [
+            min(abs(current_hour - h), 24 - abs(current_hour - h))
+            for h in typical_hours
+        ]
         min_distance = min(distances)
-        
+
         # Score based on distance (further = higher anomaly score)
         anomaly_score = min(1.0, min_distance / 12.0)  # Max distance is 12 hours
-        
-        return anomaly_score > self.config.intelligence.time_sensitivity, anomaly_score, {
-            "current_hour": current_hour,
-            "typical_hours": list(typical_hours),
-            "min_distance_hours": min_distance,
-            "anomaly_score": anomaly_score
-        }
-    
+
+        return (
+            anomaly_score > self.config.intelligence.time_sensitivity,
+            anomaly_score,
+            {
+                "current_hour": current_hour,
+                "typical_hours": list(typical_hours),
+                "min_distance_hours": min_distance,
+                "anomaly_score": anomaly_score,
+            },
+        )
+
     def _detect_location_anomaly(
-        self,
-        attempt: LoginAttempt,
-        user_pattern: Optional[BehavioralPattern]
+        self, attempt: LoginAttempt, user_pattern: Optional[BehavioralPattern]
     ) -> Tuple[bool, float, Dict[str, Any]]:
         """Detect location-based anomalies."""
-        if not attempt.geolocation or not user_pattern or not user_pattern.typical_locations:
+        if (
+            not attempt.geolocation
+            or not user_pattern
+            or not user_pattern.typical_locations
+        ):
             return False, 0.0, {"reason": "no_location_data"}
-        
+
         current_location = attempt.geolocation
-        if not current_location.get("latitude") or not current_location.get("longitude"):
+        if not current_location.get("latitude") or not current_location.get(
+            "longitude"
+        ):
             return False, 0.0, {"reason": "incomplete_location_data"}
-        
+
         # Calculate distance to typical locations
-        min_distance = float('inf')
+        min_distance = float("inf")
         for typical_loc in user_pattern.typical_locations:
             if typical_loc.get("latitude") and typical_loc.get("longitude"):
                 distance = self._calculate_distance(
-                    current_location["latitude"], current_location["longitude"],
-                    typical_loc["latitude"], typical_loc["longitude"]
+                    current_location["latitude"],
+                    current_location["longitude"],
+                    typical_loc["latitude"],
+                    typical_loc["longitude"],
                 )
                 min_distance = min(min_distance, distance)
-        
-        if min_distance == float('inf'):
+
+        if min_distance == float("inf"):
             return False, 0.0, {"reason": "no_valid_typical_locations"}
-        
+
         # Score based on distance (further = higher anomaly score)
         # Assume 100km as threshold for "normal" distance
         anomaly_score = min(1.0, min_distance / 100.0)
-        
-        return anomaly_score > self.config.intelligence.location_sensitivity, anomaly_score, {
-            "current_location": current_location,
-            "min_distance_km": min_distance,
-            "anomaly_score": anomaly_score
-        }
-    
+
+        return (
+            anomaly_score > self.config.intelligence.location_sensitivity,
+            anomaly_score,
+            {
+                "current_location": current_location,
+                "min_distance_km": min_distance,
+                "anomaly_score": anomaly_score,
+            },
+        )
+
     def _detect_device_anomaly(
-        self,
-        attempt: LoginAttempt,
-        user_pattern: Optional[BehavioralPattern]
+        self, attempt: LoginAttempt, user_pattern: Optional[BehavioralPattern]
     ) -> Tuple[bool, float, Dict[str, Any]]:
         """Detect device-based anomalies."""
-        if not attempt.device_fingerprint or not user_pattern or not user_pattern.typical_devices:
+        if (
+            not attempt.device_fingerprint
+            or not user_pattern
+            or not user_pattern.typical_devices
+        ):
             return False, 0.0, {"reason": "no_device_data"}
-        
+
         current_device = attempt.device_fingerprint
         is_known_device = current_device in user_pattern.typical_devices
-        
+
         if is_known_device:
             return False, 0.0, {"device_fingerprint": current_device, "is_known": True}
-        
+
         # New device - score based on device sensitivity setting
         anomaly_score = self.config.intelligence.device_sensitivity
-        
-        return True, anomaly_score, {
-            "device_fingerprint": current_device,
-            "is_known": False,
-            "known_devices_count": len(user_pattern.typical_devices),
-            "anomaly_score": anomaly_score
-        }
-    
+
+        return (
+            True,
+            anomaly_score,
+            {
+                "device_fingerprint": current_device,
+                "is_known": False,
+                "known_devices_count": len(user_pattern.typical_devices),
+                "anomaly_score": anomaly_score,
+            },
+        )
+
     def _detect_frequency_anomaly(
-        self,
-        attempt: LoginAttempt,
-        user_pattern: Optional[BehavioralPattern]
+        self, attempt: LoginAttempt, user_pattern: Optional[BehavioralPattern]
     ) -> Tuple[bool, float, Dict[str, Any]]:
         """Detect frequency-based anomalies."""
         if not user_pattern or not user_pattern.login_frequency:
             return False, 0.0, {"reason": "no_frequency_data"}
-        
+
         day_of_week = attempt.timestamp.strftime("%A").lower()
         typical_frequency = user_pattern.login_frequency.get(day_of_week, 0)
-        
+
         # For now, just check if user typically logs in on this day
         if typical_frequency > 0:
             return False, 0.0, {"day_of_week": day_of_week, "is_typical_day": True}
-        
+
         # User doesn't typically log in on this day
         anomaly_score = 0.3  # Moderate anomaly score for unusual day
-        
-        return True, anomaly_score, {
-            "day_of_week": day_of_week,
-            "typical_frequency": typical_frequency,
-            "is_typical_day": False,
-            "anomaly_score": anomaly_score
-        }
-    
-    def _calculate_distance(self, lat1: float, lon1: float, lat2: float, lon2: float) -> float:
+
+        return (
+            True,
+            anomaly_score,
+            {
+                "day_of_week": day_of_week,
+                "typical_frequency": typical_frequency,
+                "is_typical_day": False,
+                "anomaly_score": anomaly_score,
+            },
+        )
+
+    def _calculate_distance(
+        self, lat1: float, lon1: float, lat2: float, lon2: float
+    ) -> float:
         """Calculate distance between two points using Haversine formula."""
         import math
-        
+
         # Convert to radians
         lat1, lon1, lat2, lon2 = map(math.radians, [lat1, lon1, lat2, lon2])
-        
+
         # Haversine formula
         dlat = lat2 - lat1
         dlon = lon2 - lon1
-        a = math.sin(dlat/2)**2 + math.cos(lat1) * math.cos(lat2) * math.sin(dlon/2)**2
+        a = (
+            math.sin(dlat / 2) ** 2
+            + math.cos(lat1) * math.cos(lat2) * math.sin(dlon / 2) ** 2
+        )
         c = 2 * math.asin(math.sqrt(a))
-        
+
         # Earth's radius in kilometers
         r = 6371
-        
+
         return c * r
 
 
 class BehavioralAnalyzer:
     """Behavioral analysis component for user pattern recognition."""
-    
+
     def __init__(self, config: AuthConfig) -> None:
         """Initialize behavioral analyzer with configuration."""
         self.config = config
         self.logger = logging.getLogger(f"{__name__}.BehavioralAnalyzer")
-    
+
     async def analyze_behavior(
         self,
         attempt: LoginAttempt,
         user_data: Optional[UserData] = None,
-        historical_events: Optional[List[AuthEvent]] = None
+        historical_events: Optional[List[AuthEvent]] = None,
     ) -> Dict[str, Any]:
         """Analyze user behavior patterns."""
         try:
             if not user_data or not historical_events:
                 return {"status": "insufficient_data", "analysis": {}}
-            
+
             # Build behavioral pattern from historical data
-            pattern = await self._build_behavioral_pattern(user_data.user_id, historical_events)
-            
+            pattern = await self._build_behavioral_pattern(
+                user_data.user_id, historical_events
+            )
+
             # Analyze current attempt against pattern
             analysis = {
-                "pattern_established": len(historical_events) >= self.config.intelligence.min_training_samples,
+                "pattern_established": len(historical_events)
+                >= self.config.intelligence.min_training_samples,
                 "time_analysis": self._analyze_time_pattern(attempt, pattern),
                 "location_analysis": self._analyze_location_pattern(attempt, pattern),
                 "device_analysis": self._analyze_device_pattern(attempt, pattern),
@@ -356,223 +387,250 @@ class BehavioralAnalyzer:
                     "typical_hours": pattern.typical_login_hours,
                     "location_count": len(pattern.typical_locations),
                     "device_count": len(pattern.typical_devices),
-                    "total_logins": len(historical_events)
-                }
+                    "total_logins": len(historical_events),
+                },
             }
-            
+
             return {"status": "success", "analysis": analysis, "pattern": pattern}
-            
+
         except Exception as e:
             self.logger.error(f"Error in behavioral analysis: {e}")
             return {"status": "error", "error": str(e)}
-    
+
     async def _build_behavioral_pattern(
-        self,
-        user_id: str,
-        historical_events: List[AuthEvent]
+        self, user_id: str, historical_events: List[AuthEvent]
     ) -> BehavioralPattern:
         """Build behavioral pattern from historical authentication events."""
         pattern = BehavioralPattern(user_id=user_id)
-        
+
         # Filter successful login events
         login_events = [
-            event for event in historical_events
+            event
+            for event in historical_events
             if event.event_type == AuthEventType.LOGIN_SUCCESS
         ]
-        
+
         if not login_events:
             return pattern
-        
+
         # Analyze time patterns
         login_hours = [event.timestamp.hour for event in login_events]
         pattern.typical_login_hours = list(set(login_hours))
-        
+
         # Analyze frequency patterns
         frequency = {}
         for event in login_events:
             day = event.timestamp.strftime("%A").lower()
             frequency[day] = frequency.get(day, 0) + 1
         pattern.login_frequency = frequency
-        
+
         # Analyze location patterns (if available)
         locations = []
         for event in login_events:
             if event.details.get("geolocation"):
                 locations.append(event.details["geolocation"])
         pattern.typical_locations = self._cluster_locations(locations)
-        
+
         # Analyze device patterns (if available)
         devices = []
         for event in login_events:
             if event.details.get("device_fingerprint"):
                 devices.append(event.details["device_fingerprint"])
         pattern.typical_devices = list(set(devices))
-        
+
         pattern.last_updated = datetime.utcnow()
         return pattern
-    
-    def _analyze_time_pattern(self, attempt: LoginAttempt, pattern: BehavioralPattern) -> Dict[str, Any]:
+
+    def _analyze_time_pattern(
+        self, attempt: LoginAttempt, pattern: BehavioralPattern
+    ) -> Dict[str, Any]:
         """Analyze time-based behavior patterns."""
         current_hour = attempt.timestamp.hour
         is_typical_hour = current_hour in pattern.typical_login_hours
-        
+
         return {
             "current_hour": current_hour,
             "is_typical_hour": is_typical_hour,
             "typical_hours": pattern.typical_login_hours,
-            "hour_deviation": self._calculate_hour_deviation(current_hour, pattern.typical_login_hours)
+            "hour_deviation": self._calculate_hour_deviation(
+                current_hour, pattern.typical_login_hours
+            ),
         }
-    
-    def _analyze_location_pattern(self, attempt: LoginAttempt, pattern: BehavioralPattern) -> Dict[str, Any]:
+
+    def _analyze_location_pattern(
+        self, attempt: LoginAttempt, pattern: BehavioralPattern
+    ) -> Dict[str, Any]:
         """Analyze location-based behavior patterns."""
         if not attempt.geolocation:
             return {"status": "no_location_data"}
-        
+
         is_typical_location = False
-        min_distance = float('inf')
-        
+        min_distance = float("inf")
+
         for typical_loc in pattern.typical_locations:
             if typical_loc.get("latitude") and typical_loc.get("longitude"):
                 distance = self._calculate_distance(
-                    attempt.geolocation["latitude"], attempt.geolocation["longitude"],
-                    typical_loc["latitude"], typical_loc["longitude"]
+                    attempt.geolocation["latitude"],
+                    attempt.geolocation["longitude"],
+                    typical_loc["latitude"],
+                    typical_loc["longitude"],
                 )
                 min_distance = min(min_distance, distance)
                 if distance < 50:  # Within 50km considered typical
                     is_typical_location = True
                     break
-        
+
         return {
             "current_location": attempt.geolocation,
             "is_typical_location": is_typical_location,
-            "min_distance_km": min_distance if min_distance != float('inf') else None,
-            "typical_locations_count": len(pattern.typical_locations)
+            "min_distance_km": min_distance if min_distance != float("inf") else None,
+            "typical_locations_count": len(pattern.typical_locations),
         }
-    
-    def _analyze_device_pattern(self, attempt: LoginAttempt, pattern: BehavioralPattern) -> Dict[str, Any]:
+
+    def _analyze_device_pattern(
+        self, attempt: LoginAttempt, pattern: BehavioralPattern
+    ) -> Dict[str, Any]:
         """Analyze device-based behavior patterns."""
         if not attempt.device_fingerprint:
             return {"status": "no_device_data"}
-        
+
         is_known_device = attempt.device_fingerprint in pattern.typical_devices
-        
+
         return {
             "device_fingerprint": attempt.device_fingerprint,
             "is_known_device": is_known_device,
-            "known_devices_count": len(pattern.typical_devices)
+            "known_devices_count": len(pattern.typical_devices),
         }
-    
-    def _analyze_frequency_pattern(self, attempt: LoginAttempt, pattern: BehavioralPattern) -> Dict[str, Any]:
+
+    def _analyze_frequency_pattern(
+        self, attempt: LoginAttempt, pattern: BehavioralPattern
+    ) -> Dict[str, Any]:
         """Analyze frequency-based behavior patterns."""
         day_of_week = attempt.timestamp.strftime("%A").lower()
         typical_frequency = pattern.login_frequency.get(day_of_week, 0)
         total_logins = sum(pattern.login_frequency.values())
         frequency_ratio = typical_frequency / total_logins if total_logins > 0 else 0
-        
+
         return {
             "day_of_week": day_of_week,
             "typical_frequency": typical_frequency,
             "frequency_ratio": frequency_ratio,
-            "is_typical_day": typical_frequency > 0
+            "is_typical_day": typical_frequency > 0,
         }
-    
-    def _cluster_locations(self, locations: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+
+    def _cluster_locations(
+        self, locations: List[Dict[str, Any]]
+    ) -> List[Dict[str, Any]]:
         """Simple location clustering to identify typical locations."""
         if not locations:
             return []
-        
+
         # Simple clustering: group locations within 10km of each other
         clusters = []
         for location in locations:
             if not location.get("latitude") or not location.get("longitude"):
                 continue
-            
+
             added_to_cluster = False
             for cluster in clusters:
                 distance = self._calculate_distance(
-                    location["latitude"], location["longitude"],
-                    cluster["latitude"], cluster["longitude"]
+                    location["latitude"],
+                    location["longitude"],
+                    cluster["latitude"],
+                    cluster["longitude"],
                 )
                 if distance < 10:  # 10km threshold
                     added_to_cluster = True
                     break
-            
+
             if not added_to_cluster:
                 clusters.append(location)
-        
+
         return clusters
-    
-    def _calculate_hour_deviation(self, current_hour: int, typical_hours: List[int]) -> float:
+
+    def _calculate_hour_deviation(
+        self, current_hour: int, typical_hours: List[int]
+    ) -> float:
         """Calculate deviation from typical hours."""
         if not typical_hours:
             return 12.0  # Maximum deviation
-        
-        distances = [min(abs(current_hour - h), 24 - abs(current_hour - h)) for h in typical_hours]
+
+        distances = [
+            min(abs(current_hour - h), 24 - abs(current_hour - h))
+            for h in typical_hours
+        ]
         return min(distances)
-    
-    def _calculate_distance(self, lat1: float, lon1: float, lat2: float, lon2: float) -> float:
+
+    def _calculate_distance(
+        self, lat1: float, lon1: float, lat2: float, lon2: float
+    ) -> float:
         """Calculate distance between two points using Haversine formula."""
         import math
-        
+
         # Convert to radians
         lat1, lon1, lat2, lon2 = map(math.radians, [lat1, lon1, lat2, lon2])
-        
+
         # Haversine formula
         dlat = lat2 - lat1
         dlon = lon2 - lon1
-        a = math.sin(dlat/2)**2 + math.cos(lat1) * math.cos(lat2) * math.sin(dlon/2)**2
+        a = (
+            math.sin(dlat / 2) ** 2
+            + math.cos(lat1) * math.cos(lat2) * math.sin(dlon / 2) ** 2
+        )
         c = 2 * math.asin(math.sqrt(a))
-        
+
         # Earth's radius in kilometers
         r = 6371
-        
+
         return c * r
 
 
 class RiskScorer:
     """Risk scoring component for authentication attempts."""
-    
+
     def __init__(self, config: AuthConfig) -> None:
         """Initialize risk scorer with configuration."""
         self.config = config
         self.logger = logging.getLogger(f"{__name__}.RiskScorer")
-    
+
     def calculate_risk_score(
         self,
         attempt: LoginAttempt,
         anomaly_result: Optional[AnomalyResult] = None,
         behavioral_analysis: Optional[Dict[str, Any]] = None,
-        user_data: Optional[UserData] = None
+        user_data: Optional[UserData] = None,
     ) -> Tuple[float, str]:
         """Calculate overall risk score and level."""
         try:
             base_score = 0.0
-            
+
             # Anomaly-based risk
             if anomaly_result and anomaly_result.is_anomaly:
                 anomaly_weight = 0.4
                 base_score += anomaly_result.anomaly_score * anomaly_weight
-            
+
             # Behavioral analysis risk
             if behavioral_analysis and behavioral_analysis.get("status") == "success":
                 behavioral_weight = 0.3
-                behavioral_risk = self._calculate_behavioral_risk(behavioral_analysis["analysis"])
+                behavioral_risk = self._calculate_behavioral_risk(
+                    behavioral_analysis["analysis"]
+                )
                 base_score += behavioral_risk * behavioral_weight
-            
+
             # User history risk
             if user_data:
                 history_weight = 0.2
                 history_risk = self._calculate_history_risk(user_data)
                 base_score += history_risk * history_weight
-            
+
             # Context-based risk
             context_weight = 0.1
             context_risk = self._calculate_context_risk(attempt)
             base_score += context_risk * context_weight
-            
+
             # Ensure score is between 0 and 1
             risk_score = max(0.0, min(1.0, base_score))
-            
+
             # Determine risk level
             if risk_score < self.config.intelligence.risk_threshold_low:
                 risk_level = "low"
@@ -582,101 +640,103 @@ class RiskScorer:
                 risk_level = "high"
             else:
                 risk_level = "critical"
-            
+
             return risk_score, risk_level
-            
+
         except Exception as e:
             self.logger.error(f"Error calculating risk score: {e}")
             return 0.5, "medium"  # Default to medium risk on error
-    
+
     def _calculate_behavioral_risk(self, analysis: Dict[str, Any]) -> float:
         """Calculate risk based on behavioral analysis."""
         risk_factors = []
-        
+
         # Time-based risk
         time_analysis = analysis.get("time_analysis", {})
         if not time_analysis.get("is_typical_hour", True):
             hour_deviation = time_analysis.get("hour_deviation", 0)
             risk_factors.append(min(1.0, hour_deviation / 12.0))
-        
+
         # Location-based risk
         location_analysis = analysis.get("location_analysis", {})
         if location_analysis.get("status") != "no_location_data":
             if not location_analysis.get("is_typical_location", True):
                 min_distance = location_analysis.get("min_distance_km", 0)
                 if min_distance:
-                    risk_factors.append(min(1.0, min_distance / 1000.0))  # Normalize by 1000km
-        
+                    risk_factors.append(
+                        min(1.0, min_distance / 1000.0)
+                    )  # Normalize by 1000km
+
         # Device-based risk
         device_analysis = analysis.get("device_analysis", {})
         if device_analysis.get("status") != "no_device_data":
             if not device_analysis.get("is_known_device", True):
                 risk_factors.append(0.5)  # Moderate risk for unknown device
-        
+
         # Frequency-based risk
         frequency_analysis = analysis.get("frequency_analysis", {})
         if not frequency_analysis.get("is_typical_day", True):
             risk_factors.append(0.3)  # Low-moderate risk for unusual day
-        
+
         # Return average of risk factors
         return sum(risk_factors) / len(risk_factors) if risk_factors else 0.0
-    
+
     def _calculate_history_risk(self, user_data: UserData) -> float:
         """Calculate risk based on user history."""
         risk_score = 0.0
-        
+
         # Failed login attempts
         if user_data.failed_login_attempts > 0:
             risk_score += min(0.5, user_data.failed_login_attempts / 10.0)
-        
+
         # Account locked
         if user_data.is_locked():
             risk_score += 0.8
-        
+
         # Account not verified
         if not user_data.is_verified:
             risk_score += 0.3
-        
+
         # Account not active
         if not user_data.is_active:
             risk_score += 1.0
-        
+
         return min(1.0, risk_score)
-    
+
     def _calculate_context_risk(self, attempt: LoginAttempt) -> float:
         """Calculate risk based on attempt context."""
         risk_score = 0.0
-        
+
         # Check for suspicious IP patterns
         if self._is_suspicious_ip(attempt.ip_address):
             risk_score += 0.4
-        
+
         # Check for suspicious user agent
         if self._is_suspicious_user_agent(attempt.user_agent):
             risk_score += 0.2
-        
+
         # Check for unusual timing (e.g., very late night)
         hour = attempt.timestamp.hour
         if hour < 4 or hour > 23:  # Between midnight and 4 AM
             risk_score += 0.1
-        
+
         return min(1.0, risk_score)
-    
+
     def _is_suspicious_ip(self, ip_address: str) -> bool:
         """Check if IP address is suspicious."""
         # Simple checks - in production, this would use threat intelligence
         suspicious_patterns = [
             "127.0.0.1",  # Localhost (suspicious in production)
-            "0.0.0.0",    # Invalid IP
+            "0.0.0.0",  # Invalid IP
         ]
-        
+
         return any(pattern in ip_address for pattern in suspicious_patterns)
-    
+
     def _is_suspicious_user_agent(self, user_agent: str) -> bool:
         """Check if user agent is suspicious."""
         if not user_agent:
             return True
-        
+
         suspicious_patterns = [
             "bot",
             "crawler",
@@ -685,7 +745,7 @@ class RiskScorer:
             "curl",
             "wget",
         ]
-        
+
         user_agent_lower = user_agent.lower()
         return any(pattern in user_agent_lower for pattern in suspicious_patterns)
 
@@ -695,7 +755,7 @@ class IntelligenceEngine:
     Intelligence engine that integrates anomaly detection, behavioral analysis,
     and risk scoring for advanced authentication features.
     """
-    
+
     def __init__(self, config: AuthConfig) -> None:
         """Initialize intelligence engine with configuration."""
         self.config = config
@@ -704,60 +764,62 @@ class IntelligenceEngine:
         self.risk_scorer = RiskScorer(config)
         self.logger = logging.getLogger(f"{__name__}.IntelligenceEngine")
         self._initialized = False
-    
+
     async def initialize(self) -> None:
         """Initialize the intelligence engine."""
         if self._initialized:
             return
-        
+
         self.logger.info("Initializing intelligence engine")
         # Any async initialization can go here
         self._initialized = True
         self.logger.info("Intelligence engine initialized successfully")
-    
+
     async def analyze_login_attempt(
         self,
         attempt: LoginAttempt,
         user_data: Optional[UserData] = None,
-        historical_events: Optional[List[AuthEvent]] = None
+        historical_events: Optional[List[AuthEvent]] = None,
     ) -> IntelligenceResult:
         """Analyze a login attempt and return intelligence result."""
         start_time = datetime.utcnow()
-        
+
         try:
             await self.initialize()
-            
+
             # Perform behavioral analysis
             behavioral_analysis = await self.behavioral_analyzer.analyze_behavior(
                 attempt, user_data, historical_events
             )
-            
+
             # Extract behavioral pattern if available
             behavioral_pattern = None
             if behavioral_analysis.get("status") == "success":
                 behavioral_pattern = behavioral_analysis.get("pattern")
-            
+
             # Perform anomaly detection
             anomaly_result = await self.anomaly_detector.detect_anomalies(
                 attempt, behavioral_pattern
             )
-            
+
             # Calculate risk score
             risk_score, risk_level = self.risk_scorer.calculate_risk_score(
                 attempt, anomaly_result, behavioral_analysis, user_data
             )
-            
+
             # Determine if attempt should be blocked
-            should_block = self._should_block_attempt(risk_score, risk_level, anomaly_result)
-            
+            should_block = self._should_block_attempt(
+                risk_score, risk_level, anomaly_result
+            )
+
             # Generate recommendations
             recommendations = self._generate_recommendations(
                 risk_score, risk_level, anomaly_result, behavioral_analysis
             )
-            
+
             # Calculate processing time
             processing_time = (datetime.utcnow() - start_time).total_seconds() * 1000
-            
+
             result = IntelligenceResult(
                 risk_score=risk_score,
                 risk_level=risk_level,
@@ -765,39 +827,39 @@ class IntelligenceEngine:
                 anomaly_result=anomaly_result,
                 behavioral_analysis=behavioral_analysis,
                 recommendations=recommendations,
-                processing_time_ms=processing_time
+                processing_time_ms=processing_time,
             )
-            
+
             self.logger.info(
                 f"Intelligence analysis completed: risk_score={risk_score:.3f}, "
                 f"risk_level={risk_level}, should_block={should_block}, "
                 f"processing_time={processing_time:.1f}ms"
             )
-            
+
             return result
-            
+
         except Exception as e:
             self.logger.error(f"Error in intelligence analysis: {e}")
             processing_time = (datetime.utcnow() - start_time).total_seconds() * 1000
-            
+
             # Return safe default result on error
             return IntelligenceResult(
                 risk_score=0.5,
                 risk_level="medium",
                 should_block=False,
-                recommendations=["Intelligence analysis failed - manual review recommended"],
-                processing_time_ms=processing_time
+                recommendations=[
+                    "Intelligence analysis failed - manual review recommended"
+                ],
+                processing_time_ms=processing_time,
             )
-    
+
     async def calculate_risk_score(
-        self,
-        user_data: UserData,
-        context: Dict[str, Any]
+        self, user_data: UserData, context: Dict[str, Any]
     ) -> float:
         """Calculate risk score for authentication context."""
         try:
             await self.initialize()
-            
+
             # Create login attempt from context
             attempt = LoginAttempt(
                 user_id=user_data.user_id,
@@ -807,47 +869,49 @@ class IntelligenceEngine:
                 timestamp=datetime.utcnow(),
                 device_fingerprint=context.get("device_fingerprint"),
                 geolocation=context.get("geolocation"),
-                session_context=context.get("session_context")
+                session_context=context.get("session_context"),
             )
-            
+
             # Analyze the attempt
             result = await self.analyze_login_attempt(attempt, user_data)
             return result.risk_score
-            
+
         except Exception as e:
             self.logger.error(f"Error calculating risk score: {e}")
             return 0.5  # Default medium risk
-    
+
     def _should_block_attempt(
         self,
         risk_score: float,
         risk_level: str,
-        anomaly_result: Optional[AnomalyResult]
+        anomaly_result: Optional[AnomalyResult],
     ) -> bool:
         """Determine if an authentication attempt should be blocked."""
         # Block if risk score is above high threshold
         if risk_score >= self.config.intelligence.risk_threshold_high:
             return True
-        
+
         # Block if multiple high-confidence anomalies detected
-        if (anomaly_result and 
-            anomaly_result.is_anomaly and 
-            anomaly_result.confidence > 0.8 and 
-            len(anomaly_result.anomaly_types) >= 2):
+        if (
+            anomaly_result
+            and anomaly_result.is_anomaly
+            and anomaly_result.confidence > 0.8
+            and len(anomaly_result.anomaly_types) >= 2
+        ):
             return True
-        
+
         return False
-    
+
     def _generate_recommendations(
         self,
         risk_score: float,
         risk_level: str,
         anomaly_result: Optional[AnomalyResult],
-        behavioral_analysis: Optional[Dict[str, Any]]
+        behavioral_analysis: Optional[Dict[str, Any]],
     ) -> List[str]:
         """Generate recommendations based on analysis results."""
         recommendations = []
-        
+
         if risk_level == "critical":
             recommendations.append("Block authentication attempt immediately")
             recommendations.append("Require additional verification")
@@ -857,7 +921,7 @@ class IntelligenceEngine:
         elif risk_level == "medium":
             recommendations.append("Consider additional verification")
             recommendations.append("Log for security review")
-        
+
         if anomaly_result and anomaly_result.is_anomaly:
             for anomaly_type in anomaly_result.anomaly_types:
                 if anomaly_type == "unusual_location":
@@ -866,14 +930,44 @@ class IntelligenceEngine:
                     recommendations.append("Send device verification notification")
                 elif anomaly_type == "unusual_time":
                     recommendations.append("Consider time-based access restrictions")
-        
+
         if behavioral_analysis and behavioral_analysis.get("status") == "success":
             analysis = behavioral_analysis.get("analysis", {})
             if not analysis.get("pattern_established", False):
-                recommendations.append("Establish behavioral baseline with more login data")
-        
-        return recommendations  
-  
+                recommendations.append(
+                    "Establish behavioral baseline with more login data"
+                )
+
+        return recommendations
+
+    async def shutdown(self) -> None:
+        """Gracefully shutdown the intelligence engine and its components."""
+        if not self._initialized:
+            return
+
+        self.logger.info("Shutting down intelligence engine")
+
+        try:
+            if hasattr(self.anomaly_detector, "shutdown"):
+                await self.anomaly_detector.shutdown()
+        except Exception as e:  # pragma: no cover - defensive
+            self.logger.error(f"Error shutting down anomaly detector: {e}")
+
+        try:
+            if hasattr(self.behavioral_analyzer, "shutdown"):
+                await self.behavioral_analyzer.shutdown()
+        except Exception as e:  # pragma: no cover - defensive
+            self.logger.error(f"Error shutting down behavioral analyzer: {e}")
+
+        try:
+            if hasattr(self.risk_scorer, "shutdown"):
+                await self.risk_scorer.shutdown()
+        except Exception as e:  # pragma: no cover - defensive
+            self.logger.error(f"Error shutting down risk scorer: {e}")
+
+        self._initialized = False
+        self.logger.info("Intelligence engine shutdown complete")
+
     async def get_stats(self) -> Dict[str, Any]:
         """Get intelligence engine statistics."""
         return {
@@ -895,5 +989,5 @@ class IntelligenceEngine:
                 "location": self.config.intelligence.location_sensitivity,
                 "time": self.config.intelligence.time_sensitivity,
                 "device": self.config.intelligence.device_sensitivity,
-            }
+            },
         }

--- a/src/ai_karen_engine/auth/security.py
+++ b/src/ai_karen_engine/auth/security.py
@@ -7,18 +7,15 @@ monitoring of authentication activities.
 """
 
 import asyncio
-import hashlib
-import json
 import logging
 import time
 from collections import defaultdict
 from datetime import datetime, timedelta
-from typing import Any, Callable, Dict, List, Optional, Set, Tuple
-from uuid import uuid4
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from .config import AuthConfig
-from .exceptions import RateLimitExceededError, SecurityError, SessionError
-from .models import AuthEvent, AuthEventType, SessionData, UserData
+from .exceptions import RateLimitExceededError
+from .models import AuthEvent, AuthEventType, SessionData
 from .monitoring import metrics_hook as monitoring_metrics_hook
 from .rate_limit_store import (
     InMemoryRateLimitStore,
@@ -30,11 +27,11 @@ from .rate_limit_store import (
 class RateLimiter:
     """
     Rate limiting component to prevent brute force attacks and abuse.
-    
+
     Implements sliding window rate limiting with configurable limits
     and automatic cleanup of expired entries.
     """
-    
+
     def __init__(self, config: AuthConfig, store: Optional[RateLimitStore] = None):
         self.config = config
         self.security_config = config.security
@@ -69,7 +66,7 @@ class RateLimiter:
         self.lockout_duration_minutes = self.security_config.lockout_duration_minutes
 
         self.logger = logging.getLogger(__name__)
-    
+
     def _get_identifier(self, ip_address: str, email: Optional[str] = None) -> str:
         """Generate a unique identifier for rate limiting."""
         if email:
@@ -78,7 +75,7 @@ class RateLimiter:
         else:
             # Use IP address for general rate limiting
             return f"ip:{ip_address}"
-    
+
     async def _cleanup_expired_entries(self) -> None:
         """Clean up expired rate limiting entries."""
         current_time = time.time()
@@ -93,30 +90,27 @@ class RateLimiter:
         await self.store.cleanup(current_time, cutoff_time)
 
         self._last_cleanup = current_time
-    
+
     async def check_rate_limit(
-        self,
-        ip_address: str,
-        email: Optional[str] = None,
-        event_type: str = "general"
+        self, ip_address: str, email: Optional[str] = None, event_type: str = "general"
     ) -> bool:
         """
         Check if a request should be rate limited.
-        
+
         Args:
             ip_address: Client IP address
             email: User email (optional)
             event_type: Type of event being rate limited
-            
+
         Returns:
             True if request is allowed, False if rate limited
-            
+
         Raises:
             RateLimitExceededError: If rate limit is exceeded
         """
         if not self.security_config.enable_rate_limiting:
             return True
-        
+
         await self._cleanup_expired_entries()
 
         identifier = self._get_identifier(ip_address, email)
@@ -167,17 +161,17 @@ class RateLimiter:
             )
 
         return True
-    
+
     async def record_attempt(
         self,
         ip_address: str,
         email: Optional[str] = None,
         success: bool = True,
-        event_type: str = "general"
+        event_type: str = "general",
     ) -> None:
         """
         Record an authentication attempt for rate limiting.
-        
+
         Args:
             ip_address: Client IP address
             email: User email (optional)
@@ -186,7 +180,7 @@ class RateLimiter:
         """
         if not self.security_config.enable_rate_limiting:
             return
-        
+
         identifier = self._get_identifier(ip_address, email)
         current_time = time.time()
 
@@ -207,12 +201,12 @@ class RateLimiter:
                 self.logger.warning(
                     f"User {email} locked out due to {len(failed_attempts)} failed attempts"
                 )
-    
+
     async def is_locked_out(self, ip_address: str, email: Optional[str] = None) -> bool:
         """Check if an identifier is currently locked out."""
         if not self.security_config.enable_rate_limiting:
             return False
-        
+
         identifier = self._get_identifier(ip_address, email)
         current_time = time.time()
 
@@ -221,16 +215,14 @@ class RateLimiter:
             return lockout_until > current_time
 
         return False
-    
+
     async def get_remaining_lockout_time(
-        self,
-        ip_address: str,
-        email: Optional[str] = None
+        self, ip_address: str, email: Optional[str] = None
     ) -> int:
         """Get remaining lockout time in seconds."""
         if not self.security_config.enable_rate_limiting:
             return 0
-        
+
         identifier = self._get_identifier(ip_address, email)
         current_time = time.time()
 
@@ -240,12 +232,12 @@ class RateLimiter:
             return max(0, int(remaining))
 
         return 0
-    
+
     async def clear_lockout(self, ip_address: str, email: Optional[str] = None) -> None:
         """Clear lockout for an identifier (admin function)."""
         identifier = self._get_identifier(ip_address, email)
         await self.store.clear(identifier)
-    
+
     def get_stats(self) -> Dict[str, Any]:
         """Get rate limiting statistics."""
         current_time = time.time()
@@ -271,56 +263,58 @@ class AuditLogger:
     def __init__(
         self,
         config: AuthConfig,
-        metrics_hook: Optional[Callable[[str, Dict[str, Any]], None]] = monitoring_metrics_hook,
+        metrics_hook: Optional[
+            Callable[[str, Dict[str, Any]], None]
+        ] = monitoring_metrics_hook,
     ):
         self.config = config
         self.security_config = config.security
         self.metrics_hook = metrics_hook
-        
+
         # Set up structured logging
         self.logger = logging.getLogger(f"{__name__}.audit")
         self.logger.setLevel(logging.INFO)
-        
+
         # Create formatter for structured logging
         formatter = logging.Formatter(
-            '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+            "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
         )
-        
+
         # Add console handler if not already present
         if not self.logger.handlers:
             handler = logging.StreamHandler()
             handler.setFormatter(formatter)
             self.logger.addHandler(handler)
-        
+
         # Event counters for monitoring
         self._event_counts: Dict[str, int] = defaultdict(int)
         self._security_events: List[Dict[str, Any]] = []
         self._max_security_events = 1000  # Keep last 1000 security events in memory
-    
+
     async def log_auth_event(self, event: AuthEvent) -> None:
         """
         Log an authentication event with appropriate detail level.
-        
+
         Args:
             event: AuthEvent instance to log
         """
         if not self.security_config.enable_audit_logging:
             return
-        
+
         # Check if we should log this event type
         should_log = self._should_log_event(event)
         if not should_log:
             return
-        
+
         # Increment event counter
         self._event_counts[event.event_type.value] += 1
-        
+
         # Create log entry
         log_data = self._create_log_entry(event)
-        
+
         # Determine log level based on event type and success
         log_level = self._get_log_level(event)
-        
+
         # Log the event
         self.logger.log(
             log_level,
@@ -333,9 +327,9 @@ class AuditLogger:
                 "ip_address": event.ip_address,
                 "success": event.success,
                 "risk_score": event.risk_score,
-            }
+            },
         )
-        
+
         # Store security events for monitoring
         if self._is_security_event(event):
             self._store_security_event(log_data)
@@ -349,21 +343,23 @@ class AuditLogger:
                 )
             except Exception:  # pragma: no cover - metrics are best effort
                 self.logger.debug("Metrics hook failed", exc_info=True)
-    
+
     def _should_log_event(self, event: AuthEvent) -> bool:
         """Determine if an event should be logged based on configuration."""
         if not event.success and self.security_config.log_failed_logins:
             return True
-        
-        if event.success and event.event_type in {
-            AuthEventType.LOGIN_SUCCESS,
-            AuthEventType.SESSION_CREATED
-        } and self.security_config.log_successful_logins:
+
+        if (
+            event.success
+            and event.event_type
+            in {AuthEventType.LOGIN_SUCCESS, AuthEventType.SESSION_CREATED}
+            and self.security_config.log_successful_logins
+        ):
             return True
-        
+
         if self._is_security_event(event) and self.security_config.log_security_events:
             return True
-        
+
         # Always log critical security events
         critical_events = {
             AuthEventType.LOGIN_BLOCKED,
@@ -372,9 +368,9 @@ class AuditLogger:
             AuthEventType.ANOMALY_DETECTED,
             AuthEventType.THREAT_DETECTED,
         }
-        
+
         return event.event_type in critical_events
-    
+
     def _is_security_event(self, event: AuthEvent) -> bool:
         """Check if an event is security-related."""
         security_events = {
@@ -386,14 +382,14 @@ class AuditLogger:
             AuthEventType.THREAT_DETECTED,
             AuthEventType.TWO_FACTOR_FAILED,
         }
-        
+
         return (
-            event.event_type in security_events or
-            not event.success or
-            event.blocked_by_security or
-            event.risk_score > 0.5
+            event.event_type in security_events
+            or not event.success
+            or event.blocked_by_security
+            or event.risk_score > 0.5
         )
-    
+
     def _get_log_level(self, event: AuthEvent) -> int:
         """Get appropriate log level for an event."""
         if event.event_type in {
@@ -403,12 +399,12 @@ class AuditLogger:
             AuthEventType.THREAT_DETECTED,
         }:
             return logging.ERROR
-        
+
         if not event.success or event.risk_score > 0.7:
             return logging.WARNING
-        
+
         return logging.INFO
-    
+
     def _create_log_entry(self, event: AuthEvent) -> Dict[str, Any]:
         """Create a structured log entry from an auth event."""
         log_entry = {
@@ -428,29 +424,29 @@ class AuditLogger:
             "processing_time_ms": event.processing_time_ms,
             "service_version": event.service_version,
         }
-        
+
         # Add error information if present
         if event.error_message:
             log_entry["error_message"] = event.error_message
-        
+
         # Add details if present
         if event.details:
             log_entry["details"] = event.details
-        
+
         # Add request context if available
         if event.request_id:
             log_entry["request_id"] = event.request_id
-        
+
         return log_entry
-    
+
     def _store_security_event(self, log_data: Dict[str, Any]) -> None:
         """Store security event for monitoring and analysis."""
         self._security_events.append(log_data)
-        
+
         # Keep only the most recent events
         if len(self._security_events) > self._max_security_events:
-            self._security_events = self._security_events[-self._max_security_events:]
-    
+            self._security_events = self._security_events[-self._max_security_events :]
+
     async def log_login_attempt(
         self,
         email: str,
@@ -461,11 +457,13 @@ class AuditLogger:
         error_message: Optional[str] = None,
         risk_score: float = 0.0,
         processing_time_ms: float = 0.0,
-        **kwargs
+        **kwargs,
     ) -> None:
         """Log a login attempt with standard fields."""
-        event_type = AuthEventType.LOGIN_SUCCESS if success else AuthEventType.LOGIN_FAILED
-        
+        event_type = (
+            AuthEventType.LOGIN_SUCCESS if success else AuthEventType.LOGIN_FAILED
+        )
+
         event = AuthEvent(
             event_type=event_type,
             user_id=user_id,
@@ -476,18 +474,18 @@ class AuditLogger:
             error_message=error_message,
             risk_score=risk_score,
             processing_time_ms=processing_time_ms,
-            **kwargs
+            **kwargs,
         )
-        
+
         await self.log_auth_event(event)
-    
+
     async def log_session_event(
         self,
         event_type: AuthEventType,
         session_data: SessionData,
         success: bool = True,
         error_message: Optional[str] = None,
-        **kwargs
+        **kwargs,
     ) -> None:
         """Log a session-related event."""
         event = AuthEvent(
@@ -502,11 +500,11 @@ class AuditLogger:
             error_message=error_message,
             risk_score=session_data.risk_score,
             security_flags=session_data.security_flags,
-            **kwargs
+            **kwargs,
         )
-        
+
         await self.log_auth_event(event)
-    
+
     async def log_security_event(
         self,
         event_type: AuthEventType,
@@ -517,7 +515,7 @@ class AuditLogger:
         risk_score: float = 0.0,
         security_flags: Optional[List[str]] = None,
         details: Optional[Dict[str, Any]] = None,
-        **kwargs
+        **kwargs,
     ) -> None:
         """Log a security-related event."""
         event = AuthEvent(
@@ -531,24 +529,24 @@ class AuditLogger:
             security_flags=security_flags or [],
             blocked_by_security=True,
             details=details or {},
-            **kwargs
+            **kwargs,
         )
-        
+
         await self.log_auth_event(event)
-    
+
     def get_event_counts(self) -> Dict[str, int]:
         """Get event counts for monitoring."""
         return dict(self._event_counts)
-    
+
     def get_recent_security_events(self, limit: int = 100) -> List[Dict[str, Any]]:
         """Get recent security events for analysis."""
         return self._security_events[-limit:]
-    
+
     def get_stats(self) -> Dict[str, Any]:
         """Get audit logging statistics."""
         total_events = sum(self._event_counts.values())
         security_event_count = len(self._security_events)
-        
+
         return {
             "total_events_logged": total_events,
             "security_events_stored": security_event_count,
@@ -563,38 +561,38 @@ class AuditLogger:
 class SessionValidator:
     """
     Session validation component for enhanced session security.
-    
+
     Provides validation of session integrity, security context,
     and detection of suspicious session activity.
     """
-    
+
     def __init__(self, config: AuthConfig):
         self.config = config
         self.security_config = config.security
         self.session_config = config.session
-        
+
         self.logger = logging.getLogger(__name__)
-        
+
         # Session validation cache to avoid repeated validations
         self._validation_cache: Dict[str, Tuple[bool, float]] = {}
         self._cache_ttl = 300  # 5 minutes
-    
+
     async def validate_session_security(
         self,
         session: SessionData,
         current_ip: str,
         current_user_agent: str,
-        request_context: Optional[Dict[str, Any]] = None
+        request_context: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         """
         Validate session security and detect suspicious activity.
-        
+
         Args:
             session: Session data to validate
             current_ip: Current request IP address
             current_user_agent: Current request user agent
             request_context: Additional request context
-            
+
         Returns:
             Dictionary with validation results and security flags
         """
@@ -603,63 +601,60 @@ class SessionValidator:
                 "valid": True,
                 "security_flags": [],
                 "risk_score": 0.0,
-                "warnings": []
+                "warnings": [],
             }
-        
+
         validation_result = {
             "valid": True,
             "security_flags": [],
             "risk_score": session.risk_score,
             "warnings": [],
-            "details": {}
+            "details": {},
         }
-        
+
         # Check if session is active first
         if not session.is_active:
             validation_result["valid"] = False
             validation_result["security_flags"].append("session_inactive")
             validation_result["warnings"].append("Session is not active")
             return validation_result
-        
+
         # Check if session is expired
         if session.is_expired():
             validation_result["valid"] = False
             validation_result["security_flags"].append("session_expired")
             validation_result["warnings"].append("Session has expired")
             return validation_result
-        
+
         # Validate IP address if configured
         if self.security_config.validate_ip_address:
             ip_validation = await self._validate_ip_address(session, current_ip)
             validation_result["security_flags"].extend(ip_validation["flags"])
             validation_result["risk_score"] = max(
-                validation_result["risk_score"],
-                ip_validation["risk_score"]
+                validation_result["risk_score"], ip_validation["risk_score"]
             )
             if ip_validation["warnings"]:
                 validation_result["warnings"].extend(ip_validation["warnings"])
-        
+
         # Validate user agent if configured
         if self.security_config.validate_user_agent:
             ua_validation = await self._validate_user_agent(session, current_user_agent)
             validation_result["security_flags"].extend(ua_validation["flags"])
             validation_result["risk_score"] = max(
-                validation_result["risk_score"],
-                ua_validation["risk_score"]
+                validation_result["risk_score"], ua_validation["risk_score"]
             )
             if ua_validation["warnings"]:
                 validation_result["warnings"].extend(ua_validation["warnings"])
-        
+
         # Check session age and activity
         session_validation = await self._validate_session_activity(session)
         validation_result["security_flags"].extend(session_validation["flags"])
         validation_result["risk_score"] = max(
-            validation_result["risk_score"],
-            session_validation["risk_score"]
+            validation_result["risk_score"], session_validation["risk_score"]
         )
         if session_validation["warnings"]:
             validation_result["warnings"].extend(session_validation["warnings"])
-        
+
         # Check for device fingerprint changes if enabled
         if self.security_config.enable_device_fingerprinting and request_context:
             device_validation = await self._validate_device_fingerprint(
@@ -667,173 +662,152 @@ class SessionValidator:
             )
             validation_result["security_flags"].extend(device_validation["flags"])
             validation_result["risk_score"] = max(
-                validation_result["risk_score"],
-                device_validation["risk_score"]
+                validation_result["risk_score"], device_validation["risk_score"]
             )
             if device_validation["warnings"]:
                 validation_result["warnings"].extend(device_validation["warnings"])
-        
+
         # Update session with new security flags
         for flag in validation_result["security_flags"]:
             session.add_security_flag(flag)
-        
+
         session.update_risk_score(validation_result["risk_score"])
         session.update_last_accessed()
-        
+
         return validation_result
-    
+
     async def _validate_ip_address(
-        self,
-        session: SessionData,
-        current_ip: str
+        self, session: SessionData, current_ip: str
     ) -> Dict[str, Any]:
         """Validate IP address consistency."""
-        result = {
-            "flags": [],
-            "risk_score": 0.0,
-            "warnings": []
-        }
-        
+        result = {"flags": [], "risk_score": 0.0, "warnings": []}
+
         if session.ip_address != current_ip:
             result["flags"].append("ip_address_changed")
             result["risk_score"] = 0.3
             result["warnings"].append(
                 f"IP address changed from {session.ip_address} to {current_ip}"
             )
-            
+
             # Check if it's a significant change (different subnet)
             if not self._is_same_subnet(session.ip_address, current_ip):
                 result["flags"].append("ip_subnet_changed")
                 result["risk_score"] = 0.6
                 result["warnings"].append("IP address changed to different subnet")
-        
+
         return result
-    
+
     async def _validate_user_agent(
-        self,
-        session: SessionData,
-        current_user_agent: str
+        self, session: SessionData, current_user_agent: str
     ) -> Dict[str, Any]:
         """Validate user agent consistency."""
-        result = {
-            "flags": [],
-            "risk_score": 0.0,
-            "warnings": []
-        }
-        
+        result = {"flags": [], "risk_score": 0.0, "warnings": []}
+
         if session.user_agent != current_user_agent:
             result["flags"].append("user_agent_changed")
             result["risk_score"] = 0.2
             result["warnings"].append("User agent changed")
-            
+
             # Check for significant changes (different browser/OS)
             if not self._is_similar_user_agent(session.user_agent, current_user_agent):
                 result["flags"].append("user_agent_major_change")
                 result["risk_score"] = 0.5
                 result["warnings"].append("Major user agent change detected")
-        
+
         return result
-    
+
     async def _validate_session_activity(self, session: SessionData) -> Dict[str, Any]:
         """Validate session activity patterns."""
-        result = {
-            "flags": [],
-            "risk_score": 0.0,
-            "warnings": []
-        }
-        
+        result = {"flags": [], "risk_score": 0.0, "warnings": []}
+
         now = datetime.utcnow()
-        
+
         # Check session age
         session_age = now - session.created_at
         max_session_age = self.session_config.session_timeout
-        
+
         if session_age > max_session_age:
             result["flags"].append("session_too_old")
             result["risk_score"] = 0.8
             result["warnings"].append("Session exceeds maximum age")
-        
+
         # Check last access time
         time_since_access = now - session.last_accessed
         if time_since_access > timedelta(hours=1):
             result["flags"].append("session_inactive")
             result["risk_score"] = max(result["risk_score"], 0.3)
             result["warnings"].append("Session has been inactive for extended period")
-        
+
         return result
-    
+
     async def _validate_device_fingerprint(
-        self,
-        session: SessionData,
-        request_context: Dict[str, Any]
+        self, session: SessionData, request_context: Dict[str, Any]
     ) -> Dict[str, Any]:
         """Validate device fingerprint consistency."""
-        result = {
-            "flags": [],
-            "risk_score": 0.0,
-            "warnings": []
-        }
-        
+        result = {"flags": [], "risk_score": 0.0, "warnings": []}
+
         current_fingerprint = request_context.get("device_fingerprint")
         if not current_fingerprint or not session.device_fingerprint:
             return result
-        
+
         if session.device_fingerprint != current_fingerprint:
             result["flags"].append("device_fingerprint_changed")
             result["risk_score"] = 0.7
             result["warnings"].append("Device fingerprint changed")
-        
+
         return result
-    
+
     def _is_same_subnet(self, ip1: str, ip2: str) -> bool:
         """Check if two IP addresses are in the same subnet (simplified)."""
         try:
             # Simple check for IPv4 - same first 3 octets
-            parts1 = ip1.split('.')
-            parts2 = ip2.split('.')
-            
+            parts1 = ip1.split(".")
+            parts2 = ip2.split(".")
+
             if len(parts1) == 4 and len(parts2) == 4:
                 return parts1[:3] == parts2[:3]
         except Exception:
             pass
-        
+
         return False
-    
+
     def _is_similar_user_agent(self, ua1: str, ua2: str) -> bool:
         """Check if two user agents are similar (same browser family)."""
         if not ua1 or not ua2:
             return False
-        
+
         # Extract browser name (simplified)
         browsers = ["Chrome", "Firefox", "Safari", "Edge", "Opera"]
-        
+
         ua1_browser = None
         ua2_browser = None
-        
+
         for browser in browsers:
             if browser in ua1:
                 ua1_browser = browser
             if browser in ua2:
                 ua2_browser = browser
-        
+
         return ua1_browser == ua2_browser
-    
+
     async def validate_session_token(self, session_token: str) -> bool:
         """Validate session token format and structure."""
         if not session_token:
             return False
-        
+
         # Basic token format validation
         if len(session_token) < 32:
             return False
-        
+
         # Check for valid characters (alphanumeric and some special chars)
-        allowed_chars = set("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_.")
+        allowed_chars = set(
+            "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_."
+        )
         if not all(c in allowed_chars for c in session_token):
             return False
-        
+
         return True
-    
+
     def get_stats(self) -> Dict[str, Any]:
         """Get session validation statistics."""
         return {
@@ -856,7 +830,9 @@ class SecurityEnhancer:
     def __init__(
         self,
         config: AuthConfig,
-        metrics_hook: Optional[Callable[[str, Dict[str, Any]], None]] = monitoring_metrics_hook,
+        metrics_hook: Optional[
+            Callable[[str, Dict[str, Any]], None]
+        ] = monitoring_metrics_hook,
     ):
         self.config = config
         self.security_config = config.security
@@ -867,25 +843,25 @@ class SecurityEnhancer:
         self.session_validator = SessionValidator(config)
 
         self.logger = logging.getLogger(__name__)
-    
+
     async def check_request_security(
         self,
         ip_address: str,
         user_agent: str,
         email: Optional[str] = None,
         event_type: str = "authentication",
-        request_context: Optional[Dict[str, Any]] = None
+        request_context: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         """
         Comprehensive security check for authentication requests.
-        
+
         Args:
             ip_address: Client IP address
             user_agent: Client user agent
             email: User email (optional)
             event_type: Type of authentication event
             request_context: Additional request context
-            
+
         Returns:
             Dictionary with security check results
         """
@@ -895,17 +871,15 @@ class SecurityEnhancer:
             "risk_score": 0.0,
             "warnings": [],
             "rate_limit_info": {},
-            "details": {}
+            "details": {},
         }
-        
+
         try:
             # Check rate limiting
             await self.rate_limiter.check_rate_limit(
-                ip_address=ip_address,
-                email=email,
-                event_type=event_type
+                ip_address=ip_address, email=email, event_type=event_type
             )
-            
+
             # Get rate limit info
             is_locked = await self.rate_limiter.is_locked_out(ip_address, email)
             if is_locked:
@@ -916,111 +890,98 @@ class SecurityEnhancer:
                 security_result["security_flags"].append("rate_limited")
                 security_result["rate_limit_info"] = {
                     "locked_out": True,
-                    "remaining_seconds": remaining_time
+                    "remaining_seconds": remaining_time,
                 }
-            
+
             return security_result
-            
+
         except RateLimitExceededError as e:
             security_result["allowed"] = False
             security_result["security_flags"].append("rate_limit_exceeded")
             security_result["details"]["rate_limit_error"] = str(e)
             return security_result
-        
+
         except Exception as e:
             self.logger.error(f"Security check error: {e}")
             security_result["warnings"].append(f"Security check failed: {e}")
             return security_result
-    
+
     async def initialize(self) -> None:
         """Initialize the security enhancer."""
         # Any async initialization can go here
         pass
-    
+
     async def check_rate_limit(
-        self,
-        ip_address: str,
-        email: Optional[str] = None,
-        event_type: str = "general"
+        self, ip_address: str, email: Optional[str] = None, event_type: str = "general"
     ) -> bool:
         """Check rate limit for a request."""
         return await self.rate_limiter.check_rate_limit(ip_address, email, event_type)
-    
+
     async def record_successful_attempt(
-        self,
-        ip_address: str,
-        email: str,
-        user_id: str,
-        event_type: str = "login"
+        self, ip_address: str, email: str, user_id: str, event_type: str = "login"
     ) -> None:
         """Record a successful authentication attempt."""
         await self.rate_limiter.record_attempt(
-            ip_address=ip_address,
-            email=email,
-            success=True,
-            event_type=event_type
+            ip_address=ip_address, email=email, success=True, event_type=event_type
         )
-        
+
         await self.audit_logger.log_login_attempt(
             email=email,
             ip_address=ip_address,
             user_agent="",
             success=True,
-            user_id=user_id
+            user_id=user_id,
         )
-    
+
     async def record_failed_attempt(
         self,
         ip_address: str,
         email: str,
         error_type: str,
-        details: Optional[Dict[str, Any]] = None
+        details: Optional[Dict[str, Any]] = None,
     ) -> None:
         """Record a failed authentication attempt."""
         await self.rate_limiter.record_attempt(
-            ip_address=ip_address,
-            email=email,
-            success=False,
-            event_type="login_failed"
+            ip_address=ip_address, email=email, success=False, event_type="login_failed"
         )
-        
+
         await self.audit_logger.log_login_attempt(
             email=email,
             ip_address=ip_address,
             user_agent="",
             success=False,
-            error_message=error_type
+            error_message=error_type,
         )
-    
+
     async def validate_session_security(
         self,
         session: SessionData,
         current_ip: str,
         current_user_agent: str,
-        request_context: Optional[Dict[str, Any]] = None
+        request_context: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         """Validate session security."""
         return await self.session_validator.validate_session_security(
             session, current_ip, current_user_agent, request_context
         )
-    
+
     async def log_auth_event(self, event: AuthEvent) -> None:
         """Log an authentication event."""
         await self.audit_logger.log_auth_event(event)
-    
+
     async def log_session_event(
         self,
         event_type: AuthEventType,
         session_data: SessionData,
         success: bool = True,
         error_message: Optional[str] = None,
-        details: Optional[Dict[str, Any]] = None
+        details: Optional[Dict[str, Any]] = None,
     ) -> None:
         """Log a session-related event."""
         await self.audit_logger.log_session_event(
             event_type, session_data, success, error_message, **details or {}
         )
-    
+
     async def log_security_event(
         self,
         event_type: AuthEventType,
@@ -1030,7 +991,7 @@ class SecurityEnhancer:
         email: Optional[str] = None,
         risk_score: float = 0.0,
         security_flags: Optional[List[str]] = None,
-        details: Optional[Dict[str, Any]] = None
+        details: Optional[Dict[str, Any]] = None,
     ) -> None:
         """Log a security-related event."""
         await self.audit_logger.log_security_event(
@@ -1041,60 +1002,56 @@ class SecurityEnhancer:
             email=email,
             risk_score=risk_score,
             security_flags=security_flags,
-            details=details
+            details=details,
         )
-    
+
     async def get_user_auth_history(
-        self,
-        user_id: str,
-        days: int = 30
+        self, user_id: str, days: int = 30
     ) -> List[AuthEvent]:
         """Get authentication history for a user."""
         # This would typically query the database for auth events
         # For now, return empty list as placeholder
         return []
-    
+
     async def update_user_intelligence_data(
-        self,
-        user_id: str,
-        intelligence_result: Any
+        self, user_id: str, intelligence_result: Any
     ) -> None:
         """Update user intelligence data."""
         # Placeholder for updating user intelligence data
         pass
-    
+
     async def get_stats(self) -> Dict[str, Any]:
         """Get security layer statistics."""
         rate_limiter_stats = self.rate_limiter.get_stats()
         audit_logger_stats = self.audit_logger.get_stats()
-        
+
         return {
             "rate_limiter": rate_limiter_stats,
             "audit_logger": audit_logger_stats,
             "security_enabled": True,
             "components": {
                 "rate_limiter": "active",
-                "audit_logger": "active", 
-                "session_validator": "active"
-            }
+                "audit_logger": "active",
+                "session_validator": "active",
+            },
         }
-    
+
     async def validate_session_request(
         self,
         session: SessionData,
         ip_address: str,
         user_agent: str,
-        request_context: Optional[Dict[str, Any]] = None
+        request_context: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         """
         Validate a session-based request for security issues.
-        
+
         Args:
             session: Session data
             ip_address: Current request IP
             user_agent: Current request user agent
             request_context: Additional request context
-            
+
         Returns:
             Dictionary with validation results
         """
@@ -1102,9 +1059,9 @@ class SecurityEnhancer:
             session=session,
             current_ip=ip_address,
             current_user_agent=user_agent,
-            request_context=request_context
+            request_context=request_context,
         )
-        
+
         # Log session validation events if there are security concerns
         if validation_result["security_flags"] or validation_result["risk_score"] > 0.5:
             await self.audit_logger.log_session_event(
@@ -1114,12 +1071,12 @@ class SecurityEnhancer:
                 details={
                     "validation_result": validation_result,
                     "security_flags": validation_result["security_flags"],
-                    "risk_score": validation_result["risk_score"]
-                }
+                    "risk_score": validation_result["risk_score"],
+                },
             )
-        
+
         return validation_result
-    
+
     async def log_authentication_attempt(
         self,
         email: str,
@@ -1131,11 +1088,11 @@ class SecurityEnhancer:
         risk_score: float = 0.0,
         processing_time_ms: float = 0.0,
         session_data: Optional[SessionData] = None,
-        **kwargs
+        **kwargs,
     ) -> None:
         """
         Log an authentication attempt with security context.
-        
+
         Args:
             email: User email
             ip_address: Client IP address
@@ -1150,12 +1107,9 @@ class SecurityEnhancer:
         """
         # Record the attempt for rate limiting
         await self.rate_limiter.record_attempt(
-            ip_address=ip_address,
-            email=email,
-            success=success,
-            event_type="login"
+            ip_address=ip_address, email=email, success=success, event_type="login"
         )
-        
+
         # Log the authentication attempt
         await self.audit_logger.log_login_attempt(
             email=email,
@@ -1166,17 +1120,17 @@ class SecurityEnhancer:
             error_message=error_message,
             risk_score=risk_score,
             processing_time_ms=processing_time_ms,
-            **kwargs
+            **kwargs,
         )
-        
+
         # Log session creation if successful
         if success and session_data:
             await self.audit_logger.log_session_event(
                 event_type=AuthEventType.SESSION_CREATED,
                 session_data=session_data,
-                success=True
+                success=True,
             )
-    
+
     async def log_security_event(
         self,
         event_type: AuthEventType,
@@ -1187,7 +1141,7 @@ class SecurityEnhancer:
         risk_score: float = 0.0,
         security_flags: Optional[List[str]] = None,
         details: Optional[Dict[str, Any]] = None,
-        **kwargs
+        **kwargs,
     ) -> None:
         """Log a security-related event."""
         await self.audit_logger.log_security_event(
@@ -1199,9 +1153,9 @@ class SecurityEnhancer:
             risk_score=risk_score,
             security_flags=security_flags,
             details=details,
-            **kwargs
+            **kwargs,
         )
-    
+
     def get_security_stats(self) -> Dict[str, Any]:
         """Get comprehensive security statistics."""
         return {
@@ -1210,20 +1164,55 @@ class SecurityEnhancer:
             "session_validator": self.session_validator.get_stats(),
             "security_features_enabled": self.security_config.enable_rate_limiting,
         }
-    
+
     async def clear_user_lockout(self, email: str, ip_address: str) -> None:
         """Clear lockout for a user (admin function)."""
         await self.rate_limiter.clear_lockout(ip_address, email)
-        
+
         await self.audit_logger.log_security_event(
             event_type=AuthEventType.USER_UPDATED,
             ip_address=ip_address,
             email=email,
-            details={"action": "lockout_cleared", "admin_action": True}
+            details={"action": "lockout_cleared", "admin_action": True},
         )
-    
+
     def is_enabled(self) -> bool:
         """Check if security features are enabled."""
-        return self.security_config.enable_rate_limiting or \
-               self.security_config.enable_audit_logging or \
-               self.security_config.enable_session_validation
+        return (
+            self.security_config.enable_rate_limiting
+            or self.security_config.enable_audit_logging
+            or self.security_config.enable_session_validation
+        )
+
+    async def shutdown(self) -> None:
+        """Gracefully shutdown the security enhancer and its components."""
+        self.logger.info("Shutting down security enhancer")
+
+        try:
+            if hasattr(self.rate_limiter, "shutdown"):
+                await self.rate_limiter.shutdown()
+            else:
+                store = getattr(self.rate_limiter, "store", None)
+                client = getattr(store, "client", None)
+                close = getattr(client, "close", None)
+                if close:
+                    if asyncio.iscoroutinefunction(close):
+                        await close()
+                    else:
+                        close()
+        except Exception as e:  # pragma: no cover - defensive
+            self.logger.error(f"Error shutting down rate limiter: {e}")
+
+        try:
+            if hasattr(self.audit_logger, "shutdown"):
+                await self.audit_logger.shutdown()
+        except Exception as e:  # pragma: no cover - defensive
+            self.logger.error(f"Error shutting down audit logger: {e}")
+
+        try:
+            if hasattr(self.session_validator, "shutdown"):
+                await self.session_validator.shutdown()
+        except Exception as e:  # pragma: no cover - defensive
+            self.logger.error(f"Error shutting down session validator: {e}")
+
+        self.logger.info("Security enhancer shutdown complete")

--- a/src/ai_karen_engine/auth/service.py
+++ b/src/ai_karen_engine/auth/service.py
@@ -1725,13 +1725,11 @@ class AuthService:
 
             # Shutdown intelligence layer
             if self.intelligence_layer:
-                # Intelligence layer doesn't have shutdown method yet, but we can add it later
-                pass
+                await self.intelligence_layer.shutdown()
 
             # Shutdown security layer
             if self.security_layer:
-                # Security layer doesn't have shutdown method yet, but we can add it later
-                pass
+                await self.security_layer.shutdown()
 
             self.logger.info("AuthService shutdown completed")
 

--- a/tests/test_auth_shutdown.py
+++ b/tests/test_auth_shutdown.py
@@ -1,0 +1,37 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+from ai_karen_engine.auth.config import AuthConfig, FeatureToggles
+from ai_karen_engine.auth.intelligence import IntelligenceEngine
+from ai_karen_engine.auth.security import SecurityEnhancer
+from ai_karen_engine.auth.service import AuthService
+
+
+@pytest.mark.asyncio
+async def test_intelligence_engine_shutdown():
+    config = AuthConfig()
+    engine = IntelligenceEngine(config)
+    await engine.initialize()
+    await engine.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_security_enhancer_shutdown():
+    config = AuthConfig()
+    enhancer = SecurityEnhancer(config)
+    await enhancer.initialize()
+    await enhancer.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_auth_service_shutdown_calls_components():
+    config = AuthConfig(features=FeatureToggles(enable_intelligent_auth=True))
+    service = AuthService(config)
+    assert service.intelligence_layer is not None
+    assert service.security_layer is not None
+    service.intelligence_layer.shutdown = AsyncMock()
+    service.security_layer.shutdown = AsyncMock()
+    await service.shutdown()
+    service.intelligence_layer.shutdown.assert_awaited_once()
+    service.security_layer.shutdown.assert_awaited_once()


### PR DESCRIPTION
## Summary
- add shutdown handling to IntelligenceEngine and SecurityEnhancer
- invoke shutdown hooks from AuthService
- add unit tests for auth shutdown behavior

## Testing
- `pre-commit run --files src/ai_karen_engine/auth/intelligence.py src/ai_karen_engine/auth/security.py src/ai_karen_engine/auth/service.py tests/test_auth_shutdown.py` *(fails: ruff F811 on security.py, mypy missing type annotations and stubs)*
- `PYTHONPATH=src pytest tests/test_auth_shutdown.py` *(fails: RuntimeError KARI_JOB_SIGNING_KEY must be set)*


------
https://chatgpt.com/codex/tasks/task_e_6897e533c1988324a411502a1b4fc4fb