### PR TITLE
feat(web-ui): unify context providers in layout

### DIFF
--- a/ui_launchers/web_ui/src/app/layout.tsx
+++ b/ui_launchers/web_ui/src/app/layout.tsx
@@ -3,7 +3,7 @@ import type { Metadata } from 'next';
 import { Inter, Roboto_Mono } from 'next/font/google';
 import './globals.css';
 import { Toaster } from "@/components/ui/toaster";
-import { AuthProvider } from '@/contexts/AuthContext'
+import { Providers } from './providers';
 
 const inter = Inter({
   variable: '--font-sans',
@@ -30,9 +30,7 @@ export default function RootLayout({
   return (
     <html lang="en" className="dark">
       <body className={`${inter.variable} ${robotoMono.variable} font-sans antialiased`}>
-        <AuthProvider>
-          {children}
-        </AuthProvider>
+        <Providers>{children}</Providers>
         <Toaster />
       </body>
     </html>

--- a/ui_launchers/web_ui/src/app/page.tsx
+++ b/ui_launchers/web_ui/src/app/page.tsx
@@ -39,7 +39,6 @@ import NotificationsSection from '@/components/sidebar/NotificationsSection';
 import ModernChatInterface from '@/components/chat/ModernChatInterface';
 import Dashboard from '@/components/dashboard/Dashboard';
 import { webUIConfig } from '@/lib/config';
-import { AuthProvider } from '@/contexts/AuthContext';
 import { ProtectedRoute } from '@/components/auth/ProtectedRoute';
 import { AuthenticatedHeader } from '@/components/layout/AuthenticatedHeader';
 
@@ -49,11 +48,9 @@ type ActiveView = 'chat' | 'settings' | 'dashboard' | 'commsCenter' | 'pluginDat
 
 export default function HomePage() {
   return (
-    <AuthProvider>
-      <ProtectedRoute>
-        <AuthenticatedHomePage />
-      </ProtectedRoute>
-    </AuthProvider>
+    <ProtectedRoute>
+      <AuthenticatedHomePage />
+    </ProtectedRoute>
   );
 }
 

--- a/ui_launchers/web_ui/src/app/providers.tsx
+++ b/ui_launchers/web_ui/src/app/providers.tsx
@@ -1,0 +1,5 @@
+'use client';
+import { AppProviders } from '@/contexts/AppProviders';
+export function Providers({ children }: { children: React.ReactNode }) {
+  return <AppProviders>{children}</AppProviders>;
+}


### PR DESCRIPTION
## Summary
- add `Providers` wrapper that combines `AuthProvider` and `HookProvider`
- wrap the Next.js app with `Providers` instead of a raw `AuthProvider`
- remove redundant `AuthProvider` usage in `HomePage`

## Testing
- `npm test` *(fails: expected attribute "required" in LoginForm.test.tsx)*
- `npm run lint` *(prompts for interactive setup)*
- `npm run typecheck` *(fails: cannot find name 'initializePluginService')*

------
https://chatgpt.com/codex/tasks/task_e_6899ac1a59148324bdb38473c68d40fe