### PR TITLE
feat: allow configurable API base URL

### DIFF
--- a/ui_launchers/web_ui/README.md
+++ b/ui_launchers/web_ui/README.md
@@ -127,7 +127,7 @@ Create a `.env.local` file in the web UI directory:
 
 ```env
 # Backend Configuration
-KAREN_BACKEND_URL=http://localhost:8000
+NEXT_PUBLIC_API_BASE_URL=http://127.0.0.1:8000
 KAREN_API_KEY=your_api_key_here
 
 # Firebase Configuration (if using Firebase features)
@@ -334,7 +334,7 @@ CMD ["npm", "start"]
 curl http://localhost:8000/api/health
 
 # Verify environment variables
-echo $KAREN_BACKEND_URL
+echo $NEXT_PUBLIC_API_BASE_URL
 ```
 
 #### Build Errors

--- a/ui_launchers/web_ui/src/lib/endpoint-config.ts
+++ b/ui_launchers/web_ui/src/lib/endpoint-config.ts
@@ -64,10 +64,13 @@ export class ConfigManager {
    * Load configuration from environment variables with defaults
    */
   private loadConfiguration(): EndpointConfig {
-    // Force localhost configuration for development to prevent external IP issues
-    const backendUrl = 'http://localhost:8000';
-    const environment = 'local' as Environment;
-    const networkMode = 'localhost' as NetworkMode;
+    // Allow explicit environment configuration with sensible defaults
+    const backendUrl = this.getEnvVar(
+      'API_BASE_URL',
+      this.getEnvVar('KAREN_BACKEND_URL', 'http://localhost:8000')
+    );
+    const environment = this.getEnvVar('KAREN_ENVIRONMENT', 'local') as Environment;
+    const networkMode = this.getEnvVar('KAREN_NETWORK_MODE', 'localhost') as NetworkMode;
     
     // Parse fallback URLs
     const fallbackUrlsStr = this.getEnvVar('KAREN_FALLBACK_BACKEND_URLS', '');
@@ -101,7 +104,10 @@ export class ConfigManager {
       const value = process.env[nextPublicKey] || process.env[key] || defaultValue;
       
       // Debug logging for environment variable resolution
-      if (typeof console !== 'undefined' && key === 'KAREN_BACKEND_URL') {
+      if (
+        typeof console !== 'undefined' &&
+        (key === 'KAREN_BACKEND_URL' || key === 'API_BASE_URL')
+      ) {
         console.log(`🔍 Environment variable lookup for ${key}:`, {
           nextPublicKey,
           nextPublicValue: process.env[nextPublicKey],
@@ -165,9 +171,11 @@ export class ConfigManager {
    */
   private detectEnvironment(): void {
     // Skip environment detection if explicit configuration is provided
-    const hasExplicitConfig = this.getEnvVar('KAREN_BACKEND_URL', '') !== '' ||
-                             this.getEnvVar('KAREN_ENVIRONMENT', '') !== '' ||
-                             this.getEnvVar('KAREN_NETWORK_MODE', '') !== '';
+    const hasExplicitConfig =
+      this.getEnvVar('API_BASE_URL', '') !== '' ||
+      this.getEnvVar('KAREN_BACKEND_URL', '') !== '' ||
+      this.getEnvVar('KAREN_ENVIRONMENT', '') !== '' ||
+      this.getEnvVar('KAREN_NETWORK_MODE', '') !== '';
     
     if (hasExplicitConfig) {
       // Use explicit configuration, don't override with auto-detection

--- a/ui_launchers/web_ui/src/services/chatService.ts
+++ b/ui_launchers/web_ui/src/services/chatService.ts
@@ -82,8 +82,10 @@ export class ChatService {
         sessionId: response.data.conversation.session_id || sessionId
       };
     } catch (error) {
-      console.error('ChatService: Failed to create conversation session:', error);
-      throw error;
+      console.error('ChatService.createConversationSession failed', error);
+      throw new Error(
+        'Cannot reach Kari API. Check that the backend is running on http://127.0.0.1:8000 and that NEXT_PUBLIC_API_BASE_URL is set.'
+      );
     }
   }
 


### PR DESCRIPTION
## Summary
- allow overriding API endpoint via `NEXT_PUBLIC_API_BASE_URL`
- improve conversation session error message when backend unreachable
- document API base URL in Web UI README

## Testing
- `npm test` *(fails: Tests failed. Watching for file changes...)*

------
https://chatgpt.com/codex/tasks/task_e_6899ff26b550832491268f31329b07a0