### PR TITLE
Mask two-factor secret in user serialization

### DIFF
--- a/src/ai_karen_engine/auth/models.py
+++ b/src/ai_karen_engine/auth/models.py
@@ -98,7 +98,9 @@ class UserData:
             if self.locked_until
             else None,
             "two_factor_enabled": self.two_factor_enabled,
-            "two_factor_secret": self.two_factor_secret,
+            # Never expose the raw two-factor secret when serializing.
+            # Keep the key for backward compatibility but mask the value.
+            "two_factor_secret": None,
         }
 
     @classmethod

--- a/src/ai_karen_engine/security/models.py
+++ b/src/ai_karen_engine/security/models.py
@@ -97,7 +97,12 @@ class UserData:
             if self.locked_until
             else None,
             "two_factor_enabled": self.two_factor_enabled,
-            "two_factor_secret": self.two_factor_secret,
+            # Never expose the raw two-factor secret to prevent accidental
+            # leakage when serializing. For backward compatibility we keep
+            # the key but always mask the value.
+            # Consumers should retrieve the secret via secure channels
+            # rather than serialized representations.
+            "two_factor_secret": None,
         }
 
     @classmethod

--- a/test_optimized_auth_simple.py
+++ b/test_optimized_auth_simple.py
@@ -109,6 +109,7 @@ async def test_optimized_components():
             tenant_id="test_tenant",
             roles=["user", "tester"],
             preferences={"theme": "dark", "lang": "en"},
+            two_factor_secret="secret",
         )
         
         print(f"✅ UserData created: {user_data.email}")
@@ -118,6 +119,7 @@ async def test_optimized_components():
         
         # Test serialization
         user_dict = user_data.to_dict()
+        assert user_dict.get("two_factor_secret") is None
         user_from_dict = UserData.from_dict(user_dict)
         print(f"✅ Serialization test: {user_from_dict.email == user_data.email}")
         

--- a/tests/security/test_models.py
+++ b/tests/security/test_models.py
@@ -9,8 +9,16 @@ from ai_karen_engine.security.models import (
 
 
 def test_user_data_serialization_roundtrip():
-    user = UserData(user_id="u1", email="user@example.com")
+    user = UserData(
+        user_id="u1",
+        email="user@example.com",
+        two_factor_secret="super-secret",
+    )
     data = user.to_dict()
+    # two_factor_secret should be masked from serialized data
+    assert "two_factor_secret" in data
+    assert data["two_factor_secret"] is None
+
     restored = UserData.from_dict(data)
     assert restored.user_id == user.user_id
     assert restored.email == user.email
@@ -33,6 +41,23 @@ def test_session_data_serialization_and_expiry():
     restored = SessionData.from_dict(data)
     assert restored.session_token == session.session_token
     assert restored.is_expired() is True
+
+
+def test_session_data_masks_user_secret():
+    user = UserData(
+        user_id="u1",
+        email="user@example.com",
+        two_factor_secret="super-secret",
+    )
+    session = SessionData(
+        session_token="s",
+        access_token="a",
+        refresh_token="r",
+        user_data=user,
+        expires_in=60,
+    )
+    data = session.to_dict()
+    assert data["user_data"].get("two_factor_secret") is None
 
 
 def test_auth_event_serialization_roundtrip():


### PR DESCRIPTION
## Summary
- prevent leaking two-factor secrets by masking them when `UserData` is serialized
- extend tests to assert serialized data never contains the raw 2FA secret
- update example tests to accommodate masked secrets

## Testing
- `PYTHONPATH=src pytest tests/security/test_models.py tests/test_security_models.py --confcutdir=tests/security -q`
- `PYTHONPATH=src python test_optimized_auth_simple.py` *(fails: KeyError: 'DISPLAY')*

------
https://chatgpt.com/codex/tasks/task_e_68992bb650dc8324b27d3155fc447b66