### PR TITLE
Remove redundant login failure event type

### DIFF
--- a/docs/auth_service.md
+++ b/docs/auth_service.md
@@ -70,7 +70,7 @@ deployments that require audit trails and incident investigation.
 
 Authentication metrics are emitted through a `metrics_hook` and surfaced alongside the platform's
 standard observability endpoints. When the API server is running, counters such as
-`auth_login_success_total` and `auth_login_failure_total` appear under `/metrics` and are available for
+`auth_login_success_total` and `auth_login_failed_total` appear under `/metrics` and are available for
 Prometheus scraping. The retention window and aggregation interval can be tuned with
 `AUTH_METRICS_RETENTION_HOURS` and `AUTH_METRICS_AGGREGATION_INTERVAL`.
 

--- a/src/ai_karen_engine/auth/monitoring.py
+++ b/src/ai_karen_engine/auth/monitoring.py
@@ -12,13 +12,13 @@ import time
 from collections import defaultdict, deque
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
-from typing import Any, Callable, Dict, List, Optional, Set, Tuple
+from typing import Any, Callable, Dict, List, Optional
 from uuid import uuid4
 
 from ai_karen_engine.integrations.llm_utils import PROM_REGISTRY
 
 from .config import AuthConfig
-from .models import AuthEvent, AuthEventType, SessionData, UserData
+from .models import AuthEvent, AuthEventType
 
 try:  # pragma: no cover - optional dependency
     from prometheus_client import CollectorRegistry, Counter, Histogram
@@ -104,8 +104,7 @@ def metrics_hook(event: str, data: Dict[str, object]) -> None:
 
     # Normalize event names to a consistent set
     normalized = {
-        "login_failed": "login_failure",
-        "login_failure": "login_failure",
+        "login_failed": "login_failed",
         "login_success": "login_success",
         "login_blocked": "login_blocked",
         "rate_limit_exceeded": "rate_limit_exceeded",
@@ -116,7 +115,7 @@ def metrics_hook(event: str, data: Dict[str, object]) -> None:
             AUTH_SUCCESS.inc()
         if AUTH_PROCESSING_TIME is not None:
             AUTH_PROCESSING_TIME.observe(duration)
-    elif normalized in {"login_failure", "login_blocked", "rate_limit_exceeded"}:
+    elif normalized in {"login_failed", "login_blocked", "rate_limit_exceeded"}:
         if AUTH_FAILURE is not None:
             AUTH_FAILURE.inc()
         if AUTH_PROCESSING_TIME is not None and duration:

--- a/src/ai_karen_engine/security/models.py
+++ b/src/ai_karen_engine/security/models.py
@@ -21,7 +21,6 @@ class AuthEventType(Enum):
     LOGIN_ATTEMPT = "login_attempt"
     LOGIN_SUCCESS = "login_success"
     LOGIN_FAILED = "login_failed"
-    LOGIN_FAILURE = "login_failure"
     LOGIN_BLOCKED = "login_blocked"
     LOGOUT = "logout"
     SESSION_CREATED = "session_created"

--- a/ui_launchers/web_ui/src/types/auth-enhanced.ts
+++ b/ui_launchers/web_ui/src/types/auth-enhanced.ts
@@ -1,6 +1,6 @@
 /**
  * Enhanced Authentication Types and Interfaces
- * 
+ *
  * This module exports all enhanced authentication types, interfaces, and utilities
  * for the comprehensive login feedback system.
  */
@@ -92,10 +92,10 @@ export const DEFAULT_AUTH_SYSTEM_CONFIG: AuthSystemConfig = {
 /**
  * Authentication event types for logging and analytics
  */
-export type AuthEventType = 
+export type AuthEventType =
   | 'login_attempt'
   | 'login_success'
-  | 'login_failure'
+  | 'login_failed'
   | 'validation_error'
   | 'network_error'
   | 'security_block'
@@ -159,21 +159,21 @@ export interface EnhancedAuthService {
   login(credentials: LoginCredentials): Promise<AuthServiceResponse<LoginResponse>>;
   logout(): Promise<void>;
   refreshToken(): Promise<AuthServiceResponse<LoginResponse>>;
-  
+
   // Validation methods
   validateCredentials(credentials: LoginCredentials): Promise<ValidationErrors>;
   validateEmail(email: string): Promise<string | null>;
   validatePassword(password: string): Promise<string | null>;
-  
+
   // Error handling methods
   parseError(error: any): AuthenticationError;
   classifyError(error: AuthenticationError): ErrorClassification;
   shouldRetry(error: AuthenticationError, attemptCount: number): boolean;
-  
+
   // Security methods
   checkSecurityFlags(credentials: LoginCredentials): Promise<SecurityFlags>;
   handleRateLimit(error: AuthenticationError): Promise<number>;
-  
+
   // Logging and monitoring
   logEvent(event: AuthEvent): void;
   getMetrics(): AuthMetrics;
@@ -190,7 +190,7 @@ export interface UseAuthenticationHook {
   feedbackMessage: FeedbackMessage | null;
   validationErrors: ValidationErrors;
   isSubmitting: boolean;
-  
+
   // Actions
   login: (credentials: LoginCredentials) => Promise<void>;
   validateField: (field: FormFieldType, value: string) => Promise<string | null>;
@@ -198,7 +198,7 @@ export interface UseAuthenticationHook {
   clearFeedback: () => void;
   setFeedback: (message: FeedbackMessage) => void;
   resetForm: () => void;
-  
+
   // Utilities
   canSubmit: boolean;
   hasErrors: boolean;
@@ -237,15 +237,15 @@ export const AuthTypeGuards = {
   isUser: (value: any): value is User => {
     return value && typeof value === 'object' && 'user_id' in value && 'email' in value;
   },
-  
+
   isAuthenticationError: (value: any): value is AuthenticationError => {
     return value && typeof value === 'object' && 'type' in value && 'message' in value;
   },
-  
+
   isFeedbackMessage: (value: any): value is FeedbackMessage => {
     return value && typeof value === 'object' && 'type' in value && 'title' in value && 'message' in value;
   },
-  
+
   isValidationErrors: (value: any): value is ValidationErrors => {
     return value && typeof value === 'object';
   }
@@ -259,23 +259,23 @@ export const AUTH_CONSTANTS = {
   DEFAULT_REQUEST_TIMEOUT: 30000, // 30 seconds
   DEFAULT_RETRY_DELAY: 1000, // 1 second
   DEFAULT_FEEDBACK_DURATION: 5000, // 5 seconds
-  
+
   // Limits
   MAX_RETRY_ATTEMPTS: 3,
   MAX_VALIDATION_ERRORS: 10,
   MAX_SESSION_DURATION: 24 * 60 * 60 * 1000, // 24 hours
-  
+
   // Validation
   MIN_PASSWORD_LENGTH: 8,
   MAX_PASSWORD_LENGTH: 128,
   MAX_EMAIL_LENGTH: 254,
   TOTP_CODE_LENGTH: 6,
-  
+
   // UI
   DEBOUNCE_DELAY: 300,
   ANIMATION_DURATION: 300,
   LOADING_SPINNER_SIZE: 20,
-  
+
   // Storage keys
   STORAGE_KEYS: {
     REMEMBER_EMAIL: 'auth_remember_email',


### PR DESCRIPTION
## Summary
- remove unused `LOGIN_FAILURE` from `AuthEventType`
- normalize metrics and types to use `LOGIN_FAILED`
- document metrics with `auth_login_failed_total`

## Testing
- `KARI_DUCKDB_PASSWORD=foo KARI_JOB_SIGNING_KEY=bar PYTHONPATH=src pytest tests/test_auth_monitoring_metrics.py tests_auto/test_auth_database_schema.py -q`
- `SKIP=mypy pre-commit run --files src/ai_karen_engine/security/models.py src/ai_karen_engine/auth/monitoring.py docs/auth_service.md ui_launchers/web_ui/src/types/auth-enhanced.ts`

------
https://chatgpt.com/codex/tasks/task_e_689904babf188324b2eb951f160f9754