### PR TITLE
feat: scope auth rate limits by ip

### DIFF
--- a/src/ai_karen_engine/api_routes/users.py
+++ b/src/ai_karen_engine/api_routes/users.py
@@ -153,7 +153,9 @@ async def create_user(
     except UserAlreadyExistsError as e:
         raise HTTPException(status_code=409, detail=str(e))
     except RateLimitExceededError as e:
-        raise HTTPException(status_code=429, detail=str(e))
+        retry_after = e.details.get("retry_after") if isinstance(e.details, dict) else None
+        headers = {"Retry-After": str(retry_after)} if retry_after is not None else None
+        raise HTTPException(status_code=429, detail=str(e), headers=headers)
     except SecurityError as e:
         raise HTTPException(status_code=403, detail=str(e))
     except AuthError as e:

--- a/src/ai_karen_engine/auth/rate_limit_store.py
+++ b/src/ai_karen_engine/auth/rate_limit_store.py
@@ -12,6 +12,22 @@ except Exception:  # pragma: no cover
     redis_asyncio = None  # type: ignore
 
 
+def build_limit_key(identifier: str, event_type: str, ip: str | None = None) -> str:
+    """Construct a standardized rate-limit key.
+
+    Args:
+        identifier: Base identifier, typically `user:<email>` or `ip`.
+        event_type: The type of event being limited (e.g., ``login_attempt``).
+        ip: Optional IP address to scope the identifier.
+
+    Returns:
+        A namespaced key suitable for storing rate limit data.
+    """
+
+    suffix = f":{ip}" if ip else ""
+    return f"rl:{event_type}:{identifier}{suffix}"
+
+
 class RateLimitStore:
     """Abstract rate limit storage backend."""
 


### PR DESCRIPTION
## Summary
- scope rate-limit keys by client IP so one user doesn't block others
- return Retry-After headers when throttling login or registration
- resolve secure DuckDB path flexibly across environments

## Testing
- `KARI_DUCKDB_PASSWORD=pass KARI_JOB_SIGNING_KEY=key PYTHONPATH=src pytest tests/test_rate_limiter.py`

------
https://chatgpt.com/codex/tasks/task_e_6899bfeb61c4832489cb984b310ce80d