### PR TITLE
Add security model serialization and service health tests

### DIFF
--- a/tests/test_security_models.py
+++ b/tests/test_security_models.py
@@ -1,0 +1,76 @@
+from datetime import datetime, timedelta
+
+import pytest  # type: ignore[import-not-found]
+
+from ai_karen_engine.security.models import (  # type: ignore[import-not-found]
+    AuthContext,
+    GeoLocation,
+    IntelligentAuthConfig,
+)
+
+
+def create_auth_context() -> AuthContext:
+    return AuthContext(
+        email="user@example.com",
+        password_hash="hashed",
+        client_ip="127.0.0.1",
+        user_agent="pytest",
+        timestamp=datetime.utcnow(),
+        request_id="req-1",
+        geolocation=GeoLocation(
+            country="US",
+            region="NY",
+            city="New York",
+            latitude=40.7128,
+            longitude=-74.0060,
+            timezone="UTC",
+        ),
+        time_since_last_login=timedelta(hours=1),
+        threat_intel_score=0.1,
+        previous_failed_attempts=0,
+    )
+
+
+def test_auth_context_serialization_roundtrip() -> None:
+    context = create_auth_context()
+    data = context.to_dict()
+    restored = AuthContext.from_dict(data)
+    assert restored == context
+    assert restored.validate()
+
+
+def test_auth_context_invalid_timestamp() -> None:
+    context = create_auth_context()
+    data = context.to_dict()
+    data["timestamp"] = "invalid-timestamp"
+    with pytest.raises(ValueError):
+        AuthContext.from_dict(data)
+
+
+def test_auth_context_validation_failure() -> None:
+    context = create_auth_context()
+    context.threat_intel_score = 1.5
+    assert not context.validate()
+
+
+def test_intelligent_auth_config_serialization_and_validation() -> None:
+    config = IntelligentAuthConfig()
+    data = config.to_dict()
+    restored = IntelligentAuthConfig.from_dict(data)
+    assert restored == config
+    assert restored.validate()
+
+
+def test_intelligent_auth_config_validation_failure() -> None:
+    config = IntelligentAuthConfig()
+    config.max_processing_time = -1
+    assert not config.validate()
+
+
+def test_intelligent_auth_config_from_env_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("INTELLIGENT_AUTH_RISK_LOW", "0.9")
+    monkeypatch.setenv("INTELLIGENT_AUTH_RISK_HIGH", "0.1")
+    with pytest.raises(ValueError):
+        IntelligentAuthConfig.from_env()

--- a/tests/test_security_services_health.py
+++ b/tests/test_security_services_health.py
@@ -1,0 +1,52 @@
+from unittest.mock import AsyncMock
+
+import pytest  # type: ignore[import-not-found]
+
+from ai_karen_engine.security.anomaly_detector import (  # type: ignore[import-not-found]
+    AnomalyDetector,
+)
+from ai_karen_engine.security.intelligent_auth_base import (  # type: ignore[import-not-found]
+    ServiceStatus,
+)
+from ai_karen_engine.security.models import (  # type: ignore[import-not-found]
+    IntelligentAuthConfig,
+)
+from ai_karen_engine.security.threat_intelligence import (  # type: ignore[import-not-found]
+    ReputationLevel,
+    ThreatIntelligenceEngine,
+)
+
+
+@pytest.mark.asyncio  # type: ignore[misc]
+async def test_anomaly_detector_health_check_success() -> None:
+    detector = AnomalyDetector(IntelligentAuthConfig())
+    detector._perform_health_check = AsyncMock(return_value=True)
+    status = await detector.health_check()
+    assert status.status == ServiceStatus.HEALTHY
+
+
+@pytest.mark.asyncio  # type: ignore[misc]
+async def test_anomaly_detector_health_check_failure() -> None:
+    detector = AnomalyDetector(IntelligentAuthConfig())
+    detector._perform_health_check = AsyncMock(return_value=False)
+    status = await detector.health_check()
+    assert status.status == ServiceStatus.DEGRADED
+
+
+@pytest.mark.asyncio  # type: ignore[misc]
+async def test_anomaly_detector_health_check_exception() -> None:
+    detector = AnomalyDetector(IntelligentAuthConfig())
+    detector._perform_health_check = AsyncMock(side_effect=RuntimeError("boom"))
+    status = await detector.health_check()
+    assert status.status == ServiceStatus.UNHEALTHY
+    assert "boom" in status.error_message
+
+
+@pytest.mark.asyncio  # type: ignore[misc]
+async def test_threat_intelligence_engine_basic_health_check() -> None:
+    engine = ThreatIntelligenceEngine({})
+    stats = engine.get_threat_statistics()
+    assert stats["total_indicators"] > 0
+
+    result = await engine.analyze_ip_reputation("10.0.0.1")
+    assert result.reputation_level != ReputationLevel.CLEAN


### PR DESCRIPTION
## Summary
- add tests for AuthContext and IntelligentAuthConfig serialization, validation, and env var error handling
- test health_check behavior of AnomalyDetector and ThreatIntelligenceEngine

## Testing
- `pre-commit run --files tests/test_security_models.py tests/test_security_services_health.py`
- `KARI_DUCKDB_PASSWORD=test KARI_JOB_SIGNING_KEY=test KARI_MODEL_SIGNING_KEY=test DISPLAY=:0 PYTHONPATH=src pytest tests/test_security_models.py tests/test_security_services_health.py`

------
https://chatgpt.com/codex/tasks/task_e_6898f1b9058c83249b6affaf5a49a0e1