### PR TITLE
Add migration manager and rollback documentation

### DIFF
--- a/docs/PRODUCTION_AUTH_SETUP.md
+++ b/docs/PRODUCTION_AUTH_SETUP.md
@@ -118,6 +118,39 @@ For dry-run (preview changes):
 python scripts/run_auth_migration.py --dry-run
 ```
 
+### Migration Rollback
+
+If a migration needs to be reverted, use the migration manager and specify the
+target version:
+
+```bash
+python scripts/migrate.py rollback --version <migration_version>
+```
+
+Current migration versions include:
+
+1. `001_create_auth_tables`
+2. `001_create_tables`
+3. `002_create_extension_tables`
+4. `002_create_memory_entries_table`
+5. `003_web_ui_integration`
+6. `004_create_memory_entries_table`
+7. `005_create_conversations_table`
+8. `006_create_plugin_executions_table`
+9. `007_create_audit_log_table`
+10. `008_create_web_ui_memory_entries_table`
+11. `009_create_memory_items_table`
+12. `009_create_production_auth_tables`
+13. `010_add_production_auth_columns`
+14. `011_add_messages_table`
+15. `012_create_usage_and_rate_limit_tables`
+16. `013_production_auth_schema_alignment`
+17. `014_fix_user_id_type_mismatch`
+
+The rollback command expects a corresponding `<migration_version>_rollback.sql`
+file in the migrations directory. If no such file exists, the migration cannot
+be automatically reverted.
+
 ### Step 2: Initialize Production Authentication
 
 Run the production initialization script:
@@ -235,20 +268,20 @@ async def login(
             ip_address=request.client.host,
             user_agent=request.headers.get("user-agent", "")
         )
-        
+
         session = await auth_service.create_session(
             user_data=user,
             ip_address=request.client.host,
             user_agent=request.headers.get("user-agent", "")
         )
-        
+
         return {
             "access_token": session.access_token,
             "refresh_token": session.refresh_token,
             "session_token": session.session_token,
             "user": user.to_dict()
         }
-        
+
     except InvalidCredentialsError:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
@@ -300,21 +333,21 @@ Monitor system health with these queries:
 
 ```sql
 -- Failed login attempts in last hour
-SELECT COUNT(*) FROM auth_events 
-WHERE event_type = 'LOGIN_FAILED' 
+SELECT COUNT(*) FROM auth_events
+WHERE event_type = 'LOGIN_FAILED'
 AND timestamp > NOW() - INTERVAL '1 hour';
 
 -- Active sessions by user
 SELECT u.email, COUNT(s.session_token) as active_sessions
 FROM auth_users u
-LEFT JOIN auth_sessions s ON u.user_id = s.user_id 
+LEFT JOIN auth_sessions s ON u.user_id = s.user_id
 WHERE s.is_active = true
 GROUP BY u.email
 ORDER BY active_sessions DESC;
 
 -- Locked accounts
 SELECT email, locked_until, failed_login_attempts
-FROM auth_users 
+FROM auth_users
 WHERE locked_until > NOW();
 ```
 
@@ -363,7 +396,7 @@ WHERE locked_until > NOW();
    ```bash
    # Check database is running
    sudo systemctl status postgresql
-   
+
    # Test connection
    psql -h localhost -U karen_user -d ai_karen
    ```
@@ -372,7 +405,7 @@ WHERE locked_until > NOW();
    ```bash
    # Check Redis is running
    sudo systemctl status redis-server
-   
+
    # Test connection
    redis-cli ping
    ```

--- a/scripts/migrate.py
+++ b/scripts/migrate.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+# mypy: ignore-errors
+"""CLI for running SQL migrations."""
+
+import argparse
+from pathlib import Path
+
+from ai_karen_engine.core.chat_memory_config import settings
+from ai_karen_engine.database.migration_runner import MigrationRunner
+
+DEFAULT_MIGRATIONS_DIR = (
+    Path(__file__).parent.parent / "data" / "migrations" / "postgres"
+)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run database migrations")
+    parser.add_argument(
+        "command", choices=["migrate", "rollback", "status"], help="Action to perform"
+    )
+    parser.add_argument(
+        "--database-url", default=settings.database_url, help="Database URL"
+    )
+    parser.add_argument(
+        "--migrations-dir",
+        default=str(DEFAULT_MIGRATIONS_DIR),
+        help="Directory containing migration SQL files",
+    )
+    parser.add_argument("--version", help="Target version for rollback")
+    args = parser.parse_args()
+
+    runner = MigrationRunner(args.database_url, Path(args.migrations_dir))
+
+    if args.command == "migrate":
+        runner.run_migrations()
+    elif args.command == "rollback":
+        if not args.version:
+            parser.error("rollback requires --version")
+        runner.rollback(args.version)
+    elif args.command == "status":
+        status = runner.get_status()
+        print("Applied migrations:", ", ".join(status["applied"]))
+        print("Pending migrations:", ", ".join(status["pending"]))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/ai_karen_engine/database/migration_runner.py
+++ b/src/ai_karen_engine/database/migration_runner.py
@@ -1,0 +1,79 @@
+"""Lightweight SQL migration runner."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List
+
+from sqlalchemy import create_engine, text
+
+# mypy: ignore-errors
+
+
+
+
+@dataclass
+class MigrationRunner:
+    """Apply plain SQL migrations in order."""
+
+    database_url: str
+    migrations_dir: Path
+
+    def _ensure_table(self, conn) -> None:
+        conn.execute(
+            text(
+                """
+                CREATE TABLE IF NOT EXISTS schema_migrations (
+                    version TEXT PRIMARY KEY,
+                    applied_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                )
+                """
+            )
+        )
+
+    def _applied(self, conn) -> List[str]:
+        self._ensure_table(conn)
+        result = conn.execute(
+            text("SELECT version FROM schema_migrations ORDER BY version")
+        )
+        return [row[0] for row in result.fetchall()]
+
+    def run_migrations(self) -> None:
+        engine = create_engine(self.database_url)
+        with engine.begin() as conn:
+            applied = set(self._applied(conn))
+            for path in sorted(self.migrations_dir.glob("*.sql")):
+                version = path.stem
+                if version in applied:
+                    continue
+                sql = path.read_text()
+                conn.execute(text(sql))
+                conn.execute(
+                    text("INSERT INTO schema_migrations (version) VALUES (:v)"),
+                    {"v": version},
+                )
+
+    def rollback(self, version: str) -> None:
+        engine = create_engine(self.database_url)
+        rollback_file = self.migrations_dir / f"{version}_rollback.sql"
+        if not rollback_file.exists():
+            raise FileNotFoundError(f"No rollback file for {version}")
+        with engine.begin() as conn:
+            sql = rollback_file.read_text()
+            conn.execute(text(sql))
+            conn.execute(
+                text("DELETE FROM schema_migrations WHERE version = :v"),
+                {"v": version},
+            )
+
+    def get_status(self) -> Dict[str, List[str]]:
+        engine = create_engine(self.database_url)
+        with engine.begin() as conn:
+            applied = self._applied(conn)
+        all_versions = [p.stem for p in sorted(self.migrations_dir.glob("*.sql"))]
+        pending = [v for v in all_versions if v not in applied]
+        return {"applied": applied, "pending": pending}
+
+
+__all__ = ["MigrationRunner"]

--- a/tests/test_blank_db_migrations.py
+++ b/tests/test_blank_db_migrations.py
@@ -1,0 +1,44 @@
+"""Tests for the simple migration runner on a blank database."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from sqlalchemy import create_engine, text
+
+from ai_karen_engine.database.migration_runner import MigrationRunner
+
+# mypy: ignore-errors
+
+
+
+
+
+def test_migrations_run_cleanly(tmp_path: Path) -> None:
+    """Ensure migrations apply sequentially on a fresh database."""
+    db_url = f"sqlite:///{tmp_path/'test.db'}"
+    migrations_dir = tmp_path / "migrations"
+    migrations_dir.mkdir()
+
+    # Create two simple migrations
+    (migrations_dir / "001_create_table.sql").write_text(
+        "CREATE TABLE example(id INTEGER PRIMARY KEY, name TEXT);"
+    )
+    (migrations_dir / "002_insert_row.sql").write_text(
+        "INSERT INTO example(name) VALUES ('karen');"
+    )
+
+    runner = MigrationRunner(db_url, migrations_dir)
+    runner.run_migrations()
+
+    engine = create_engine(db_url)
+    with engine.connect() as conn:
+        count = conn.execute(text("SELECT COUNT(*) FROM example")).scalar()
+        assert count == 1
+        versions = [
+            row[0]
+            for row in conn.execute(
+                text("SELECT version FROM schema_migrations ORDER BY version")
+            )
+        ]
+        assert versions == ["001_create_table", "002_insert_row"]


### PR DESCRIPTION
## Summary
- introduce `MigrationRunner` utility and CLI to run SQL migrations sequentially
- document rollback steps for existing migrations
- add tests confirming migrations run on a fresh database

## Testing
- `pre-commit run --files scripts/migrate.py src/ai_karen_engine/database/migration_runner.py docs/PRODUCTION_AUTH_SETUP.md tests/test_blank_db_migrations.py`
- `KARI_DUCKDB_PASSWORD=test KARI_JOB_SIGNING_KEY=key PYTHONPATH=src pytest tests/test_blank_db_migrations.py --noconftest`


------
https://chatgpt.com/codex/tasks/task_e_6899057a1980832480917757ddc5d2a6