### PR TITLE
feat(web-ui): centralize auth and hook providers

### DIFF
--- a/ui_launchers/web_ui/src/app/layout.tsx
+++ b/ui_launchers/web_ui/src/app/layout.tsx
@@ -3,7 +3,7 @@ import type { Metadata } from 'next';
 import { Inter, Roboto_Mono } from 'next/font/google';
 import './globals.css';
 import { Toaster } from "@/components/ui/toaster";
-import { AuthProvider } from '@/contexts/AuthContext'
+import { Providers } from './providers';
 
 const inter = Inter({
   variable: '--font-sans',
@@ -30,9 +30,7 @@ export default function RootLayout({
   return (
     <html lang="en" className="dark">
       <body className={`${inter.variable} ${robotoMono.variable} font-sans antialiased`}>
-        <AuthProvider>
-          {children}
-        </AuthProvider>
+        <Providers>{children}</Providers>
         <Toaster />
       </body>
     </html>

--- a/ui_launchers/web_ui/src/app/providers.tsx
+++ b/ui_launchers/web_ui/src/app/providers.tsx
@@ -1,0 +1,5 @@
+'use client';
+import { AppProviders } from '@/contexts/AppProviders';
+export function Providers({ children }: { children: React.ReactNode }) {
+  return <AppProviders>{children}</AppProviders>;
+}


### PR DESCRIPTION
## Summary
- add `Providers` wrapper that delegates to existing `AppProviders`
- update app layout to use combined providers instead of `AuthProvider` alone

## Testing
- `pre-commit run --files ui_launchers/web_ui/src/app/providers.tsx ui_launchers/web_ui/src/app/layout.tsx`
- `npx vitest run src/__tests__/file-handling-components.test.tsx` *(fails: URL.createObjectURL is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_6899ac1a59148324bdb38473c68d40fe