### PR TITLE
Add tests for anomaly and threat intelligence modules

### DIFF
--- a/tests/security/conftest.py
+++ b/tests/security/conftest.py
@@ -1,0 +1,15 @@
+import os
+import sys
+import types
+
+# Provide required environment defaults
+os.environ.setdefault("KARI_DUCKDB_PASSWORD", "test")
+os.environ.setdefault("KARI_JOB_SIGNING_KEY", "test")
+
+# Stub out GUI-related modules to avoid X server dependencies during tests
+pyautogui_stub = types.ModuleType("pyautogui")
+pyautogui_stub.FAILSAFE = False
+sys.modules.setdefault("pyautogui", pyautogui_stub)
+
+mouseinfo_stub = types.ModuleType("mouseinfo")
+sys.modules.setdefault("mouseinfo", mouseinfo_stub)

--- a/tests/security/test_anomaly_detector.py
+++ b/tests/security/test_anomaly_detector.py
@@ -1,0 +1,83 @@
+import pytest
+from datetime import datetime, timezone
+
+from ai_karen_engine.auth.config import AuthConfig
+from ai_karen_engine.auth.intelligence import (
+    AnomalyDetector,
+    BehavioralPattern,
+    LoginAttempt,
+)
+
+
+@pytest.mark.asyncio
+async def test_detect_anomalies_normal_behavior():
+    """AnomalyDetector should flag unusual attributes."""
+    detector = AnomalyDetector(AuthConfig())
+
+    attempt = LoginAttempt(
+        user_id="user1",
+        email="user@example.com",
+        ip_address="1.2.3.4",
+        user_agent="agent",
+        timestamp=datetime(2024, 1, 1, 3, tzinfo=timezone.utc),
+        device_fingerprint="device-999",
+        geolocation={"latitude": 34.0522, "longitude": -118.2437},
+    )
+    pattern = BehavioralPattern(
+        user_id="user1",
+        typical_login_hours=[9, 10, 11],
+        typical_locations=[{"latitude": 40.7128, "longitude": -74.0060}],
+        typical_devices=["device-123"],
+        login_frequency={"tuesday": 5},
+    )
+
+    result = await detector.detect_anomalies(attempt, pattern)
+    assert result.is_anomaly is True
+    assert {
+        "unusual_time",
+        "unusual_location",
+        "unusual_device",
+        "unusual_frequency",
+    }.issubset(set(result.anomaly_types))
+    assert result.anomaly_score > 0
+    assert result.confidence > 0
+
+
+@pytest.mark.asyncio
+async def test_detect_anomalies_without_pattern():
+    """No behavioral pattern should yield no anomalies."""
+    detector = AnomalyDetector(AuthConfig())
+    attempt = LoginAttempt(
+        user_id="user1",
+        email="user@example.com",
+        ip_address="1.2.3.4",
+        user_agent="agent",
+        timestamp=datetime(2024, 1, 1, tzinfo=timezone.utc),
+    )
+
+    result = await detector.detect_anomalies(attempt, None)
+    assert result.is_anomaly is False
+    assert result.anomaly_score == 0.0
+
+
+@pytest.mark.asyncio
+async def test_detect_anomalies_error_handling(monkeypatch):
+    """Failures in detection methods should be handled gracefully."""
+    detector = AnomalyDetector(AuthConfig())
+    attempt = LoginAttempt(
+        user_id="user1",
+        email="user@example.com",
+        ip_address="1.2.3.4",
+        user_agent="agent",
+        timestamp=datetime(2024, 1, 1, tzinfo=timezone.utc),
+    )
+
+    def boom(*_args, **_kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(detector, "_detect_time_anomaly", boom)
+
+    result = await detector.detect_anomalies(attempt, None)
+    assert result.is_anomaly is False
+    assert result.anomaly_score == 0.0
+    assert "error" in result.details

--- a/tests/security/test_threat_intelligence.py
+++ b/tests/security/test_threat_intelligence.py
@@ -1,0 +1,81 @@
+import asyncio
+
+import pytest
+
+from ai_karen_engine.security.threat_intelligence import ThreatFeedManager
+
+
+class MockResponse:
+    def __init__(self, status=200, payload=None):
+        self.status = status
+        self._payload = payload or {}
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    async def json(self):
+        await asyncio.sleep(0)  # simulate async
+        return self._payload
+
+
+class DummySession:
+    def __init__(self, response):
+        self._response = response
+        self.calls = 0
+
+    def get(self, *args, **kwargs):
+        self.calls += 1
+        return self._response
+
+    async def close(self):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_query_abuse_ipdb_success_and_cache(monkeypatch):
+    response = MockResponse(payload={"data": {"ipAddress": "1.2.3.4"}})
+    session = DummySession(response)
+    monkeypatch.setattr(
+        "aiohttp.ClientSession", lambda *a, **k: session
+    )
+
+    async with ThreatFeedManager({"abuseipdb_api_key": "key"}) as manager:
+        result1 = await manager.query_abuse_ipdb("1.2.3.4")
+        result2 = await manager.query_abuse_ipdb("1.2.3.4")  # cached
+
+    assert result1 == {"ipAddress": "1.2.3.4"}
+    assert result2 == {"ipAddress": "1.2.3.4"}
+    assert session.calls == 1  # second call used cache
+
+
+@pytest.mark.asyncio
+async def test_query_abuse_ipdb_error_handling(monkeypatch):
+    class ErrorSession(DummySession):
+        def get(self, *args, **kwargs):  # type: ignore[override]
+            raise RuntimeError("boom")
+
+    session = ErrorSession(MockResponse())
+    monkeypatch.setattr("aiohttp.ClientSession", lambda *a, **k: session)
+
+    async with ThreatFeedManager({"abuseipdb_api_key": "key"}) as manager:
+        result = await manager.query_abuse_ipdb("1.2.3.4")
+
+    assert result is None
+    assert session.calls == 0
+
+
+@pytest.mark.asyncio
+async def test_query_virustotal_rate_limit(monkeypatch):
+    response = MockResponse(payload={"data": {"id": "1.2.3.4"}})
+    session = DummySession(response)
+    monkeypatch.setattr("aiohttp.ClientSession", lambda *a, **k: session)
+
+    async with ThreatFeedManager({"virustotal_api_key": "key"}) as manager:
+        monkeypatch.setattr(manager, "_check_rate_limit", lambda *a, **k: False)
+        result = await manager.query_virustotal("1.2.3.4")
+
+    assert result is None
+    assert session.calls == 0


### PR DESCRIPTION
## Summary
- add async tests for anomaly detection covering normal flow, missing pattern, and error handling
- add threat intelligence feed tests with caching, error handling, and rate limit scenarios
- provide local conftest with environment stubs to run tests without external services

## Testing
- `PYTHONPATH=src pytest tests/security/test_anomaly_detector.py tests/security/test_threat_intelligence.py -q --confcutdir=tests/security`


------
https://chatgpt.com/codex/tasks/task_e_689905c780b08324bf2b0dc8fc1d7f74