### PR TITLE
Stream file uploads to temp files

### DIFF
--- a/tests/stubs/ai_karen_engine/chat/__init__.py
+++ b/tests/stubs/ai_karen_engine/chat/__init__.py
@@ -1,0 +1,3 @@
+from pathlib import Path
+__path__ = [str(Path(__file__).resolve().parents[4] / 'src' / 'ai_karen_engine' / 'chat')]
+__all__ = []

--- a/tests/stubs/ai_karen_engine/services/nlp_service_manager.py
+++ b/tests/stubs/ai_karen_engine/services/nlp_service_manager.py
@@ -1,0 +1,1 @@
+nlp_service_manager = object()

--- a/tests/stubs/numpy.py
+++ b/tests/stubs/numpy.py
@@ -5,6 +5,7 @@ float32 = "float32"
 uint8 = "uint8"
 inf = float("inf")
 nan = float("nan")
+__version__ = "0.0"
 
 # Additional numpy types needed for torch compatibility
 bool_ = bool

--- a/tests/test_enhanced_file_handling.py
+++ b/tests/test_enhanced_file_handling.py
@@ -4,6 +4,7 @@ Tests for enhanced file handling with AG-UI multimedia interface and hook integr
 
 import asyncio
 import json
+import io
 import pytest
 from datetime import datetime, timedelta
 from pathlib import Path
@@ -101,7 +102,7 @@ class TestHookEnabledFileService:
         )
         
         # Mock file content
-        file_content = b"fake_image_data"
+        file_content = io.BytesIO(b"fake_image_data")
         
         # Mock the base upload method
         with patch.object(file_service, '_validate_file', return_value=(True, "Valid")), \
@@ -163,7 +164,7 @@ class TestHookEnabledFileService:
             metadata={"enable_hooks": True}
         )
         
-        file_content = b"malicious_content"
+        file_content = io.BytesIO(b"malicious_content")
         
         # Execute upload
         result = await file_service.upload_file(request, file_content)
@@ -545,7 +546,7 @@ class TestEnhancedFileRoutes:
         mock_file = Mock()
         mock_file.filename = "test.jpg"
         mock_file.content_type = "image/jpeg"
-        mock_file.read = AsyncMock(return_value=b"fake_image_data")
+        mock_file.read = AsyncMock(side_effect=[b"fake_image_data", b""])
         
         metadata_json = json.dumps({
             "conversation_id": "conv_123",


### PR DESCRIPTION
## Summary
- Stream upload content to temporary files in file attachment routes
- Update file attachment services to process file-like objects directly
- Switch tests to use in-memory file handles for uploads

## Testing
- `KARI_DUCKDB_PASSWORD=testpass KARI_JOB_SIGNING_KEY=testsign PYTHONPATH=tests/stubs:src pytest tests/test_advanced_chat_features.py tests/test_enhanced_file_handling.py -q` *(fails: ModuleNotFoundError: No module named 'ai_karen_engine.clients.nlp')*


------
https://chatgpt.com/codex/tasks/task_e_6899b5095a9c8324a9fa021d5d9d4ddc