### PR TITLE
Add fallback handling to intelligence engine

### DIFF
--- a/src/ai_karen_engine/security/intelligence_engine.py
+++ b/src/ai_karen_engine/security/intelligence_engine.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
+from dataclasses import dataclass
 from typing import Optional
 
 from ai_karen_engine.security.adaptive_learning import AdaptiveLearningEngine
@@ -10,11 +12,23 @@ from ai_karen_engine.security.comprehensive_anomaly_engine import (
     ComprehensiveAnomalyEngine,
 )
 from ai_karen_engine.security.credential_analyzer import CredentialAnalyzer
-from ai_karen_engine.security.models import AuthContext, IntelligentAuthConfig
+from ai_karen_engine.security.models import (
+    AuthContext,
+    EmbeddingAnalysis,
+    IntelligentAuthConfig,
+)
 
 # mypy: ignore-errors
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass
+class RiskScoreResult:
+    """Risk score along with fallback state."""
+
+    risk_score: float
+    fallback_mode: bool = False
 
 
 class IntelligenceEngine:
@@ -40,24 +54,63 @@ class IntelligenceEngine:
         )
         self._initialized = True
 
-    async def calculate_risk_score(self, context: AuthContext) -> float:
+    async def calculate_risk_score(self, context: AuthContext) -> RiskScoreResult:
         """Calculate risk score for an authentication attempt."""
         await self.initialize()
-        nlp_features = await self.credential_analyzer.analyze_credentials(
-            context.email, context.password_hash
-        )
-        embedding_result = (
-            await self.behavioral_embedding.generate_behavioral_embedding(context)
-        )
-        embedding_analysis = (
-            await self.behavioral_embedding.analyze_embedding_for_anomalies(
+
+        fallback_mode = False
+
+        try:
+            nlp_features = await self.credential_analyzer.analyze_credentials(
+                context.email, context.password_hash
+            )
+        except Exception as e:  # pragma: no cover - logging only
+            logger.error(f"Credential analysis failed: {e}")
+            fallback_mode = True
+            nlp_features = self.credential_analyzer._create_fallback_nlp_features(
+                context.email, context.password_hash, 0.0
+            )
+
+        start_time = time.time()
+        try:
+            embedding_result = await self.behavioral_embedding.generate_behavioral_embedding(
+                context
+            )
+        except Exception as e:  # pragma: no cover - logging only
+            logger.error(f"Behavioral embedding generation failed: {e}")
+            fallback_mode = True
+            embedding_result = await self.behavioral_embedding._generate_fallback_embedding(
+                context, start_time
+            )
+
+        try:
+            embedding_analysis = await self.behavioral_embedding.analyze_embedding_for_anomalies(
                 context, embedding_result
             )
-        )
-        analysis = await self.anomaly_engine.analyze_authentication_attempt(
-            context, nlp_features, embedding_analysis
-        )
-        return analysis.overall_risk_score
+        except Exception as e:  # pragma: no cover - logging only
+            logger.error(f"Embedding anomaly analysis failed: {e}")
+            fallback_mode = True
+            embedding_analysis = EmbeddingAnalysis(
+                embedding_vector=getattr(embedding_result, "embedding_vector", []),
+                similarity_to_user_profile=0.0,
+                similarity_to_attack_patterns=0.0,
+                cluster_assignment=None,
+                outlier_score=0.5,
+                processing_time=getattr(embedding_result, "processing_time", 0.0),
+                model_version=getattr(embedding_result, "model_version", "fallback"),
+            )
+
+        try:
+            analysis = await self.anomaly_engine.analyze_authentication_attempt(
+                context, nlp_features, embedding_analysis
+            )
+            risk_score = analysis.overall_risk_score
+        except Exception as e:  # pragma: no cover - logging only
+            logger.error(f"Anomaly engine analysis failed: {e}")
+            fallback_mode = True
+            risk_score = self.config.fallback_config.fallback_risk_score
+
+        return RiskScoreResult(risk_score=risk_score, fallback_mode=fallback_mode)
 
 
-__all__ = ["IntelligenceEngine"]
+__all__ = ["IntelligenceEngine", "RiskScoreResult"]

--- a/tests/test_security_intelligence_engine.py
+++ b/tests/test_security_intelligence_engine.py
@@ -1,0 +1,79 @@
+import pytest
+from datetime import datetime
+from types import SimpleNamespace
+
+from ai_karen_engine.security.intelligence_engine import IntelligenceEngine
+from ai_karen_engine.security.models import AuthContext, IntelligentAuthConfig
+
+
+class DummyCredentialAnalyzer:
+    async def initialize(self):
+        pass
+
+    async def analyze_credentials(self, email: str, password_hash: str):
+        raise RuntimeError("fail")
+
+    def _create_fallback_nlp_features(self, email: str, password_hash: str, processing_time: float):
+        return SimpleNamespace()
+
+
+class DummyBehavioralEmbedding:
+    async def initialize(self):
+        pass
+
+    async def generate_behavioral_embedding(self, context: AuthContext):
+        return SimpleNamespace(
+            embedding_vector=[0.0],
+            processing_time=0.0,
+            model_version="dummy",
+        )
+
+    async def analyze_embedding_for_anomalies(self, context: AuthContext, embedding_result: SimpleNamespace):
+        return SimpleNamespace(
+            embedding_vector=embedding_result.embedding_vector,
+            similarity_to_user_profile=0.0,
+            similarity_to_attack_patterns=0.0,
+            cluster_assignment=None,
+            outlier_score=0.0,
+            processing_time=embedding_result.processing_time,
+            model_version=embedding_result.model_version,
+        )
+
+    async def _generate_fallback_embedding(self, context: AuthContext, start_time: float):
+        return await self.generate_behavioral_embedding(context)
+
+
+class DummyAnomalyEngine:
+    async def initialize(self):
+        pass
+
+    async def analyze_authentication_attempt(self, context: AuthContext, nlp_features, embedding_analysis):
+        raise RuntimeError("fail")
+
+
+class DummyAdaptiveLearning:
+    async def initialize(self):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_fallback_flag_triggered():
+    engine = IntelligenceEngine(IntelligentAuthConfig())
+    engine.credential_analyzer = DummyCredentialAnalyzer()
+    engine.behavioral_embedding = DummyBehavioralEmbedding()
+    engine.anomaly_engine = DummyAnomalyEngine()
+    engine.adaptive_learning = DummyAdaptiveLearning()
+
+    context = AuthContext(
+        email="user@example.com",
+        password_hash="hash",
+        client_ip="127.0.0.1",
+        user_agent="agent",
+        timestamp=datetime.utcnow(),
+        request_id="req",
+    )
+
+    result = await engine.calculate_risk_score(context)
+
+    assert result.fallback_mode is True
+    assert result.risk_score == engine.config.fallback_config.fallback_risk_score


### PR DESCRIPTION
## Summary
- ensure security intelligence engine gracefully falls back when credential analysis, embeddings, or anomaly detection fail
- expose `RiskScoreResult` with `fallback_mode` flag for downstream logic
- add unit test covering fallback behavior

## Testing
- `KARI_DUCKDB_PASSWORD=dummy KARI_JOB_SIGNING_KEY=secret PYTHONPATH=src pytest tests/test_security_intelligence_engine.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6898c70d5ad88324b8280056c2866e4c