### PR TITLE
Handle missing user email in AuthenticatedHeader

### DIFF
--- a/ui_launchers/web_ui/src/components/layout/AuthenticatedHeader.tsx
+++ b/ui_launchers/web_ui/src/components/layout/AuthenticatedHeader.tsx
@@ -5,23 +5,23 @@ import { useAuth } from '@/contexts/AuthContext';
 import { UserProfile } from '@/components/auth/UserProfile';
 import { Button } from '@/components/ui/button';
 import { Avatar, AvatarFallback } from '@/components/ui/avatar';
-import { 
-  DropdownMenu, 
-  DropdownMenuContent, 
-  DropdownMenuItem, 
-  DropdownMenuLabel, 
-  DropdownMenuSeparator, 
-  DropdownMenuTrigger 
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger
 } from '@/components/ui/dropdown-menu';
-import { 
-  Dialog, 
-  DialogContent, 
-  DialogHeader, 
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
   DialogTitle,
   DialogDescription,
   DialogFooter
 } from '@/components/ui/dialog';
-import { 
+import {
   AlertDialog,
   AlertDialogAction,
   AlertDialogCancel,
@@ -43,7 +43,7 @@ export const AuthenticatedHeader: React.FC = () => {
     return null;
   }
 
-  const userInitials = user.email.charAt(0).toUpperCase();
+  const userInitials = (user?.email?.charAt(0) ?? user?.user_id?.charAt(0) ?? '?').toUpperCase();
 
   const handleLogout = () => {
     setShowLogoutConfirm(false);
@@ -66,7 +66,7 @@ export const AuthenticatedHeader: React.FC = () => {
           <DropdownMenuContent className="w-56" align="end" forceMount>
             <DropdownMenuLabel className="font-normal">
               <div className="flex flex-col space-y-1">
-                <p className="text-sm font-medium leading-none">{user.email}</p>
+                <p className="text-sm font-medium leading-none">{user?.email ?? user?.user_id ?? ''}</p>
                 <p className="text-xs leading-none text-muted-foreground">
                   {user.roles.join(', ')}
                 </p>

--- a/ui_launchers/web_ui/src/components/layout/__tests__/AuthenticatedHeader.test.tsx
+++ b/ui_launchers/web_ui/src/components/layout/__tests__/AuthenticatedHeader.test.tsx
@@ -1,0 +1,18 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
+import { AuthenticatedHeader } from '../AuthenticatedHeader';
+
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => ({
+    user: { user_id: 'user123', roles: ['user'] },
+    logout: vi.fn(),
+  }),
+}));
+
+test('renders without crashing when user email is undefined', async () => {
+  render(<AuthenticatedHeader />);
+  expect(screen.getByText('U')).toBeInTheDocument();
+  await userEvent.click(screen.getByRole('button'));
+  expect(screen.getByText('user123')).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- safeguard user initials calculation when `user.email` is absent
- fall back to `user_id` when displaying a user's identifier
- add unit test ensuring header renders without an email

## Testing
- `pre-commit run --files ui_launchers/web_ui/src/components/layout/AuthenticatedHeader.tsx ui_launchers/web_ui/src/components/layout/__tests__/AuthenticatedHeader.test.tsx`
- `cd ui_launchers/web_ui && npm test` *(fails: 4 failed, 31 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_6899e76a8a088324b56668d4ea59e9e8