### PR TITLE
feat: register CopilotKit provider

### DIFF
--- a/docs/extension_management_tutorial.md
+++ b/docs/extension_management_tutorial.md
@@ -7,8 +7,10 @@ This tutorial walks through enabling and managing extensions in the AI Karen web
    Set the environment variable `KAREN_ENABLE_EXTENSIONS=true` before starting the web UI. This will replace the plugin sidebar with the new Extension Manager.
 
 2. **Browse extensions**
-   
-   Open the navigation sidebar and select **Extensions**. Categories and breadcrumbs help you drill down to specific providers, models and settings.
+
+    Open the navigation sidebar and select **Extensions**. Categories and breadcrumbs help you drill down to specific providers, models and settings.
+
+   The system now pre-registers **CopilotKit** as a provider. It will appear in the list and requires an API key before use.
 
 3. **Install from marketplace**
    

--- a/examples/llm_integration_example.py
+++ b/examples/llm_integration_example.py
@@ -24,6 +24,7 @@ async def test_llm_utils():
         # Test provider listing
         providers = llm_manager.list_available_providers()
         print(f"Available providers: {providers}")
+        # CopilotKit should now appear in the default provider list
         
         # Test health check
         health = llm_manager.health_check_all()
@@ -51,3 +52,4 @@ async def test_llm_utils():
 
 if __name__ == "__main__":
     asyncio.run(test_llm_utils())
+

--- a/src/ai_karen_engine/integrations/__init__.py
+++ b/src/ai_karen_engine/integrations/__init__.py
@@ -18,6 +18,7 @@ from ai_karen_engine.integrations.video_registry import (
 from ai_karen_engine.integrations.provider_registry import (
     ProviderRegistry,
     ModelInfo,
+    get_provider_registry,
 )
 
 __all__ = [
@@ -26,6 +27,7 @@ __all__ = [
     "LLMProfileRouter",
     "ProviderRegistry",
     "ModelInfo",
+    "get_provider_registry",
     "VoiceRegistry",
     "VoiceProviderBase",
     "DummyVoiceProvider",

--- a/src/ai_karen_engine/integrations/provider_registry.py
+++ b/src/ai_karen_engine/integrations/provider_registry.py
@@ -35,6 +35,21 @@ class ProviderRegistry:
         self._registrations: Dict[str, ProviderRegistration] = {}
         self._instances: Dict[str, Any] = {}
 
+    def register_default_providers(self) -> None:
+        """Register built-in providers."""
+        from ai_karen_engine.integrations.providers.copilotkit_provider import (
+            CopilotKitProvider,
+        )
+
+        self.register_provider(
+            "copilotkit",
+            CopilotKitProvider,
+            description="CopilotKit AI-powered code assistance and contextual suggestions",
+            models=[ModelInfo(name="gpt-4", description="Default CopilotKit model")],
+            requires_api_key=True,
+            default_model="gpt-4",
+        )
+
     def register_provider(
         self,
         name: str,
@@ -76,4 +91,25 @@ class ProviderRegistry:
         if not reg:
             return []
         return [m.name for m in reg.models]
+
+
+# Global registry instance
+_provider_registry: ProviderRegistry | None = None
+
+
+def get_provider_registry() -> ProviderRegistry:
+    """Get or create the global provider registry."""
+    global _provider_registry
+    if _provider_registry is None:
+        _provider_registry = ProviderRegistry()
+        _provider_registry.register_default_providers()
+    return _provider_registry
+
+
+__all__ = [
+    "ModelInfo",
+    "ProviderRegistration",
+    "ProviderRegistry",
+    "get_provider_registry",
+]
 

--- a/tests/test_provider_registry.py
+++ b/tests/test_provider_registry.py
@@ -1,6 +1,7 @@
 from ai_karen_engine.integrations.provider_registry import (
     ProviderRegistry,
     ModelInfo,
+    get_provider_registry,
 )
 
 
@@ -24,4 +25,10 @@ def test_register_and_get_provider():
     assert provider.model == "base"
     assert registry.list_providers() == ["dummy"]
     assert registry.list_models("dummy") == ["base"]
+
+
+def test_default_copilotkit_registration():
+    registry = get_provider_registry()
+    assert "copilotkit" in registry.list_providers()
+    assert "gpt-4" in registry.list_models("copilotkit")
 


### PR DESCRIPTION
## Summary
- add register_default_providers to ProviderRegistry to include CopilotKit
- expose global provider registry with default registration
- document and demonstrate CopilotKit default discovery

## Testing
- `pytest tests/test_provider_registry.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689b500904b88324a27cf0c42cded61d