### PR TITLE
Add provider info for CopilotKit

### DIFF
--- a/src/ai_karen_engine/integrations/llm_registry.py
+++ b/src/ai_karen_engine/integrations/llm_registry.py
@@ -12,8 +12,14 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Type
 
 from ai_karen_engine.integrations.llm_utils import LLMProviderBase
-from ai_karen_engine.integrations.providers import (DeepseekProvider, GeminiProvider, HuggingFaceProvider,
-                        OllamaProvider, OpenAIProvider, CopilotKitProvider)
+from ai_karen_engine.integrations.providers import (
+    CopilotKitProvider,
+    DeepseekProvider,
+    GeminiProvider,
+    HuggingFaceProvider,
+    OllamaProvider,
+    OpenAIProvider,
+)
 
 logger = logging.getLogger("kari.llm_registry")
 
@@ -165,7 +171,6 @@ class LLMRegistry:
             with open(self.registry_path, "w") as f:
                 json.dump(data, f, indent=2)
 
-
         except Exception as ex:
             logger.error(f"Could not save registry to {self.registry_path}: {ex}")
 
@@ -263,10 +268,14 @@ class LLMRegistry:
         registration = self._registrations[name]
         info = asdict(registration)
 
-        # Add runtime info if provider is instantiated
-        if name in self._providers:
+        # Ensure provider is instantiated to gather runtime metadata
+        provider = self._providers.get(name)
+        if provider is None:
+            provider = self.get_provider(name)
+
+        if provider:
             try:
-                provider_info = self._providers[name].get_provider_info()
+                provider_info = provider.get_provider_info()
                 info.update(provider_info)
             except Exception as ex:
                 logger.warning(f"Could not get provider info for {name}: {ex}")

--- a/src/ai_karen_engine/integrations/providers/copilotkit_provider.py
+++ b/src/ai_karen_engine/integrations/providers/copilotkit_provider.py
@@ -1,18 +1,17 @@
 """CopilotKit integration provider for AI-powered development assistance."""
 
 import asyncio
-import json
 import logging
-from datetime import datetime
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List
 
-from ai_karen_engine.integrations.providers.base import BaseLLMProvider
 from ai_karen_engine.hooks.hook_mixin import HookMixin
+from ai_karen_engine.integrations.providers.base import BaseLLMProvider
 
 logger = logging.getLogger(__name__)
 
 try:
     import copilotkit
+
     COPILOTKIT_AVAILABLE = True
 except ImportError:
     COPILOTKIT_AVAILABLE = False
@@ -21,199 +20,213 @@ except ImportError:
 
 class CopilotKitProvider(BaseLLMProvider, HookMixin):
     """CopilotKit integration provider for AI-powered development assistance."""
-    
+
     def __init__(self, config: Dict[str, Any]):
         super().__init__(config)
         self.provider_name = "copilotkit"
         self.api_key = config.get("api_key")
         self.base_url = config.get("base_url", "https://api.copilotkit.ai")
-        self.models = config.get("models", {
-            "completion": "gpt-4",
-            "chat": "gpt-4",
-            "embedding": "text-embedding-ada-002"
-        })
-        self.features = config.get("features", {
-            "code_completion": True,
-            "contextual_suggestions": True,
-            "debugging_assistance": True,
-            "documentation_generation": True,
-            "chat_assistance": True
-        })
-        
+        self.models = config.get(
+            "models",
+            {
+                "completion": "gpt-4",
+                "chat": "gpt-4",
+                "embedding": "text-embedding-ada-002",
+            },
+        )
+        self.features = config.get(
+            "features",
+            {
+                "code_completion": True,
+                "contextual_suggestions": True,
+                "debugging_assistance": True,
+                "documentation_generation": True,
+                "chat_assistance": True,
+            },
+        )
+
         # Initialize CopilotKit client if available
         if COPILOTKIT_AVAILABLE and self.api_key:
             self._init_copilot_client()
         else:
-            logger.warning("CopilotKit client not initialized - API key missing or library unavailable")
+            logger.warning(
+                "CopilotKit client not initialized - API key missing or library unavailable"
+            )
             self.client = None
-        
+
         # Register hooks
         asyncio.create_task(self._register_copilot_hooks())
-    
+
     def _init_copilot_client(self):
         """Initialize CopilotKit client."""
         try:
             # Initialize CopilotKit client (pseudo-code as actual API may vary)
             self.client = copilotkit.Client(
-                api_key=self.api_key,
-                base_url=self.base_url
+                api_key=self.api_key, base_url=self.base_url
             )
             logger.info("CopilotKit client initialized successfully")
         except Exception as e:
             logger.error(f"Failed to initialize CopilotKit client: {e}")
             self.client = None
-    
+
     async def _register_copilot_hooks(self):
         """Register CopilotKit-specific hooks."""
         try:
             # Code completion hooks
             await self.register_hook(
-                'code_completion_request',
-                self._handle_code_completion,
-                priority=80
+                "code_completion_request", self._handle_code_completion, priority=80
             )
-            
+
             # Code analysis hooks
             await self.register_hook(
-                'code_analysis_request',
-                self._handle_code_analysis,
-                priority=80
+                "code_analysis_request", self._handle_code_analysis, priority=80
             )
-            
+
             # Documentation generation hooks
             await self.register_hook(
-                'documentation_generation_request',
+                "documentation_generation_request",
                 self._handle_documentation_generation,
-                priority=80
+                priority=80,
             )
-            
+
             # Contextual suggestions hooks
             await self.register_hook(
-                'contextual_suggestions_request',
+                "contextual_suggestions_request",
                 self._handle_contextual_suggestions,
-                priority=80
+                priority=80,
             )
-            
+
             logger.info("CopilotKit hooks registered successfully")
-            
+
         except Exception as e:
             logger.error(f"Failed to register CopilotKit hooks: {e}")
-    
-    async def _handle_code_completion(self, context: Dict[str, Any], user_context: Dict[str, Any]) -> Dict[str, Any]:
+
+    async def _handle_code_completion(
+        self, context: Dict[str, Any], user_context: Dict[str, Any]
+    ) -> Dict[str, Any]:
         """Handle code completion requests."""
         try:
-            code_context = context.get('code', '')
-            language = context.get('language', 'javascript')
-            cursor_position = context.get('cursor_position', len(code_context))
-            
-            if not self.features.get('code_completion', False):
-                return {'success': False, 'error': 'Code completion feature disabled'}
-            
+            code_context = context.get("code", "")
+            language = context.get("language", "javascript")
+            cursor_position = context.get("cursor_position", len(code_context))
+
+            if not self.features.get("code_completion", False):
+                return {"success": False, "error": "Code completion feature disabled"}
+
             # Get code completion suggestions
             suggestions = await self.get_code_completion(
                 code_context=code_context,
                 language=language,
-                cursor_position=cursor_position
+                cursor_position=cursor_position,
             )
-            
+
             return {
-                'success': True,
-                'suggestions': suggestions,
-                'provider': 'copilotkit',
-                'language': language
+                "success": True,
+                "suggestions": suggestions,
+                "provider": "copilotkit",
+                "language": language,
             }
-            
+
         except Exception as e:
             logger.error(f"Code completion failed: {e}")
-            return {'success': False, 'error': str(e)}
-    
-    async def _handle_code_analysis(self, context: Dict[str, Any], user_context: Dict[str, Any]) -> Dict[str, Any]:
+            return {"success": False, "error": str(e)}
+
+    async def _handle_code_analysis(
+        self, context: Dict[str, Any], user_context: Dict[str, Any]
+    ) -> Dict[str, Any]:
         """Handle code analysis requests."""
         try:
-            code = context.get('code', '')
-            language = context.get('language', 'javascript')
-            analysis_type = context.get('analysis_type', 'comprehensive')
-            
-            if not self.features.get('debugging_assistance', False):
-                return {'success': False, 'error': 'Code analysis feature disabled'}
-            
+            code = context.get("code", "")
+            language = context.get("language", "javascript")
+            analysis_type = context.get("analysis_type", "comprehensive")
+
+            if not self.features.get("debugging_assistance", False):
+                return {"success": False, "error": "Code analysis feature disabled"}
+
             # Perform code analysis
             analysis = await self.analyze_code(
-                code=code,
-                language=language,
-                analysis_type=analysis_type
+                code=code, language=language, analysis_type=analysis_type
             )
-            
+
             return {
-                'success': True,
-                'analysis': analysis,
-                'provider': 'copilotkit',
-                'language': language
+                "success": True,
+                "analysis": analysis,
+                "provider": "copilotkit",
+                "language": language,
             }
-            
+
         except Exception as e:
             logger.error(f"Code analysis failed: {e}")
-            return {'success': False, 'error': str(e)}
-    
-    async def _handle_documentation_generation(self, context: Dict[str, Any], user_context: Dict[str, Any]) -> Dict[str, Any]:
+            return {"success": False, "error": str(e)}
+
+    async def _handle_documentation_generation(
+        self, context: Dict[str, Any], user_context: Dict[str, Any]
+    ) -> Dict[str, Any]:
         """Handle documentation generation requests."""
         try:
-            code = context.get('code', '')
-            language = context.get('language', 'javascript')
-            style = context.get('style', 'comprehensive')
-            
-            if not self.features.get('documentation_generation', False):
-                return {'success': False, 'error': 'Documentation generation feature disabled'}
-            
+            code = context.get("code", "")
+            language = context.get("language", "javascript")
+            style = context.get("style", "comprehensive")
+
+            if not self.features.get("documentation_generation", False):
+                return {
+                    "success": False,
+                    "error": "Documentation generation feature disabled",
+                }
+
             # Generate documentation
             documentation = await self.generate_documentation(
-                code=code,
-                language=language,
-                style=style
+                code=code, language=language, style=style
             )
-            
+
             return {
-                'success': True,
-                'documentation': documentation,
-                'provider': 'copilotkit',
-                'language': language
+                "success": True,
+                "documentation": documentation,
+                "provider": "copilotkit",
+                "language": language,
             }
-            
+
         except Exception as e:
             logger.error(f"Documentation generation failed: {e}")
-            return {'success': False, 'error': str(e)}
-    
-    async def _handle_contextual_suggestions(self, context: Dict[str, Any], user_context: Dict[str, Any]) -> Dict[str, Any]:
+            return {"success": False, "error": str(e)}
+
+    async def _handle_contextual_suggestions(
+        self, context: Dict[str, Any], user_context: Dict[str, Any]
+    ) -> Dict[str, Any]:
         """Handle contextual suggestions requests."""
         try:
-            text_context = context.get('context', '')
-            suggestion_type = context.get('type', 'general')
-            
-            if not self.features.get('contextual_suggestions', False):
-                return {'success': False, 'error': 'Contextual suggestions feature disabled'}
-            
+            text_context = context.get("context", "")
+            suggestion_type = context.get("type", "general")
+
+            if not self.features.get("contextual_suggestions", False):
+                return {
+                    "success": False,
+                    "error": "Contextual suggestions feature disabled",
+                }
+
             # Get contextual suggestions
             suggestions = await self.get_contextual_suggestions(
-                context=text_context,
-                suggestion_type=suggestion_type
+                context=text_context, suggestion_type=suggestion_type
             )
-            
+
             return {
-                'success': True,
-                'suggestions': suggestions,
-                'provider': 'copilotkit',
-                'type': suggestion_type
+                "success": True,
+                "suggestions": suggestions,
+                "provider": "copilotkit",
+                "type": suggestion_type,
             }
-            
+
         except Exception as e:
             logger.error(f"Contextual suggestions failed: {e}")
-            return {'success': False, 'error': str(e)}
-    
-    async def get_code_completion(self, code_context: str, language: str, cursor_position: int) -> List[Dict[str, Any]]:
+            return {"success": False, "error": str(e)}
+
+    async def get_code_completion(
+        self, code_context: str, language: str, cursor_position: int
+    ) -> List[Dict[str, Any]]:
         """Get code completion suggestions."""
         if not self.client:
             return await self._fallback_code_completion(code_context, language)
-        
+
         try:
             # Call CopilotKit API for code completion
             response = await self._make_copilot_request(
@@ -223,21 +236,23 @@ class CopilotKitProvider(BaseLLMProvider, HookMixin):
                     "language": language,
                     "cursor_position": cursor_position,
                     "model": self.models.get("completion", "gpt-4"),
-                    "max_suggestions": 5
-                }
+                    "max_suggestions": 5,
+                },
             )
-            
+
             return response.get("suggestions", [])
-            
+
         except Exception as e:
             logger.error(f"CopilotKit code completion failed: {e}")
             return await self._fallback_code_completion(code_context, language)
-    
-    async def analyze_code(self, code: str, language: str, analysis_type: str = "comprehensive") -> Dict[str, Any]:
+
+    async def analyze_code(
+        self, code: str, language: str, analysis_type: str = "comprehensive"
+    ) -> Dict[str, Any]:
         """Analyze code for issues and improvements."""
         if not self.client:
             return await self._fallback_code_analysis(code, language)
-        
+
         try:
             # Call CopilotKit API for code analysis
             response = await self._make_copilot_request(
@@ -246,21 +261,23 @@ class CopilotKitProvider(BaseLLMProvider, HookMixin):
                     "code": code,
                     "language": language,
                     "analysis_type": analysis_type,
-                    "model": self.models.get("completion", "gpt-4")
-                }
+                    "model": self.models.get("completion", "gpt-4"),
+                },
             )
-            
+
             return response.get("analysis", {})
-            
+
         except Exception as e:
             logger.error(f"CopilotKit code analysis failed: {e}")
             return await self._fallback_code_analysis(code, language)
-    
-    async def generate_documentation(self, code: str, language: str, style: str = "comprehensive") -> str:
+
+    async def generate_documentation(
+        self, code: str, language: str, style: str = "comprehensive"
+    ) -> str:
         """Generate documentation for code."""
         if not self.client:
             return await self._fallback_documentation_generation(code, language)
-        
+
         try:
             # Call CopilotKit API for documentation generation
             response = await self._make_copilot_request(
@@ -269,21 +286,23 @@ class CopilotKitProvider(BaseLLMProvider, HookMixin):
                     "code": code,
                     "language": language,
                     "style": style,
-                    "model": self.models.get("completion", "gpt-4")
-                }
+                    "model": self.models.get("completion", "gpt-4"),
+                },
             )
-            
+
             return response.get("documentation", "")
-            
+
         except Exception as e:
             logger.error(f"CopilotKit documentation generation failed: {e}")
             return await self._fallback_documentation_generation(code, language)
-    
-    async def get_contextual_suggestions(self, context: str, suggestion_type: str = "general") -> List[Dict[str, Any]]:
+
+    async def get_contextual_suggestions(
+        self, context: str, suggestion_type: str = "general"
+    ) -> List[Dict[str, Any]]:
         """Get contextual suggestions based on context."""
         if not self.client:
             return await self._fallback_contextual_suggestions(context, suggestion_type)
-        
+
         try:
             # Call CopilotKit API for contextual suggestions
             response = await self._make_copilot_request(
@@ -292,22 +311,24 @@ class CopilotKitProvider(BaseLLMProvider, HookMixin):
                     "context": context,
                     "type": suggestion_type,
                     "model": self.models.get("completion", "gpt-4"),
-                    "max_suggestions": 3
-                }
+                    "max_suggestions": 3,
+                },
             )
-            
+
             return response.get("suggestions", [])
-            
+
         except Exception as e:
             logger.error(f"CopilotKit contextual suggestions failed: {e}")
             return await self._fallback_contextual_suggestions(context, suggestion_type)
-    
-    async def _make_copilot_request(self, endpoint: str, data: Dict[str, Any]) -> Dict[str, Any]:
+
+    async def _make_copilot_request(
+        self, endpoint: str, data: Dict[str, Any]
+    ) -> Dict[str, Any]:
         """Make request to CopilotKit API."""
         # This is a placeholder - actual implementation would depend on CopilotKit's API
         # For now, return mock data
         await asyncio.sleep(0.1)  # Simulate API call
-        
+
         if endpoint == "/completion":
             return {
                 "suggestions": [
@@ -315,7 +336,7 @@ class CopilotKitProvider(BaseLLMProvider, HookMixin):
                         "type": "completion",
                         "content": "// AI-generated code completion",
                         "confidence": 0.9,
-                        "reasoning": "Based on code context and patterns"
+                        "reasoning": "Based on code context and patterns",
                     }
                 ]
             }
@@ -325,7 +346,7 @@ class CopilotKitProvider(BaseLLMProvider, HookMixin):
                     "issues": [],
                     "suggestions": ["Consider adding error handling"],
                     "complexity": "low",
-                    "maintainability": "high"
+                    "maintainability": "high",
                 }
             }
         elif endpoint == "/generate-docs":
@@ -339,76 +360,84 @@ class CopilotKitProvider(BaseLLMProvider, HookMixin):
                         "type": "suggestion",
                         "content": "Consider using async/await for better performance",
                         "confidence": 0.8,
-                        "reasoning": "Improves code readability and error handling"
+                        "reasoning": "Improves code readability and error handling",
                     }
                 ]
             }
-        
+
         return {}
-    
+
     # Fallback methods when CopilotKit is not available
-    async def _fallback_code_completion(self, code_context: str, language: str) -> List[Dict[str, Any]]:
+    async def _fallback_code_completion(
+        self, code_context: str, language: str
+    ) -> List[Dict[str, Any]]:
         """Fallback code completion when CopilotKit is unavailable."""
         return [
             {
                 "type": "completion",
                 "content": f"// Fallback completion for {language}",
                 "confidence": 0.6,
-                "reasoning": "Generated using fallback method"
+                "reasoning": "Generated using fallback method",
             }
         ]
-    
+
     async def _fallback_code_analysis(self, code: str, language: str) -> Dict[str, Any]:
         """Fallback code analysis when CopilotKit is unavailable."""
         return {
             "issues": [],
             "suggestions": ["CopilotKit unavailable - using basic analysis"],
             "complexity": "unknown",
-            "maintainability": "unknown"
+            "maintainability": "unknown",
         }
-    
+
     async def _fallback_documentation_generation(self, code: str, language: str) -> str:
         """Fallback documentation generation when CopilotKit is unavailable."""
         return f"# Documentation\n\nThis {language} code requires documentation. CopilotKit is currently unavailable."
-    
-    async def _fallback_contextual_suggestions(self, context: str, suggestion_type: str) -> List[Dict[str, Any]]:
+
+    async def _fallback_contextual_suggestions(
+        self, context: str, suggestion_type: str
+    ) -> List[Dict[str, Any]]:
         """Fallback contextual suggestions when CopilotKit is unavailable."""
         return [
             {
                 "type": "suggestion",
                 "content": "CopilotKit is currently unavailable for contextual suggestions",
                 "confidence": 0.5,
-                "reasoning": "Fallback response"
+                "reasoning": "Fallback response",
             }
         ]
-    
+
     # BaseLLMProvider interface implementation
     async def generate_response(self, prompt: str, **kwargs) -> str:
         """Generate response using CopilotKit chat model."""
         if not self.client:
-            return "CopilotKit is currently unavailable. Please check your configuration."
-        
+            return (
+                "CopilotKit is currently unavailable. Please check your configuration."
+            )
+
         try:
             response = await self._make_copilot_request(
                 endpoint="/chat",
                 data={
                     "prompt": prompt,
                     "model": self.models.get("chat", "gpt-4"),
-                    **kwargs
-                }
+                    **kwargs,
+                },
             )
-            
+
             return response.get("response", "No response generated")
-            
+
         except Exception as e:
             logger.error(f"CopilotKit response generation failed: {e}")
             return f"Error generating response: {str(e)}"
-    
-    async def generate_completion(self, prompt: str, max_tokens: int = 150, temperature: float = 0.7) -> str:
+
+    async def generate_completion(
+        self, prompt: str, max_tokens: int = 150, temperature: float = 0.7
+    ) -> str:
         """Generate completion using CopilotKit for memory enhancement."""
         if not self.client:
             return await self._fallback_completion(prompt)
-        
+
         try:
             response = await self._make_copilot_request(
                 endpoint="/completion",
@@ -416,40 +445,64 @@ class CopilotKitProvider(BaseLLMProvider, HookMixin):
                     "prompt": prompt,
                     "model": self.models.get("completion", "gpt-4"),
                     "max_tokens": max_tokens,
-                    "temperature": temperature
-                }
+                    "temperature": temperature,
+                },
             )
-            
+
             return response.get("completion", "")
-            
+
         except Exception as e:
             logger.error(f"CopilotKit completion generation failed: {e}")
             return await self._fallback_completion(prompt)
-    
+
     async def _fallback_completion(self, prompt: str) -> str:
         """Fallback completion when CopilotKit is unavailable."""
         # Simple rule-based fallback for memory enhancement
         if "enhance" in prompt.lower():
-            return "Consider adding more specific details and context to improve clarity."
+            return (
+                "Consider adding more specific details and context to improve clarity."
+            )
         elif "categorize" in prompt.lower():
             return "Type: context\nCluster: general\nConfidence: 0.5\nReasoning: Basic categorization applied"
         else:
             return "CopilotKit is currently unavailable for advanced suggestions."
-    
+
     async def stream_response(self, prompt: str, **kwargs):
         """Stream response using CopilotKit."""
         # For now, yield the full response
         response = await self.generate_response(prompt, **kwargs)
         yield response
-    
+
     def get_available_models(self) -> List[str]:
         """Get available CopilotKit models."""
         return list(self.models.values())
-    
+
+    def get_provider_info(self) -> Dict[str, Any]:
+        """Get provider metadata."""
+        return {
+            "name": "copilotkit",
+            "model": self.models.get("completion", ""),
+            "base_url": self.base_url,
+            "has_api_key": bool(self.api_key),
+            "available_models": list({v for v in self.models.values() if v}),
+            "supports_streaming": False,
+            "supports_embeddings": bool(self.models.get("embedding")),
+            "supports_code_completion": self.features.get("code_completion", False),
+            "supports_contextual_suggestions": self.features.get(
+                "contextual_suggestions", False
+            ),
+            "supports_debugging_assistance": self.features.get(
+                "debugging_assistance", False
+            ),
+            "supports_documentation_generation": self.features.get(
+                "documentation_generation", False
+            ),
+        }
+
     def is_available(self) -> bool:
         """Check if CopilotKit is available."""
         return COPILOTKIT_AVAILABLE and self.client is not None
-    
+
     async def get_status(self) -> Dict[str, Any]:
         """Get CopilotKit provider status."""
         return {
@@ -458,5 +511,5 @@ class CopilotKitProvider(BaseLLMProvider, HookMixin):
             "features": self.features,
             "models": self.models,
             "api_configured": bool(self.api_key),
-            "client_initialized": self.client is not None
+            "client_initialized": self.client is not None,
         }


### PR DESCRIPTION
## Summary
- expose provider metadata for CopilotKit, including model, base URL, features and API-key info
- ensure registry attaches runtime provider details when fetching provider info

## Testing
- `pre-commit run --files src/ai_karen_engine/integrations/providers/copilotkit_provider.py src/ai_karen_engine/integrations/llm_registry.py` *(mypy: module is installed, but missing library stubs or py.typed marker)*
- `pytest` *(23 errors, e.g. ModuleNotFoundError: No module named 'ai_karen_engine.auth.auth_service')*


------
https://chatgpt.com/codex/tasks/task_e_689b7e4103b48324830019ccd4317864