### PR TITLE
refactor(web-ui): rely on root AuthProvider

### DIFF
--- a/ui_launchers/web_ui/src/app/page.tsx
+++ b/ui_launchers/web_ui/src/app/page.tsx
@@ -39,7 +39,6 @@ import NotificationsSection from '@/components/sidebar/NotificationsSection';
 import ModernChatInterface from '@/components/chat/ModernChatInterface';
 import Dashboard from '@/components/dashboard/Dashboard';
 import { webUIConfig } from '@/lib/config';
-import { AuthProvider } from '@/contexts/AuthContext';
 import { ProtectedRoute } from '@/components/auth/ProtectedRoute';
 import { AuthenticatedHeader } from '@/components/layout/AuthenticatedHeader';
 
@@ -49,11 +48,9 @@ type ActiveView = 'chat' | 'settings' | 'dashboard' | 'commsCenter' | 'pluginDat
 
 export default function HomePage() {
   return (
-    <AuthProvider>
-      <ProtectedRoute>
-        <AuthenticatedHomePage />
-      </ProtectedRoute>
-    </AuthProvider>
+    <ProtectedRoute>
+      <AuthenticatedHomePage />
+    </ProtectedRoute>
   );
 }
 


### PR DESCRIPTION
## Summary
- remove redundant AuthProvider wrapper from HomePage and rely on root-level provider

## Testing
- `npm run lint` *(fails: prompts for ESLint config)*
- `npm run typecheck` *(fails: cannot find various services)*
- `npm test` *(fails: network errors and missing canvas implementations)*
- `npm run build` *(fails: unable to fetch font files)*

------
https://chatgpt.com/codex/tasks/task_e_6899ae27b9608324a959243017461185