### PR TITLE
feat(auth): support argon2 password hashing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,9 @@ requires-python = ">=3.10"
 authors = [{ name = "Kari AI Team" }]
 license = { file = "LICENSE" }
 
+[project.optional-dependencies]
+argon2 = ["argon2-cffi"]
+
 [tool.setuptools]
 package-dir = {"" = "src"}
 

--- a/src/ai_karen_engine/auth/config.py
+++ b/src/ai_karen_engine/auth/config.py
@@ -20,6 +20,11 @@ try:
 except ImportError:  # pragma: no cover - yaml is optional
     yaml = None
 
+try:
+    import argon2  # type: ignore
+except Exception:  # pragma: no cover - argon2 is optional
+    argon2 = None  # type: ignore
+
 
 def _env_bool(value: Optional[str], default: bool) -> bool:
     """Convert environment string to boolean with a default."""
@@ -861,7 +866,12 @@ class AuthConfig:
         if self.security.password_hash_algorithm == "bcrypt":
             if not (4 <= self.security.password_hash_rounds <= 20):
                 errors.append("Password hash rounds must be between 4 and 20")
-        elif self.security.password_hash_algorithm != "argon2":
+        elif self.security.password_hash_algorithm == "argon2":
+            if self.security.password_hash_rounds <= 0:
+                errors.append("Password hash rounds must be positive")
+            if argon2 is None:
+                errors.append("argon2-cffi must be installed for argon2 hashing")
+        else:
             errors.append("Unsupported password hash algorithm")
 
         # Intelligence validation

--- a/src/ai_karen_engine/auth/optimized_core.py
+++ b/src/ai_karen_engine/auth/optimized_core.py
@@ -58,6 +58,7 @@ class OptimizedPasswordHasher:
         self.rounds = rounds
         self.algorithm = algorithm
         self.logger = logging.getLogger(f"{__name__}.OptimizedPasswordHasher")
+        self.argon2_hasher = None
         if algorithm == "argon2":
             if Argon2Hasher is None:
                 raise ImportError(
@@ -71,7 +72,7 @@ class OptimizedPasswordHasher:
             raise ValueError("Password cannot be empty")
 
         if self.algorithm == "argon2":
-            return self.argon2_hasher.hash(password)
+            return self._get_argon2_hasher().hash(password)
 
         salt = bcrypt.gensalt(rounds=self.rounds)
         hashed = bcrypt.hashpw(password.encode("utf-8"), salt)
@@ -82,9 +83,10 @@ class OptimizedPasswordHasher:
         if not password or not hashed:
             return False
 
-        if self.algorithm == "argon2":
+        algorithm = self._detect_algorithm(hashed)
+        if algorithm == "argon2":
             try:
-                return self.argon2_hasher.verify(hashed, password)
+                return self._get_argon2_hasher().verify(hashed, password)
             except VerificationError:
                 return False
 
@@ -108,19 +110,40 @@ class OptimizedPasswordHasher:
 
     def needs_rehash(self, hashed: str) -> bool:
         """Check if password hash needs updating."""
-        if self.algorithm == "argon2":
+        algorithm = self._detect_algorithm(hashed)
+        if algorithm != self.algorithm:
+            return True
+        if algorithm == "argon2":
             try:
-                return self.argon2_hasher.check_needs_rehash(hashed)
+                return self._get_argon2_hasher().check_needs_rehash(hashed)
             except Exception:
                 return False
         try:
             parts = hashed.split("$")
-            if len(parts) >= 3 and parts[1] == "2b":
+            if len(parts) >= 3 and parts[1] in {"2a", "2b", "2y"}:
                 current_rounds = int(parts[2])
                 return current_rounds < self.rounds
         except (ValueError, IndexError):
             pass
         return True
+
+    def _detect_algorithm(self, hashed: str) -> str:
+        """Identify hash algorithm from hash prefix."""
+        if hashed.startswith("$argon2"):
+            return "argon2"
+        if hashed.startswith("$2"):
+            return "bcrypt"
+        return self.algorithm
+
+    def _get_argon2_hasher(self) -> "Argon2Hasher":
+        """Get or initialize Argon2 hasher."""
+        if Argon2Hasher is None:
+            raise ImportError(
+                "argon2-cffi is required for argon2 hashing. Install with: pip install argon2-cffi"
+            )
+        if self.argon2_hasher is None:
+            self.argon2_hasher = Argon2Hasher(time_cost=self.rounds)
+        return self.argon2_hasher
 
 
 class OptimizedCoreAuthenticator:

--- a/tests/security/test_password_hashing.py
+++ b/tests/security/test_password_hashing.py
@@ -29,3 +29,16 @@ def test_password_hashing_algorithms(algorithm):
     hashed = hasher.hash_password(password)
     assert hasher.verify_password(password, hashed)
     assert not hasher.verify_password("wrong", hashed)
+
+
+def test_password_hash_backward_compatibility():
+    bcrypt_hasher = PasswordHasher(rounds=6, algorithm="bcrypt")
+    argon2_hasher = PasswordHasher(rounds=6, algorithm="argon2")
+    password = "StrongPassw0rd!"
+    bcrypt_hash = bcrypt_hasher.hash_password(password)
+    argon2_hash = argon2_hasher.hash_password(password)
+
+    assert argon2_hasher.verify_password(password, bcrypt_hash)
+    assert bcrypt_hasher.verify_password(password, argon2_hash)
+    assert argon2_hasher.needs_rehash(bcrypt_hash)
+    assert bcrypt_hasher.needs_rehash(argon2_hash)


### PR DESCRIPTION
## Summary
- support bcrypt and argon2 in PasswordHasher with automatic detection
- validate argon2 dependency in config and expose optional dependency
- cover both algorithms and legacy hashes in tests

## Testing
- `KARI_DUCKDB_PASSWORD=test KARI_JOB_SIGNING_KEY=test PYTHONPATH=src pytest tests/security/test_password_hashing.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689960cf30448324927b62a9df738e76