### PR TITLE
feat(web-ui): handle optional user email

### DIFF
--- a/ui_launchers/web_ui/src/components/auth/UserProfile.tsx
+++ b/ui_launchers/web_ui/src/components/auth/UserProfile.tsx
@@ -335,7 +335,7 @@ export const UserProfile: React.FC<UserProfileProps> = ({ onClose }) => {
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4 p-4 bg-muted/50 rounded-lg">
             <div>
               <Label className="text-sm font-medium text-muted-foreground">Email</Label>
-              <p className="font-medium">{user.email}</p>
+              <p className="font-medium">{user.email ?? 'N/A'}</p>
             </div>
             <div>
               <Label className="text-sm font-medium text-muted-foreground">User ID</Label>

--- a/ui_launchers/web_ui/src/components/auth/__tests__/auth-integration.manual.test.tsx
+++ b/ui_launchers/web_ui/src/components/auth/__tests__/auth-integration.manual.test.tsx
@@ -90,13 +90,13 @@ vi.mock('@/components/ui/alert', () => ({
 // Test component to verify auth context integration
 const AuthTestComponent = () => {
   const { isAuthenticated, isLoading, user } = useAuth();
-  
+
   return (
     <div data-testid="auth-test">
       <div data-testid="auth-status">
         {isLoading ? 'loading' : isAuthenticated ? 'authenticated' : 'unauthenticated'}
       </div>
-      {user && <div data-testid="user-email">{user.email}</div>}
+      {user?.email && <div data-testid="user-email">{user.email}</div>}
     </div>
   );
 };

--- a/ui_launchers/web_ui/src/components/chat/ChatInterface.tsx
+++ b/ui_launchers/web_ui/src/components/chat/ChatInterface.tsx
@@ -9,11 +9,11 @@ import { sanitizeInput } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Loader2, SendHorizontal, Mic, MicOff, AlertTriangle, Sparkles } from 'lucide-react';
-import { 
-  handleUserMessage, 
+import {
+  handleUserMessage,
   handleUserMessageWithKarenBackend,
-  getSuggestedStarter, 
-  type HandleUserMessageResult 
+  getSuggestedStarter,
+  type HandleUserMessageResult
 } from '@/app/actions';
 import { MessageBubble } from './MessageBubble';
 import { useToast } from "@/hooks/use-toast";
@@ -66,7 +66,7 @@ export default function ChatInterface() {
       }
 
       // Set welcome message with user's name if available
-      const welcomeMessage = user 
+      const welcomeMessage = user?.email
         ? `Hello ${user.email}! I'm Karen, your intelligent assistant. How can I help you today?`
         : "Hello! I'm Karen, your intelligent assistant. How can I help you today?";
 
@@ -118,7 +118,7 @@ export default function ChatInterface() {
         }
       }
     };
-    
+
     window.addEventListener('storage', handleStorageChange);
     return () => {
       window.removeEventListener('storage', handleStorageChange);
@@ -211,7 +211,7 @@ export default function ChatInterface() {
       if (conversationId) {
         await chatService.addMessageToConversation(conversationId, userMessage);
       }
-      
+
       const newMessages: ChatMessage[] = [];
       const autoPlayThisMessage = isVoice;
 
@@ -221,7 +221,7 @@ export default function ChatInterface() {
           role: 'assistant',
           content: result.acknowledgement,
           timestamp: new Date(),
-          shouldAutoPlay: autoPlayThisMessage, 
+          shouldAutoPlay: autoPlayThisMessage,
         });
       }
 
@@ -241,7 +241,7 @@ export default function ChatInterface() {
           role: 'assistant',
           content: result.proactiveSuggestion,
           timestamp: new Date(),
-          shouldAutoPlay: autoPlayThisMessage, 
+          shouldAutoPlay: autoPlayThisMessage,
         });
       }
 
@@ -292,8 +292,8 @@ export default function ChatInterface() {
       }
 
 
-      if (result.aiDataForFinalResponse?.knowledgeGraphInsights && 
-          parsedSettings.notifications.enabled && 
+      if (result.aiDataForFinalResponse?.knowledgeGraphInsights &&
+          parsedSettings.notifications.enabled &&
           parsedSettings.notifications.alertOnNewInsights) {
         toast({
           title: "✨ New Insight from Karen!",
@@ -304,12 +304,12 @@ export default function ChatInterface() {
 
     } catch (error) {
       console.error("Error sending message in ChatInterface handleSubmit:", error);
-      
+
       setMessages((prevMessages) => prevMessages.filter(m => m.id !== userMessage.id));
-      
+
       let errorMessageContent = "Failed to get a response from Karen. Please check your connection or try again later.";
       if (error instanceof Error && error.message) {
-        if (error.message.startsWith("Karen: ")) { 
+        if (error.message.startsWith("Karen: ")) {
           errorMessageContent = error.message;
         } else if (error.message.includes("API key not valid")) {
           errorMessageContent = `Karen: There seems to be an issue with the API key. Please go to Settings > API Key for setup instructions. The key needs to be in a .env file at your project root, and the Genkit server must be restarted.`;
@@ -317,7 +317,7 @@ export default function ChatInterface() {
           error.message.includes("INVALID_ARGUMENT") &&
           error.message.includes("Schema validation failed") &&
           error.message.includes("(root): must be object") &&
-          /Provided data:\s*null/.test(error.message) 
+          /Provided data:\s*null/.test(error.message)
         ) {
           errorMessageContent = `Karen: I'm having a little trouble formulating a response right now. This can sometimes happen if the request is very complex or if content filters are active. Could you try rephrasing your request?`;
         } else {
@@ -329,7 +329,7 @@ export default function ChatInterface() {
         title: "Processing Error",
         description: errorMessageContent.startsWith("Karen: ") ? errorMessageContent.substring(7) : errorMessageContent,
       });
-      
+
       const systemErrorMessage: ChatMessage = {
         id: 'error-' + Date.now(),
         role: 'system',
@@ -372,7 +372,7 @@ export default function ChatInterface() {
       console.error('Speech recognition error:', event.error, event.message);
       let errorTitle = 'Speech Recognition Error';
       let errorMessage = 'An unexpected error occurred during speech recognition.';
-      
+
       switch (event.error) {
           case 'no-speech': errorMessage = 'No speech was detected. Please ensure your microphone is active and try again.'; break;
           case 'audio-capture': errorMessage = 'Audio capture failed. Please ensure your microphone is working and selected correctly.'; break;
@@ -381,7 +381,7 @@ export default function ChatInterface() {
               errorMessage = 'Microphone access was denied. Enable it in browser settings and refresh.';
               setMicPermissionGranted(false);
               break;
-          case 'aborted': break; 
+          case 'aborted': break;
           case 'network': errorMessage = 'Network error with speech service. Check connection.'; break;
           case 'service-not-allowed':
               errorTitle = 'Speech Service Unavailable';
@@ -396,18 +396,18 @@ export default function ChatInterface() {
               break;
           default: if (event.message) { errorMessage = `Error: ${event.message}`; } break;
       }
-      
+
       if (event.error !== 'aborted' && event.error !== 'no-speech') { // Don't toast for these common, less critical errors
         toast({ variant: 'destructive', title: errorTitle, description: errorMessage });
       }
-      setIsRecording(false); 
+      setIsRecording(false);
     };
 
     recognitionInstance.onend = () => {
       setIsRecording(false);
       setShouldSubmitVoiceInput(true); // Always attempt to submit after STT ends
     };
-    
+
     recognitionRef.current = recognitionInstance;
 
     return () => {
@@ -421,7 +421,7 @@ export default function ChatInterface() {
             clearTimeout(micReactivationTimerRef.current);
       }
     };
-  }, [toast]); 
+  }, [toast]);
 
 
   useEffect(() => {
@@ -430,7 +430,7 @@ export default function ChatInterface() {
       if (input.trim() && !isLoading) {
         handleSubmit({isVoiceSubmission: true});
       }
-      setShouldSubmitVoiceInput(false); 
+      setShouldSubmitVoiceInput(false);
     }
   }, [shouldSubmitVoiceInput, input, isLoading, handleSubmit]);
 
@@ -451,11 +451,11 @@ export default function ChatInterface() {
       });
       return;
     }
-    
+
     if (!recognitionRef.current) return;
 
     if (isRecording) {
-      recognitionRef.current.stop(); 
+      recognitionRef.current.stop();
     } else {
       try {
         let permissionState = 'prompt';
@@ -477,11 +477,11 @@ export default function ChatInterface() {
           });
           return;
         }
-        
+
         if (permissionState !== 'granted') {
           try {
             const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
-            stream.getTracks().forEach(track => track.stop()); 
+            stream.getTracks().forEach(track => track.stop());
             setMicPermissionGranted(true);
           } catch (err) {
              console.error('Error accessing microphone:', err);
@@ -499,14 +499,14 @@ export default function ChatInterface() {
                   description: 'Could not access the microphone. Ensure it is connected and not in use by another application.',
                 });
             }
-            return; 
+            return;
           }
         } else {
-           setMicPermissionGranted(true); 
+           setMicPermissionGranted(true);
         }
-        
+
         setLastInputMethod('voice');
-        setInput(''); 
+        setInput('');
         recognitionRef.current.start();
         setIsRecording(true);
         toast({
@@ -514,7 +514,7 @@ export default function ChatInterface() {
           description: "Using your browser's speech recognition. Stops on pause or click.",
         });
 
-      } catch (err) { 
+      } catch (err) {
         console.error('Unexpected error in handleMicClick:', err);
         toast({
             variant: 'destructive',
@@ -524,9 +524,9 @@ export default function ChatInterface() {
       }
     }
   };
-  
+
   const showMicPermissionAlert = micPermissionGranted === false && !isRecording;
-  
+
   const handleFormSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     handleSubmit();
@@ -614,7 +614,7 @@ export default function ChatInterface() {
             }}
             placeholder={isRecording ? "Listening..." : (speechRecognitionSupported ? "Ask Karen anything or use mic..." : "Ask Karen anything (mic not supported)...")}
             className="flex-1 text-sm md:text-base h-11 md:h-12 rounded-lg focus-visible:ring-primary focus-visible:ring-offset-0"
-            disabled={isLoading || (isRecording && !input)} 
+            disabled={isLoading || (isRecording && !input)}
             aria-label="Chat input"
           />
           <Button

--- a/ui_launchers/web_ui/src/components/chat/ModernChatInterface.tsx
+++ b/ui_launchers/web_ui/src/components/chat/ModernChatInterface.tsx
@@ -2,7 +2,7 @@
 
 /**
  * Modern Chat Interface with AG-UI + CopilotKit Integration
- * 
+ *
  * This component replaces the legacy ChatInterface with a modern implementation that:
  * - Uses AG-Grid for conversation management and history
  * - Integrates CopilotKit for AI-powered assistance
@@ -26,11 +26,11 @@ import { Separator } from '@/components/ui/separator';
 import { Progress } from '@/components/ui/progress';
 
 // Icons
-import { 
-  MessageSquare, 
-  Send, 
-  Bot, 
-  User, 
+import {
+  MessageSquare,
+  Send,
+  Bot,
+  User,
   Sparkles,
   Grid3X3,
   BarChart3,
@@ -234,7 +234,7 @@ export const ModernChatInterface: React.FC<ModernChatInterfaceProps> = ({
   const initializeChatData = async () => {
     try {
       setIsLoading(true);
-      
+
       // Load conversations
       const userConversations = await chatService.getUserConversations(user!.user_id);
       const conversationRows: ConversationRow[] = userConversations.map(conv => ({
@@ -243,20 +243,20 @@ export const ModernChatInterface: React.FC<ModernChatInterfaceProps> = ({
         messageCount: conv.messages.length,
         lastMessage: conv.messages[conv.messages.length - 1]?.content || 'No messages',
         timestamp: conv.updatedAt,
-        participants: [user!.email],
+        participants: [user?.email ?? 'Unknown'],
         status: 'active' as const,
         sentiment: 'neutral' as const,
         aiConfidence: 0.85,
         tags: ['general']
       }));
-      
+
       setConversations(conversationRows);
-      
+
       // If no current conversation, create one
       if (!currentConversationId && conversationRows.length === 0) {
         await createNewConversation();
       }
-      
+
     } catch (error) {
       console.error('Failed to initialize chat data:', error);
       toast({
@@ -273,7 +273,7 @@ export const ModernChatInterface: React.FC<ModernChatInterfaceProps> = ({
     try {
       const { conversationId, sessionId } = await chatService.createConversationSession(user!.user_id);
       setCurrentConversationId(conversationId);
-      
+
       // Add to conversations list
       const newConversation: ConversationRow = {
         id: conversationId,
@@ -281,16 +281,16 @@ export const ModernChatInterface: React.FC<ModernChatInterfaceProps> = ({
         messageCount: 0,
         lastMessage: 'Conversation started',
         timestamp: new Date(),
-        participants: [user!.email],
+        participants: [user?.email ?? 'Unknown'],
         status: 'active',
         sentiment: 'neutral',
         aiConfidence: 0.0,
         tags: ['new']
       };
-      
+
       setConversations(prev => [newConversation, ...prev]);
       setMessages([]);
-      
+
     } catch (error) {
       console.error('Failed to create conversation:', error);
       toast({
@@ -357,8 +357,8 @@ export const ModernChatInterface: React.FC<ModernChatInterfaceProps> = ({
       }
 
       // Update conversation in grid
-      setConversations(prev => prev.map(conv => 
-        conv.id === currentConversationId 
+      setConversations(prev => prev.map(conv =>
+        conv.id === currentConversationId
           ? {
               ...conv,
               messageCount: conv.messageCount + 2,
@@ -389,7 +389,7 @@ export const ModernChatInterface: React.FC<ModernChatInterfaceProps> = ({
       suggestions: ['Consider exploring advanced features', 'Review documentation'],
       summary: 'Productive conversation about technical topics'
     };
-    
+
     return analysis[type as keyof typeof analysis] || analysis;
   };
 
@@ -401,7 +401,7 @@ export const ModernChatInterface: React.FC<ModernChatInterfaceProps> = ({
       helpful: "I understand what you're looking for. Here's how I can assist:",
       creative: "That's an interesting challenge! Let's explore some innovative solutions."
     };
-    
+
     return suggestions[tone as keyof typeof suggestions] || suggestions.helpful;
   };
 
@@ -417,7 +417,7 @@ export const ModernChatInterface: React.FC<ModernChatInterfaceProps> = ({
 
   const MessageComponent = ({ message }: { message: ChatMessage }) => {
     const isUser = message.role === 'user';
-    
+
     return (
       <div className={`flex gap-3 mb-4 ${isUser ? 'flex-row-reverse' : 'flex-row'}`}>
         <div className={`flex-shrink-0 w-8 h-8 rounded-full flex items-center justify-center ${
@@ -425,17 +425,17 @@ export const ModernChatInterface: React.FC<ModernChatInterfaceProps> = ({
         }`}>
           {isUser ? <User className="h-4 w-4" /> : <Bot className="h-4 w-4" />}
         </div>
-        
+
         <div className={`flex-1 max-w-[80%] ${isUser ? 'text-right' : 'text-left'}`}>
           <div className={`inline-block p-3 rounded-lg ${
-            isUser 
-              ? 'bg-primary text-primary-foreground' 
+            isUser
+              ? 'bg-primary text-primary-foreground'
               : 'bg-muted border'
           }`}>
             <div className="whitespace-pre-wrap break-words">
               {message.content}
             </div>
-            
+
             {message.aiData && (
               <div className="mt-2 pt-2 border-t border-border/20">
                 <div className="flex items-center gap-2 text-xs opacity-70">
@@ -451,10 +451,10 @@ export const ModernChatInterface: React.FC<ModernChatInterfaceProps> = ({
               </div>
             )}
           </div>
-          
+
           <div className="flex items-center gap-2 mt-1 text-xs text-muted-foreground">
             <span>{message.timestamp.toLocaleTimeString()}</span>
-            
+
             {!isUser && (
               <div className="flex items-center gap-1">
                 <Button variant="ghost" size="sm" className="h-6 w-6 p-0">
@@ -493,7 +493,7 @@ export const ModernChatInterface: React.FC<ModernChatInterfaceProps> = ({
               <MessageComponent key={message.id} message={message} />
             ))
           )}
-          
+
           {isTyping && (
             <div className="flex gap-3 mb-4">
               <div className="flex-shrink-0 w-8 h-8 rounded-full bg-muted flex items-center justify-center">
@@ -509,7 +509,7 @@ export const ModernChatInterface: React.FC<ModernChatInterfaceProps> = ({
               </div>
             </div>
           )}
-          
+
           <div ref={messagesEndRef} />
         </div>
       </ScrollArea>
@@ -543,7 +543,7 @@ export const ModernChatInterface: React.FC<ModernChatInterfaceProps> = ({
             }}
             disabled={isLoading || isTyping}
           />
-          <Button 
+          <Button
             onClick={() => sendMessage(inputValue)}
             disabled={!inputValue.trim() || isLoading || isTyping}
             size="sm"
@@ -555,7 +555,7 @@ export const ModernChatInterface: React.FC<ModernChatInterfaceProps> = ({
             )}
           </Button>
         </div>
-        
+
         {/* Quick Actions */}
         <div className="flex items-center gap-2 mt-2">
           <Button
@@ -625,7 +625,7 @@ export const ModernChatInterface: React.FC<ModernChatInterfaceProps> = ({
             <p className="text-xs text-muted-foreground">In current conversation</p>
           </CardContent>
         </Card>
-        
+
         <Card>
           <CardHeader className="pb-2">
             <CardTitle className="text-sm font-medium">AI Confidence</CardTitle>
@@ -635,7 +635,7 @@ export const ModernChatInterface: React.FC<ModernChatInterfaceProps> = ({
             <p className="text-xs text-muted-foreground">Average response quality</p>
           </CardContent>
         </Card>
-        
+
         <Card>
           <CardHeader className="pb-2">
             <CardTitle className="text-sm font-medium">Active Conversations</CardTitle>
@@ -646,7 +646,7 @@ export const ModernChatInterface: React.FC<ModernChatInterfaceProps> = ({
           </CardContent>
         </Card>
       </div>
-      
+
       <Card>
         <CardHeader>
           <CardTitle>Conversation Insights</CardTitle>
@@ -681,7 +681,7 @@ export const ModernChatInterface: React.FC<ModernChatInterfaceProps> = ({
                 AG-UI + CopilotKit
               </Badge>
             </CardTitle>
-            
+
             {enableFullscreen && (
               <Button
                 variant="ghost"
@@ -713,15 +713,15 @@ export const ModernChatInterface: React.FC<ModernChatInterfaceProps> = ({
                   </TabsTrigger>
                 </TabsList>
               </div>
-              
+
               <TabsContent value="chat" className="flex-1 m-0">
                 <ChatTab />
               </TabsContent>
-              
+
               <TabsContent value="conversations" className="flex-1 m-0 p-4">
                 <ConversationsTab />
               </TabsContent>
-              
+
               <TabsContent value="analytics" className="flex-1 m-0">
                 <AnalyticsTab />
               </TabsContent>

--- a/ui_launchers/web_ui/src/components/dashboard/Dashboard.tsx
+++ b/ui_launchers/web_ui/src/components/dashboard/Dashboard.tsx
@@ -20,7 +20,7 @@ export default function Dashboard() {
       ) : (
         <>
           <h2 className="text-2xl font-semibold">My Dashboard</h2>
-          <p className="text-muted-foreground">Welcome, {user.email}</p>
+          <p className="text-muted-foreground">Welcome, {user.email ?? 'User'}</p>
           <UsageAnalyticsCharts />
         </>
       )}

--- a/ui_launchers/web_ui/src/components/dashboard/__tests__/Dashboard.test.tsx
+++ b/ui_launchers/web_ui/src/components/dashboard/__tests__/Dashboard.test.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { vi, test } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import Dashboard from '../Dashboard';
+
+// Mock authentication context
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => ({
+    user: {
+      user_id: 'user1',
+      roles: ['user'],
+      tenant_id: 'tenant1',
+      two_factor_enabled: false,
+      preferences: {} as any,
+      email: undefined
+    }
+  })
+}));
+
+// Mock dashboard dependencies
+vi.mock('../monitoring/health-dashboard', () => ({
+  HealthDashboard: () => <div />
+}));
+
+vi.mock('../analytics/UsageAnalyticsCharts', () => ({
+  __esModule: true,
+  default: () => <div />
+}));
+
+vi.mock('../analytics/AuditLogTable', () => ({
+  __esModule: true,
+  default: () => <div />
+}));
+
+test('renders fallback when user email is undefined', () => {
+  render(<Dashboard />);
+  expect(screen.getByText('Welcome, User')).toBeInTheDocument();
+});

--- a/ui_launchers/web_ui/src/components/files/FilePermissionManager.tsx
+++ b/ui_launchers/web_ui/src/components/files/FilePermissionManager.tsx
@@ -3,15 +3,15 @@
 import React, { useState, useMemo, useCallback } from 'react';
 import { AgGridReact } from 'ag-grid-react';
 import { ColDef, GridReadyEvent, SelectionChangedEvent } from 'ag-grid-community';
-import { 
-  Shield, 
-  Users, 
-  User, 
-  Lock, 
-  Unlock, 
-  Eye, 
-  Edit, 
-  Download, 
+import {
+  Shield,
+  Users,
+  User,
+  Lock,
+  Unlock,
+  Eye,
+  Edit,
+  Download,
   Trash2,
   Plus,
   Settings,
@@ -22,20 +22,20 @@ import {
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { 
-  Dialog, 
-  DialogContent, 
-  DialogHeader, 
-  DialogTitle, 
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
   DialogTrigger,
   DialogFooter
 } from '@/components/ui/dialog';
-import { 
-  Select, 
-  SelectContent, 
-  SelectItem, 
-  SelectTrigger, 
-  SelectValue 
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
 } from '@/components/ui/select';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -164,12 +164,12 @@ const StatusRenderer = ({ data }: { data: FilePermission }) => {
   );
 };
 
-const ActionsRenderer = ({ 
-  data, 
-  onEdit, 
+const ActionsRenderer = ({
+  data,
+  onEdit,
   onDelete,
-  readOnly 
-}: { 
+  readOnly
+}: {
   data: FilePermission;
   onEdit: (permission: FilePermission) => void;
   onDelete: (permissionId: string) => void;
@@ -261,7 +261,7 @@ export const FilePermissionManager: React.FC<FilePermissionManagerProps> = ({
       headerName: 'Expires',
       field: 'expires_at',
       width: 150,
-      cellRenderer: ({ value }: { value?: string }) => 
+      cellRenderer: ({ value }: { value?: string }) =>
         value ? formatDate(value) : <span className="text-muted-foreground">Never</span>,
       filter: 'agDateColumnFilter'
     },
@@ -340,10 +340,10 @@ export const FilePermissionManager: React.FC<FilePermissionManagerProps> = ({
   // Permission statistics
   const permissionStats = useMemo(() => {
     const activePermissions = currentPermissions.filter(p => p.is_active);
-    const expiredPermissions = currentPermissions.filter(p => 
+    const expiredPermissions = currentPermissions.filter(p =>
       p.expires_at && new Date(p.expires_at) < new Date()
     );
-    
+
     const typeDistribution = currentPermissions.reduce((acc, p) => {
       acc[p.permission_type] = (acc[p.permission_type] || 0) + 1;
       return acc;
@@ -407,7 +407,7 @@ export const FilePermissionManager: React.FC<FilePermissionManagerProps> = ({
                             <SelectContent>
                               {availableUsers.map(user => (
                                 <SelectItem key={user.id} value={user.id}>
-                                  {user.name} ({user.email})
+                                  {user.name} ({user.email ?? 'Unknown'})
                                 </SelectItem>
                               ))}
                             </SelectContent>
@@ -522,7 +522,7 @@ export const FilePermissionManager: React.FC<FilePermissionManagerProps> = ({
             </div>
           </CardContent>
         </Card>
-        
+
         <Card>
           <CardContent className="p-4">
             <div className="flex items-center gap-2">
@@ -534,7 +534,7 @@ export const FilePermissionManager: React.FC<FilePermissionManagerProps> = ({
             </div>
           </CardContent>
         </Card>
-        
+
         <Card>
           <CardContent className="p-4">
             <div className="flex items-center gap-2">
@@ -546,7 +546,7 @@ export const FilePermissionManager: React.FC<FilePermissionManagerProps> = ({
             </div>
           </CardContent>
         </Card>
-        
+
         <Card>
           <CardContent className="p-4">
             <div className="flex items-center gap-2">
@@ -566,7 +566,7 @@ export const FilePermissionManager: React.FC<FilePermissionManagerProps> = ({
           <CardTitle>Current Permissions</CardTitle>
         </CardHeader>
         <CardContent className="p-0">
-          <div 
+          <div
             className="ag-theme-alpine w-full"
             style={{ height: '400px' }}
           >
@@ -583,7 +583,7 @@ export const FilePermissionManager: React.FC<FilePermissionManagerProps> = ({
               getRowStyle={(params) => {
                 const permission = params.data as FilePermission;
                 const isExpired = permission.expires_at && new Date(permission.expires_at) < new Date();
-                
+
                 if (!permission.is_active || isExpired) {
                   return { backgroundColor: '#fef2f2', opacity: 0.7 };
                 }

--- a/ui_launchers/web_ui/src/types/auth.ts
+++ b/ui_launchers/web_ui/src/types/auth.ts
@@ -1,6 +1,6 @@
 export interface User {
   user_id: string;
-  email: string;
+  email?: string;
   roles: string[];
   tenant_id: string;
   two_factor_enabled: boolean;
@@ -65,7 +65,7 @@ export interface AuthContextType {
 /**
  * Authentication step types for the authentication flow
  */
-export type AuthenticationStep = 
+export type AuthenticationStep =
   | 'initial'
   | 'validating'
   | 'authenticating'
@@ -76,7 +76,7 @@ export type AuthenticationStep =
 /**
  * Authentication error types for comprehensive error classification
  */
-export type AuthenticationErrorType = 
+export type AuthenticationErrorType =
   | 'invalid_credentials'
   | 'network_error'
   | 'security_block'
@@ -99,7 +99,7 @@ export type FeedbackMessageType = 'success' | 'error' | 'warning' | 'info';
 /**
  * Error categories for classification system
  */
-export type ErrorCategory = 
+export type ErrorCategory =
   | 'authentication'
   | 'validation'
   | 'network'
@@ -115,7 +115,7 @@ export type ErrorSeverity = 'low' | 'medium' | 'high' | 'critical';
 /**
  * User action types for error handling guidance
  */
-export type UserAction = 
+export type UserAction =
   | 'retry'
   | 'correct_input'
   | 'wait'
@@ -298,4 +298,3 @@ export interface EnhancedAuthContextType extends AuthContextType {
   setFeedback: (message: FeedbackMessage) => void;
   validateCredentials: (credentials: LoginCredentials) => ValidationErrors;
 }
-


### PR DESCRIPTION
## Summary
- make `User.email` optional in auth types
- guard UI components and tests against missing user email
- add test for dashboard greeting when email is undefined

## Testing
- `pre-commit run --files ui_launchers/web_ui/src/types/auth.ts ui_launchers/web_ui/src/components/dashboard/Dashboard.tsx ui_launchers/web_ui/src/components/auth/UserProfile.tsx ui_launchers/web_ui/src/components/auth/__tests__/auth-integration.manual.test.tsx ui_launchers/web_ui/src/components/files/FilePermissionManager.tsx ui_launchers/web_ui/src/components/chat/ChatInterface.tsx ui_launchers/web_ui/src/components/chat/ModernChatInterface.tsx ui_launchers/web_ui/src/components/dashboard/__tests__/Dashboard.test.tsx`
- `cd ui_launchers/web_ui && npm test` (fails: 18 failed, 11 passed)


------
https://chatgpt.com/codex/tasks/task_e_6899f34ee7908324a9ae18dae9737208