### PR TITLE
feat(web-ui): provide global CopilotKit context

### DIFF
--- a/ui_launchers/web_ui/src/__tests__/modern-chat-integration.test.tsx
+++ b/ui_launchers/web_ui/src/__tests__/modern-chat-integration.test.tsx
@@ -8,15 +8,8 @@ import { render, screen } from '@testing-library/react';
 import { vi } from 'vitest';
 import ModernChatInterface from '@/components/chat/ModernChatInterface';
 import { AuthProvider } from '@/contexts/AuthContext';
-
-// Mock CopilotKit components
-vi.mock('@copilotkit/react-core', () => ({
-  CopilotKit: ({ children }: { children: React.ReactNode }) => (
-    <div data-testid="copilot-provider">{children}</div>
-  ),
-  useCopilotAction: () => {},
-  useCopilotReadable: () => {},
-}));
+import { HookProvider } from '@/contexts/HookContext';
+import { CopilotKitProvider } from '@/components/copilot';
 
 vi.mock('@copilotkit/react-textarea', () => ({
   CopilotTextarea: (props: any) => (
@@ -42,7 +35,9 @@ const mockUser = {
 
 const TestWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
   <AuthProvider>
-    {children}
+    <HookProvider>
+      <CopilotKitProvider>{children}</CopilotKitProvider>
+    </HookProvider>
   </AuthProvider>
 );
 
@@ -59,14 +54,15 @@ describe('ModernChatInterface Integration', () => {
     });
   });
 
-  it('renders with CopilotKit provider', () => {
-    render(
-      <TestWrapper>
-        <ModernChatInterface />
-      </TestWrapper>
-    );
+  it('renders without CopilotKit provider errors', () => {
+    const renderComponent = () =>
+      render(
+        <TestWrapper>
+          <ModernChatInterface />
+        </TestWrapper>
+      );
 
-    expect(screen.getByTestId('copilot-provider')).toBeInTheDocument();
+    expect(renderComponent).not.toThrow();
   });
 
   it('includes CopilotKit textarea for input', () => {

--- a/ui_launchers/web_ui/src/app/providers.tsx
+++ b/ui_launchers/web_ui/src/app/providers.tsx
@@ -2,12 +2,15 @@
 
 import { HookProvider } from '@/contexts/HookContext';
 import { AuthProvider } from '@/contexts/AuthContext';
+import { CopilotKitProvider } from '@/components/copilot';
 
 export function Providers({ children }: { children: React.ReactNode }) {
   return (
     <AuthProvider>
       <HookProvider>
-        {children}
+        <CopilotKitProvider>
+          {children}
+        </CopilotKitProvider>
       </HookProvider>
     </AuthProvider>
   );

--- a/ui_launchers/web_ui/src/components/chat/ModernChatInterface.tsx
+++ b/ui_launchers/web_ui/src/components/chat/ModernChatInterface.tsx
@@ -13,7 +13,6 @@
 import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import { AgGridReact } from 'ag-grid-react';
 import { ColDef, GridReadyEvent, RowSelectedEvent } from 'ag-grid-community';
-import { CopilotKit } from '@copilotkit/react-core';
 import { CopilotTextarea } from '@copilotkit/react-textarea';
 import { useCopilotAction, useCopilotReadable } from '@copilotkit/react-core';
 
@@ -672,8 +671,7 @@ export const ModernChatInterface: React.FC<ModernChatInterfaceProps> = ({
   }
 
   return (
-    <CopilotKit runtimeUrl="/api/copilot">
-      <Card className={`flex flex-col ${className} ${isFullscreen ? 'fixed inset-0 z-50' : ''}`} style={{ height }}>
+    <Card className={`flex flex-col ${className} ${isFullscreen ? 'fixed inset-0 z-50' : ''}`} style={{ height }}>
         <CardHeader className="pb-3">
           <div className="flex items-center justify-between">
             <CardTitle className="flex items-center gap-2">
@@ -733,7 +731,6 @@ export const ModernChatInterface: React.FC<ModernChatInterfaceProps> = ({
           )}
         </CardContent>
       </Card>
-    </CopilotKit>
   );
 };
 


### PR DESCRIPTION
## Summary
- add CopilotKitProvider to app-wide Providers
- remove local CopilotKit wrapper from ModernChatInterface
- update modern chat integration tests for global provider

## Testing
- `npm test` *(fails: HTMLCanvasElement.prototype.getContext not implemented)*

------
https://chatgpt.com/codex/tasks/task_e_6899b4d21e78832490a2eaeb7e45dc17