### PR TITLE
Add package initializers for CopilotKit and middleware modules

### DIFF
--- a/src/ai_karen_engine/copilotkit/__init__.py
+++ b/src/ai_karen_engine/copilotkit/__init__.py
@@ -1,0 +1,8 @@
+"""Integration utilities for CopilotKit."""
+
+from ai_karen_engine.copilotkit.error_handler import (
+    CopilotKitErrorType,
+    CopilotKitFallbackHandler,
+)
+
+__all__ = ["CopilotKitErrorType", "CopilotKitFallbackHandler"]

--- a/src/ai_karen_engine/middleware/__init__.py
+++ b/src/ai_karen_engine/middleware/__init__.py
@@ -1,0 +1,11 @@
+"""FastAPI middleware components for Kari AI."""
+
+from ai_karen_engine.middleware.auth import auth_middleware
+from ai_karen_engine.middleware.error_counter import error_counter_middleware
+from ai_karen_engine.middleware.rate_limit import rate_limit_middleware
+
+__all__ = [
+    "auth_middleware",
+    "error_counter_middleware",
+    "rate_limit_middleware",
+]


### PR DESCRIPTION
## Summary
- expose CopilotKit error handling classes via package initializer
- bundle available FastAPI middleware through a new package initializer

## Testing
- `pytest tests -q` *(fails: RuntimeError: KARI_DUCKDB_PASSWORD must be set in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_6898ebfc180c83248871915399abb9d5