### PR TITLE
feat: add global hook provider

### DIFF
--- a/ui_launchers/web_ui/src/app/layout.tsx
+++ b/ui_launchers/web_ui/src/app/layout.tsx
@@ -3,7 +3,7 @@ import type { Metadata } from 'next';
 import { Inter, Roboto_Mono } from 'next/font/google';
 import './globals.css';
 import { Toaster } from "@/components/ui/toaster";
-import { AuthProvider } from '@/contexts/AuthContext'
+import { Providers } from './providers';
 
 const inter = Inter({
   variable: '--font-sans',
@@ -30,9 +30,9 @@ export default function RootLayout({
   return (
     <html lang="en" className="dark">
       <body className={`${inter.variable} ${robotoMono.variable} font-sans antialiased`}>
-        <AuthProvider>
+        <Providers>
           {children}
-        </AuthProvider>
+        </Providers>
         <Toaster />
       </body>
     </html>

--- a/ui_launchers/web_ui/src/app/page.tsx
+++ b/ui_launchers/web_ui/src/app/page.tsx
@@ -11,7 +11,6 @@ import GmailPluginPage from '@/components/plugins/GmailPluginPage';
 import DateTimePluginPage from '@/components/plugins/DateTimePluginPage';
 import WeatherPluginPage from '@/components/plugins/WeatherPluginPage';
 import PluginOverviewPage from '@/components/plugins/PluginOverviewPage'; // Ensure this is imported
-import AuthHeader from '@/components/auth/AuthHeader'
 import { Button } from '@/components/ui/button';
 import {
   Sheet,
@@ -39,7 +38,6 @@ import NotificationsSection from '@/components/sidebar/NotificationsSection';
 import ModernChatInterface from '@/components/chat/ModernChatInterface';
 import Dashboard from '@/components/dashboard/Dashboard';
 import { webUIConfig } from '@/lib/config';
-import { AuthProvider } from '@/contexts/AuthContext';
 import { ProtectedRoute } from '@/components/auth/ProtectedRoute';
 import { AuthenticatedHeader } from '@/components/layout/AuthenticatedHeader';
 
@@ -49,11 +47,9 @@ type ActiveView = 'chat' | 'settings' | 'dashboard' | 'commsCenter' | 'pluginDat
 
 export default function HomePage() {
   return (
-    <AuthProvider>
-      <ProtectedRoute>
-        <AuthenticatedHomePage />
-      </ProtectedRoute>
-    </AuthProvider>
+    <ProtectedRoute>
+      <AuthenticatedHomePage />
+    </ProtectedRoute>
   );
 }
 

--- a/ui_launchers/web_ui/src/app/providers.tsx
+++ b/ui_launchers/web_ui/src/app/providers.tsx
@@ -1,0 +1,15 @@
+'use client';
+
+import { HookProvider } from '@/contexts/HookContext';
+import { AuthProvider } from '@/contexts/AuthContext';
+
+export function Providers({ children }: { children: React.ReactNode }) {
+  return (
+    <AuthProvider>
+      <HookProvider>
+        {children}
+      </HookProvider>
+    </AuthProvider>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add `Providers` component to centralize HookProvider and AuthProvider
- wrap app layout with Providers
- remove redundant AuthProvider wrapper from home page

## Testing
- `npm test` *(fails: 22 failed, 12 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6899abd875c88324b5950942c9c2417e