### PR TITLE
Add optional Argon2 password hashing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -50,5 +50,6 @@ pyotp
 tenacity
 pytest-asyncio
 bcrypt
+argon2-cffi
 copilotkit
 sse-starlette

--- a/src/ai_karen_engine/core/chat_memory_config.py
+++ b/src/ai_karen_engine/core/chat_memory_config.py
@@ -94,7 +94,10 @@ class ProductionAuthSettings(BaseSettings):
     refresh_token_expire_days: int = Field(7, description="Refresh token TTL (days)")
 
     # Password hashing
-    password_hash_rounds: int = Field(12, description="Bcrypt rounds")
+    password_hash_rounds: int = Field(12, description="Bcrypt rounds or Argon2 time cost")
+    password_hash_algorithm: str = Field(
+        "bcrypt", description="Password hashing algorithm (bcrypt or argon2)", json_schema_extra={"env": "AUTH_PASSWORD_HASH_ALGORITHM"}
+    )
 
     # Session management
     session_expire_hours: int = Field(24, description="Session expiry (hours)")

--- a/tests/security/test_password_hashing.py
+++ b/tests/security/test_password_hashing.py
@@ -1,0 +1,31 @@
+import importlib
+import pathlib
+import types
+import sys
+
+import pytest
+
+# Create stub packages to import core without executing package __init__
+repo_root = pathlib.Path(__file__).resolve().parents[2]
+engine_path = repo_root / 'src' / 'ai_karen_engine'
+auth_path = engine_path / 'auth'
+
+engine_pkg = types.ModuleType('ai_karen_engine')
+engine_pkg.__path__ = [str(engine_path)]
+auth_pkg = types.ModuleType('ai_karen_engine.auth')
+auth_pkg.__path__ = [str(auth_path)]
+
+sys.modules.setdefault('ai_karen_engine', engine_pkg)
+sys.modules.setdefault('ai_karen_engine.auth', auth_pkg)
+
+core = importlib.import_module('ai_karen_engine.auth.core')
+PasswordHasher = core.PasswordHasher
+
+
+@pytest.mark.parametrize("algorithm", ["bcrypt", "argon2"])
+def test_password_hashing_algorithms(algorithm):
+    hasher = PasswordHasher(rounds=6, algorithm=algorithm)
+    password = "StrongPassw0rd!"
+    hashed = hasher.hash_password(password)
+    assert hasher.verify_password(password, hashed)
+    assert not hasher.verify_password("wrong", hashed)


### PR DESCRIPTION
## Summary
- support bcrypt or argon2 password hashing with new configurable algorithm
- expose password_hash_algorithm in auth configs and core settings
- test both algorithms and add argon2-cffi dependency

## Testing
- `pip install argon2-cffi`
- `KARI_DUCKDB_PASSWORD=test KARI_JOB_SIGNING_KEY=test PYTHONPATH=src pytest tests/security/test_password_hashing.py --noconftest`

------
https://chatgpt.com/codex/tasks/task_e_6898f90b179c83249dfbfee9872c1cfe