### PR TITLE
Wrap Next.js layout with CopilotKitProvider for ModernChatInterface

### DIFF
--- a/ui_launchers/web_ui/src/app/layout.tsx
+++ b/ui_launchers/web_ui/src/app/layout.tsx
@@ -3,7 +3,7 @@ import type { Metadata } from 'next';
 import { Inter, Roboto_Mono } from 'next/font/google';
 import './globals.css';
 import { Toaster } from "@/components/ui/toaster";
-import { AuthProvider } from '@/contexts/AuthContext'
+import { Providers } from './providers'
 
 const inter = Inter({
   variable: '--font-sans',
@@ -30,9 +30,9 @@ export default function RootLayout({
   return (
     <html lang="en" className="dark">
       <body className={`${inter.variable} ${robotoMono.variable} font-sans antialiased`}>
-        <AuthProvider>
+        <Providers>
           {children}
-        </AuthProvider>
+        </Providers>
         <Toaster />
       </body>
     </html>

--- a/ui_launchers/web_ui/src/app/providers.tsx
+++ b/ui_launchers/web_ui/src/app/providers.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import { HookProvider } from '@/contexts/HookContext';
+import { AuthProvider } from '@/contexts/AuthContext';
+import { CopilotKitProvider } from '@/components/copilot';
+
+export function Providers({ children }: { children: React.ReactNode }) {
+  return (
+    <AuthProvider>
+      <HookProvider>
+        <CopilotKitProvider>
+          {children}
+        </CopilotKitProvider>
+      </HookProvider>
+    </AuthProvider>
+  );
+}
+
+export default Providers;


### PR DESCRIPTION
## Summary
- add CopilotKitProvider to app-level Providers wrapper
- allow ModernChatInterface to access CopilotKit context in Next.js layout

## Testing
- `npm test` *(fails: URL.createObjectURL is not a function)*
- `pre-commit run --files ui_launchers/web_ui/src/app/providers.tsx ui_launchers/web_ui/src/app/layout.tsx`

------
https://chatgpt.com/codex/tasks/task_e_6899abd875c88324b5950942c9c2417e