### PR TITLE
Align configurable interface with IntelligentAuthConfig

### DIFF
--- a/src/ai_karen_engine/security/intelligent_auth_base.py
+++ b/src/ai_karen_engine/security/intelligent_auth_base.py
@@ -109,7 +109,7 @@ class HealthCheckable(Protocol):
 class Configurable(Protocol):
     """Protocol for components that support configuration updates."""
 
-    async def update_config(self, config: Dict[str, Any]) -> bool:
+    async def update_config(self, config: IntelligentAuthConfig) -> bool:
         """Update component configuration."""
         ...
 


### PR DESCRIPTION
## Summary
- use IntelligentAuthConfig in the `Configurable` protocol's `update_config` method to match `BaseIntelligentAuthService`

## Testing
- `KARI_DUCKDB_PASSWORD=dummy KARI_JOB_SIGNING_KEY=dummy PYTHONPATH=src pytest` *(fails: Invalid args for response field! and other collection errors)*

------
https://chatgpt.com/codex/tasks/task_e_6898f177af7483249b1407af13156aa8