### PR TITLE
Harden auth and rate limit middleware; tighten user APIs

### DIFF
--- a/src/ai_karen_engine/api_routes/users.py
+++ b/src/ai_karen_engine/api_routes/users.py
@@ -1,8 +1,10 @@
 import asyncio
+from datetime import datetime
 from typing import Any, Dict, List, Optional
 
 from ai_karen_engine.clients.database.duckdb_client import DuckDBClient
 from ai_karen_engine.core.dependencies import get_current_user_context
+from ai_karen_engine.core.errors import ErrorCode, ErrorResponse
 from ai_karen_engine.utils.dependency_checks import import_fastapi, import_pydantic
 from ai_karen_engine.auth.service import AuthService, get_auth_service
 from ai_karen_engine.auth.exceptions import (
@@ -13,8 +15,8 @@ from ai_karen_engine.auth.exceptions import (
     SecurityError,
 )
 
-APIRouter, Depends, HTTPException = import_fastapi(
-    "APIRouter", "Depends", "HTTPException"
+APIRouter, Depends, HTTPException, Response = import_fastapi(
+    "APIRouter", "Depends", "HTTPException", "Response"
 )
 BaseModel = import_pydantic("BaseModel")
 
@@ -38,6 +40,26 @@ async def get_auth_service_instance() -> AuthService:
     if auth_service_instance is None:
         auth_service_instance = await get_auth_service()
     return auth_service_instance
+
+
+def http_error(status_code: int, code: ErrorCode, message: str) -> None:
+    error = ErrorResponse(
+        error_code=code,
+        message=message,
+        timestamp=datetime.utcnow().isoformat(),
+    )
+    raise HTTPException(status_code=status_code, detail=error.model_dump())
+
+
+ERROR_RESPONSES = {
+    400: {"model": ErrorResponse},
+    401: {"model": ErrorResponse},
+    403: {"model": ErrorResponse},
+    404: {"model": ErrorResponse},
+    409: {"model": ErrorResponse},
+    429: {"model": ErrorResponse},
+    500: {"model": ErrorResponse},
+}
 
 
 class UserProfile(BaseModel):
@@ -75,7 +97,12 @@ class UserResponse(BaseModel):
     updated_at: str
 
 
-@router.get("/users/{user_id}/profile", response_model=UserProfile)
+@router.get(
+    "/users/{user_id}/profile",
+    response_model=UserProfile,
+    status_code=200,
+    responses=ERROR_RESPONSES,
+)
 async def get_profile(
     user_id: str,
     current_user: Dict[str, Any] = Depends(get_current_user_context),
@@ -85,17 +112,20 @@ async def get_profile(
     if current_user.get("user_id") != user_id and "admin" not in current_user.get(
         "roles", []
     ):
-        raise HTTPException(
-            status_code=403, detail="Not authorized to access this profile"
-        )
+        http_error(403, ErrorCode.AUTHORIZATION_ERROR, "Not authorized to access this profile")
 
     profile = await asyncio.to_thread(db.get_profile, user_id)
     if profile is None:
-        raise HTTPException(status_code=404, detail="Profile not found")
+        http_error(404, ErrorCode.NOT_FOUND, "Profile not found")
     return UserProfile(user_id=user_id, **profile)
 
 
-@router.put("/users/{user_id}/profile", response_model=UserProfile)
+@router.put(
+    "/users/{user_id}/profile",
+    response_model=UserProfile,
+    status_code=200,
+    responses=ERROR_RESPONSES,
+)
 async def save_profile(
     user_id: str,
     profile: UserProfile,
@@ -106,16 +136,19 @@ async def save_profile(
     if current_user.get("user_id") != user_id and "admin" not in current_user.get(
         "roles", []
     ):
-        raise HTTPException(
-            status_code=403, detail="Not authorized to modify this profile"
-        )
+        http_error(403, ErrorCode.AUTHORIZATION_ERROR, "Not authorized to modify this profile")
 
     data = profile.dict(exclude={"user_id"})
     await asyncio.to_thread(db.save_profile, user_id, data)
     return UserProfile(user_id=user_id, **data)
 
 
-@router.post("/users", response_model=UserResponse)
+@router.post(
+    "/users",
+    response_model=UserResponse,
+    status_code=201,
+    responses=ERROR_RESPONSES,
+)
 async def create_user(
     request: CreateUserRequest,
     current_user: Dict[str, Any] = Depends(get_current_user_context),
@@ -123,9 +156,7 @@ async def create_user(
     """Create a new user (admin only)."""
     # Only allow admin users to create new users
     if "admin" not in current_user.get("roles", []):
-        raise HTTPException(
-            status_code=403, detail="Not authorized to create users"
-        )
+        http_error(403, ErrorCode.AUTHORIZATION_ERROR, "Not authorized to create users")
 
     try:
         auth_service = await get_auth_service_instance()
@@ -151,18 +182,23 @@ async def create_user(
         )
 
     except UserAlreadyExistsError as e:
-        raise HTTPException(status_code=409, detail=str(e))
+        http_error(409, ErrorCode.VALIDATION_ERROR, str(e))
     except RateLimitExceededError as e:
-        raise HTTPException(status_code=429, detail=str(e))
+        http_error(429, ErrorCode.RATE_LIMIT_EXCEEDED, str(e))
     except SecurityError as e:
-        raise HTTPException(status_code=403, detail=str(e))
+        http_error(403, ErrorCode.AUTHORIZATION_ERROR, str(e))
     except AuthError as e:
-        raise HTTPException(status_code=400, detail=str(e))
-    except Exception as e:
-        raise HTTPException(status_code=500, detail="Failed to create user")
+        http_error(400, ErrorCode.SERVICE_ERROR, str(e))
+    except Exception:
+        http_error(500, ErrorCode.INTERNAL_ERROR, "Failed to create user")
 
 
-@router.get("/users/{user_id}", response_model=UserResponse)
+@router.get(
+    "/users/{user_id}",
+    response_model=UserResponse,
+    status_code=200,
+    responses=ERROR_RESPONSES,
+)
 async def get_user(
     user_id: str,
     current_user: Dict[str, Any] = Depends(get_current_user_context),
@@ -172,16 +208,14 @@ async def get_user(
     if current_user.get("user_id") != user_id and "admin" not in current_user.get(
         "roles", []
     ):
-        raise HTTPException(
-            status_code=403, detail="Not authorized to access this user"
-        )
+        http_error(403, ErrorCode.AUTHORIZATION_ERROR, "Not authorized to access this user")
 
     try:
         auth_service = await get_auth_service_instance()
         user_data = await auth_service.get_user_by_id(user_id)
 
         if not user_data:
-            raise HTTPException(status_code=404, detail="User not found")
+            http_error(404, ErrorCode.NOT_FOUND, "User not found")
 
         return UserResponse(
             user_id=user_data.user_id,
@@ -197,14 +231,19 @@ async def get_user(
         )
 
     except UserNotFoundError:
-        raise HTTPException(status_code=404, detail="User not found")
+        http_error(404, ErrorCode.NOT_FOUND, "User not found")
     except AuthError as e:
-        raise HTTPException(status_code=400, detail=str(e))
-    except Exception as e:
-        raise HTTPException(status_code=500, detail="Failed to get user")
+        http_error(400, ErrorCode.SERVICE_ERROR, str(e))
+    except Exception:
+        http_error(500, ErrorCode.INTERNAL_ERROR, "Failed to get user")
 
 
-@router.put("/users/{user_id}", response_model=UserResponse)
+@router.put(
+    "/users/{user_id}",
+    response_model=UserResponse,
+    status_code=200,
+    responses=ERROR_RESPONSES,
+)
 async def update_user(
     user_id: str,
     request: UpdateUserRequest,
@@ -216,15 +255,11 @@ async def update_user(
     if current_user.get("user_id") != user_id and "admin" not in current_user.get(
         "roles", []
     ):
-        raise HTTPException(
-            status_code=403, detail="Not authorized to modify this user"
-        )
+        http_error(403, ErrorCode.AUTHORIZATION_ERROR, "Not authorized to modify this user")
 
     # Only admin can modify roles and is_active status
     if (request.roles is not None or request.is_active is not None) and "admin" not in current_user.get("roles", []):
-        raise HTTPException(
-            status_code=403, detail="Not authorized to modify user roles or status"
-        )
+        http_error(403, ErrorCode.AUTHORIZATION_ERROR, "Not authorized to modify user roles or status")
 
     try:
         auth_service = await get_auth_service_instance()
@@ -232,7 +267,7 @@ async def update_user(
         # Get current user data
         user_data = await auth_service.get_user_by_id(user_id)
         if not user_data:
-            raise HTTPException(status_code=404, detail="User not found")
+            http_error(404, ErrorCode.NOT_FOUND, "User not found")
 
         # Update user data using the consolidated service
         updated_user = await auth_service.update_user(
@@ -257,53 +292,58 @@ async def update_user(
         )
 
     except UserNotFoundError:
-        raise HTTPException(status_code=404, detail="User not found")
+        http_error(404, ErrorCode.NOT_FOUND, "User not found")
     except SecurityError as e:
-        raise HTTPException(status_code=403, detail=str(e))
+        http_error(403, ErrorCode.AUTHORIZATION_ERROR, str(e))
     except AuthError as e:
-        raise HTTPException(status_code=400, detail=str(e))
-    except Exception as e:
-        raise HTTPException(status_code=500, detail="Failed to update user")
+        http_error(400, ErrorCode.SERVICE_ERROR, str(e))
+    except Exception:
+        http_error(500, ErrorCode.INTERNAL_ERROR, "Failed to update user")
 
 
-@router.delete("/users/{user_id}")
+@router.delete(
+    "/users/{user_id}",
+    status_code=204,
+    responses=ERROR_RESPONSES,
+)
 async def delete_user(
     user_id: str,
     current_user: Dict[str, Any] = Depends(get_current_user_context),
-) -> Dict[str, str]:
+) -> Response:
     """Delete a user (admin only)."""
     # Only allow admin users to delete users
     if "admin" not in current_user.get("roles", []):
-        raise HTTPException(
-            status_code=403, detail="Not authorized to delete users"
-        )
+        http_error(403, ErrorCode.AUTHORIZATION_ERROR, "Not authorized to delete users")
 
     # Prevent self-deletion
     if current_user.get("user_id") == user_id:
-        raise HTTPException(
-            status_code=400, detail="Cannot delete your own account"
-        )
+        http_error(400, ErrorCode.VALIDATION_ERROR, "Cannot delete your own account")
 
     try:
         auth_service = await get_auth_service_instance()
         success = await auth_service.delete_user(user_id)
 
         if not success:
-            raise HTTPException(status_code=404, detail="User not found")
+            http_error(404, ErrorCode.NOT_FOUND, "User not found")
 
-        return {"detail": "User deleted successfully"}
+        return Response(status_code=204)
 
     except UserNotFoundError:
-        raise HTTPException(status_code=404, detail="User not found")
+        http_error(404, ErrorCode.NOT_FOUND, "User not found")
     except SecurityError as e:
-        raise HTTPException(status_code=403, detail=str(e))
+        http_error(403, ErrorCode.AUTHORIZATION_ERROR, str(e))
     except AuthError as e:
-        raise HTTPException(status_code=400, detail=str(e))
-    except Exception as e:
-        raise HTTPException(status_code=500, detail="Failed to delete user")
+        http_error(400, ErrorCode.SERVICE_ERROR, str(e))
+    except Exception:
+        http_error(500, ErrorCode.INTERNAL_ERROR, "Failed to delete user")
 
 
-@router.get("/users", response_model=List[UserResponse])
+@router.get(
+    "/users",
+    response_model=List[UserResponse],
+    status_code=200,
+    responses=ERROR_RESPONSES,
+)
 async def list_users(
     current_user: Dict[str, Any] = Depends(get_current_user_context),
     tenant_id: Optional[str] = None,
@@ -313,9 +353,7 @@ async def list_users(
     """List users (admin only)."""
     # Only allow admin users to list users
     if "admin" not in current_user.get("roles", []):
-        raise HTTPException(
-            status_code=403, detail="Not authorized to list users"
-        )
+        http_error(403, ErrorCode.AUTHORIZATION_ERROR, "Not authorized to list users")
 
     try:
         auth_service = await get_auth_service_instance()
@@ -342,6 +380,6 @@ async def list_users(
         ]
 
     except AuthError as e:
-        raise HTTPException(status_code=400, detail=str(e))
-    except Exception as e:
-        raise HTTPException(status_code=500, detail="Failed to list users")
+        http_error(400, ErrorCode.SERVICE_ERROR, str(e))
+    except Exception:
+        http_error(500, ErrorCode.INTERNAL_ERROR, "Failed to list users")

--- a/src/ai_karen_engine/api_routes/websocket_routes.py
+++ b/src/ai_karen_engine/api_routes/websocket_routes.py
@@ -28,6 +28,7 @@ from ai_karen_engine.chat.chat_orchestrator import ChatOrchestrator, ChatRequest
 from ai_karen_engine.chat.stream_processor import StreamProcessor
 from ai_karen_engine.chat.websocket_gateway import WebSocketGateway
 from ai_karen_engine.auth.service import get_auth_service
+from ai_karen_engine.core.dependencies import get_current_user_context
 from ai_karen_engine.utils.dependency_checks import import_pydantic
 
 try:
@@ -209,6 +210,7 @@ async def stream_chat_sse(
     request: StreamChatRequest,
     http_request: Request,
     processor: StreamProcessor = Depends(get_stream_processor),
+    current_user: Dict[str, Any] = Depends(get_current_user_context),
 ) -> EventSourceResponse:
     """
     Server-Sent Events endpoint for streaming chat responses.
@@ -219,7 +221,7 @@ async def stream_chat_sse(
         # Create chat request
         chat_request = ChatRequest(
             message=request.message,
-            user_id=request.user_id,
+            user_id=current_user.get("user_id"),
             conversation_id=request.conversation_id,
             session_id=request.session_id,
             stream=True,
@@ -243,6 +245,7 @@ async def stream_chat_http(
     request: StreamChatRequest,
     http_request: Request,
     processor: StreamProcessor = Depends(get_stream_processor),
+    current_user: Dict[str, Any] = Depends(get_current_user_context),
 ) -> StreamingResponse:
     """
     HTTP streaming endpoint for streaming chat responses.
@@ -253,7 +256,7 @@ async def stream_chat_http(
         # Create chat request
         chat_request = ChatRequest(
             message=request.message,
-            user_id=request.user_id,
+            user_id=current_user.get("user_id"),
             conversation_id=request.conversation_id,
             session_id=request.session_id,
             stream=True,


### PR DESCRIPTION
## Summary
- run database lookups in auth and rate-limit middleware through `run_in_threadpool` to avoid blocking the event loop
- require authenticated context on SSE/HTTP streaming endpoints
- normalize user route responses with explicit status codes and structured error helper

## Testing
- `ruff check .` *(fails: numerous F841 etc)*
- `black --check .` *(fails: would reformat many files)*
- `mypy .` *(fails: workflow-builder is not a valid Python package name)*
- `bandit -r src` *(command not found)*
- `safety check -r requirements.txt` *(command not found)*
- `pytest -q` *(fails: ImportError: module 'tests.stubs.numpy' has no attribute 'int8')*

------
https://chatgpt.com/codex/tasks/task_e_6899b223289083249f756d25821ccb45