### PR TITLE
Add security service tests

### DIFF
--- a/tests/security/test_behavioral_embedding_service.py
+++ b/tests/security/test_behavioral_embedding_service.py
@@ -1,0 +1,62 @@
+from datetime import datetime
+from types import SimpleNamespace
+
+import pytest
+
+from ai_karen_engine.security.behavioral_embedding import (
+    BehavioralEmbeddingConfig,
+    BehavioralEmbeddingService,
+)
+from ai_karen_engine.security.models import AuthContext
+
+
+class FailingDistilBertService:
+    fallback_mode = False
+    config = SimpleNamespace(model_name="test")
+
+    async def get_embeddings(self, text: str, normalize: bool = True):
+        raise RuntimeError("fail")
+
+
+@pytest.mark.asyncio
+async def test_fallback_embedding_generation():
+    service = BehavioralEmbeddingService(
+        distilbert_service=FailingDistilBertService(),
+        config=BehavioralEmbeddingConfig(),
+    )
+    context = AuthContext(
+        email="user@example.com",
+        password_hash="hash",
+        client_ip="127.0.0.1",
+        user_agent="agent",
+        timestamp=datetime.utcnow(),
+        request_id="req",
+    )
+    result = await service.generate_behavioral_embedding(context)
+    assert result.used_fallback is True
+    assert len(result.embedding_vector) > 0
+
+
+@pytest.mark.asyncio
+async def test_minimal_fallback_when_hash_generation_fails():
+    service = BehavioralEmbeddingService(
+        distilbert_service=FailingDistilBertService(),
+        config=BehavioralEmbeddingConfig(),
+    )
+
+    async def fail_hash(text: str):  # type: ignore[override]
+        raise RuntimeError("hash fail")
+
+    service._generate_hash_embedding = fail_hash  # type: ignore
+    context = AuthContext(
+        email="user@example.com",
+        password_hash="hash",
+        client_ip="127.0.0.1",
+        user_agent="agent",
+        timestamp=datetime.utcnow(),
+        request_id="req",
+    )
+    result = await service.generate_behavioral_embedding(context)
+    assert result.used_fallback is True
+    assert result.model_version == "minimal_fallback"
+    assert len(result.embedding_vector) == 768

--- a/tests/security/test_credential_analyzer.py
+++ b/tests/security/test_credential_analyzer.py
@@ -1,0 +1,33 @@
+from types import SimpleNamespace
+
+import pytest
+
+from ai_karen_engine.security.credential_analyzer import CredentialAnalyzer
+from ai_karen_engine.security.models import IntelligentAuthConfig
+
+
+class DummySpacyService:
+    def __init__(self, fail: bool = False):
+        self.fail = fail
+
+    async def parse_message(self, text: str):
+        if self.fail:
+            raise RuntimeError("boom")
+        return SimpleNamespace(used_fallback=False)
+
+
+@pytest.mark.asyncio
+async def test_initialize_handles_spacy_failure():
+    analyzer = CredentialAnalyzer(
+        IntelligentAuthConfig(), spacy_service=DummySpacyService(fail=True)
+    )
+    success = await analyzer.initialize()
+    assert success is False
+
+
+@pytest.mark.asyncio
+async def test_fallback_language_detection():
+    analyzer = CredentialAnalyzer(IntelligentAuthConfig(), spacy_service=DummySpacyService())
+    assert analyzer._fallback_language_detection("hello") == "en"
+    assert analyzer._fallback_language_detection("你好") == "multi"
+    assert analyzer._fallback_language_detection("") == "unknown"

--- a/tests/security/test_intelligence_engine.py
+++ b/tests/security/test_intelligence_engine.py
@@ -1,0 +1,129 @@
+from datetime import datetime
+from types import SimpleNamespace
+
+import pytest
+
+from ai_karen_engine.security.intelligence_engine import IntelligenceEngine
+from ai_karen_engine.security.models import (
+    AuthContext,
+    EmbeddingAnalysis,
+    IntelligentAuthConfig,
+)
+
+
+class DummyCredentialAnalyzer:
+    async def initialize(self):
+        pass
+
+    async def analyze_credentials(self, email: str, password_hash: str):
+        return SimpleNamespace()
+
+    def _create_fallback_nlp_features(
+        self, email: str, password_hash: str, processing_time: float
+    ):
+        return SimpleNamespace()
+
+
+class FailingCredentialAnalyzer(DummyCredentialAnalyzer):
+    async def analyze_credentials(self, email: str, password_hash: str):
+        raise RuntimeError("boom")
+
+
+class DummyBehavioralEmbedding:
+    async def initialize(self):
+        pass
+
+    async def generate_behavioral_embedding(self, context: AuthContext):
+        return SimpleNamespace(
+            embedding_vector=[0.0],
+            processing_time=0.0,
+            model_version="dummy",
+        )
+
+    async def analyze_embedding_for_anomalies(
+        self, context: AuthContext, embedding_result: SimpleNamespace
+    ):
+        return EmbeddingAnalysis(
+            embedding_vector=embedding_result.embedding_vector,
+            similarity_to_user_profile=0.0,
+            similarity_to_attack_patterns=0.0,
+            cluster_assignment=None,
+            outlier_score=0.0,
+            processing_time=embedding_result.processing_time,
+            model_version=embedding_result.model_version,
+        )
+
+    async def _generate_fallback_embedding(
+        self, context: AuthContext, start_time: float
+    ):
+        return await self.generate_behavioral_embedding(context)
+
+
+class DummyAnomalyEngine:
+    async def initialize(self):
+        pass
+
+    async def analyze_authentication_attempt(
+        self, context: AuthContext, nlp_features, embedding_analysis
+    ):
+        return SimpleNamespace(overall_risk_score=0.42)
+
+
+class FailingAnomalyEngine(DummyAnomalyEngine):
+    async def analyze_authentication_attempt(
+        self, context: AuthContext, nlp_features, embedding_analysis
+    ):
+        raise RuntimeError("fail")
+
+
+class DummyAdaptiveLearning:
+    async def initialize(self):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_risk_score_normal_flow():
+    engine = IntelligenceEngine.__new__(IntelligenceEngine)
+    engine.config = IntelligentAuthConfig()
+    engine.credential_analyzer = DummyCredentialAnalyzer()
+    engine.behavioral_embedding = DummyBehavioralEmbedding()
+    engine.anomaly_engine = DummyAnomalyEngine()
+    engine.adaptive_learning = DummyAdaptiveLearning()
+    engine._initialized = False
+
+    context = AuthContext(
+        email="user@example.com",
+        password_hash="hash",
+        client_ip="127.0.0.1",
+        user_agent="agent",
+        timestamp=datetime.utcnow(),
+        request_id="req",
+    )
+
+    result = await engine.calculate_risk_score(context)
+    assert result.fallback_mode is False
+    assert result.risk_score == pytest.approx(0.42)
+
+
+@pytest.mark.asyncio
+async def test_risk_score_fallback_on_failure():
+    engine = IntelligenceEngine.__new__(IntelligenceEngine)
+    engine.config = IntelligentAuthConfig()
+    engine.credential_analyzer = FailingCredentialAnalyzer()
+    engine.behavioral_embedding = DummyBehavioralEmbedding()
+    engine.anomaly_engine = FailingAnomalyEngine()
+    engine.adaptive_learning = DummyAdaptiveLearning()
+    engine._initialized = False
+
+    context = AuthContext(
+        email="user@example.com",
+        password_hash="hash",
+        client_ip="127.0.0.1",
+        user_agent="agent",
+        timestamp=datetime.utcnow(),
+        request_id="req",
+    )
+
+    result = await engine.calculate_risk_score(context)
+    assert result.fallback_mode is True
+    assert result.risk_score == engine.config.fallback_config.fallback_risk_score

--- a/tests/security/test_models.py
+++ b/tests/security/test_models.py
@@ -1,0 +1,49 @@
+from datetime import datetime, timedelta
+
+from ai_karen_engine.security.models import (
+    AuthEvent,
+    AuthEventType,
+    SessionData,
+    UserData,
+)
+
+
+def test_user_data_serialization_roundtrip():
+    user = UserData(user_id="u1", email="user@example.com")
+    data = user.to_dict()
+    restored = UserData.from_dict(data)
+    assert restored.user_id == user.user_id
+    assert restored.email == user.email
+    assert restored.created_at is not None
+
+
+def test_session_data_serialization_and_expiry():
+    user = UserData(user_id="u1", email="user@example.com")
+    past = datetime.utcnow() - timedelta(seconds=2)
+    session = SessionData(
+        session_token="s",
+        access_token="a",
+        refresh_token="r",
+        user_data=user,
+        expires_in=1,
+        created_at=past,
+        last_accessed=past,
+    )
+    data = session.to_dict()
+    restored = SessionData.from_dict(data)
+    assert restored.session_token == session.session_token
+    assert restored.is_expired() is True
+
+
+def test_auth_event_serialization_roundtrip():
+    event = AuthEvent(
+        event_type=AuthEventType.LOGIN_ATTEMPT,
+        timestamp=datetime.utcnow(),
+        user_id="u1",
+        success=False,
+        error_message="boom",
+    )
+    data = event.to_dict()
+    restored = AuthEvent.from_dict(data)
+    assert restored.event_type == AuthEventType.LOGIN_ATTEMPT
+    assert restored.error_message == "boom"


### PR DESCRIPTION
## Summary
- add serialization round-trip tests for security models
- cover CredentialAnalyzer initialization errors and language fallback
- test BehavioralEmbeddingService fallback embeddings and minimal fallback path
- verify IntelligenceEngine risk score fallback and normal flows

## Testing
- `KARI_DUCKDB_PASSWORD=test KARI_JOB_SIGNING_KEY=test PYTHONPATH=src pytest tests/security -q`


------
https://chatgpt.com/codex/tasks/task_e_6898ebadf78883248417287752429cf2