### PR TITLE
fix: handle missing user roles in header

### DIFF
--- a/ui_launchers/web_ui/src/components/layout/AuthenticatedHeader.tsx
+++ b/ui_launchers/web_ui/src/components/layout/AuthenticatedHeader.tsx
@@ -68,7 +68,9 @@ export const AuthenticatedHeader: React.FC = () => {
               <div className="flex flex-col space-y-1">
                 <p className="text-sm font-medium leading-none">{user?.email ?? user?.user_id ?? ''}</p>
                 <p className="text-xs leading-none text-muted-foreground">
-                  {user.roles.join(', ')}
+                  {Array.isArray(user.roles)
+                    ? user.roles.join(', ')
+                    : user.roles ?? ''}
                 </p>
               </div>
             </DropdownMenuLabel>

--- a/ui_launchers/web_ui/src/components/layout/__tests__/AuthenticatedHeader.test.tsx
+++ b/ui_launchers/web_ui/src/components/layout/__tests__/AuthenticatedHeader.test.tsx
@@ -3,16 +3,36 @@ import userEvent from '@testing-library/user-event';
 import { vi } from 'vitest';
 import { AuthenticatedHeader } from '../AuthenticatedHeader';
 
+const mockUseAuth = vi.fn();
 vi.mock('@/contexts/AuthContext', () => ({
-  useAuth: () => ({
-    user: { user_id: 'user123', roles: ['user'] },
-    logout: vi.fn(),
-  }),
+  useAuth: () => mockUseAuth(),
 }));
 
+beforeEach(() => {
+  mockUseAuth.mockReset();
+});
+
 test('renders without crashing when user email is undefined', async () => {
+  mockUseAuth.mockReturnValue({
+    user: { user_id: 'user123', roles: ['user'] },
+    logout: vi.fn(),
+  });
+
   render(<AuthenticatedHeader />);
   expect(screen.getByText('U')).toBeInTheDocument();
   await userEvent.click(screen.getByRole('button'));
   expect(screen.getByText('user123')).toBeInTheDocument();
 });
+
+test('renders without crashing when user roles are undefined', async () => {
+  mockUseAuth.mockReturnValue({
+    user: { user_id: 'user123' },
+    logout: vi.fn(),
+  });
+
+  render(<AuthenticatedHeader />);
+  expect(screen.getByText('U')).toBeInTheDocument();
+  await userEvent.click(screen.getByRole('button'));
+  expect(screen.getByText('user123')).toBeInTheDocument();
+});
+


### PR DESCRIPTION
## Summary
- prevent crash when user roles are undefined by safely rendering roles
- expand AuthenticatedHeader tests to cover missing roles

## Testing
- `cd ui_launchers/web_ui && npm test` *(fails: Tests failed. Watching for file changes...)*

------
https://chatgpt.com/codex/tasks/task_e_689a4197ef848324b89614fed6a16779