### PR TITLE
feat: add caching and pool metrics

### DIFF
--- a/src/ai_karen_engine/clients/database/milvus_client.py
+++ b/src/ai_karen_engine/clients/database/milvus_client.py
@@ -4,34 +4,80 @@ Persona embeddings, upserts, deletes, recall, cosine similarity.
 Updated with async contract compatibility methods.
 """
 
-from pymilvus import (
-    connections, Collection, CollectionSchema, FieldSchema, DataType, utility
-)
+import queue
+from contextlib import contextmanager
+
 import numpy as np
+from pymilvus import (
+    Collection,
+    CollectionSchema,
+    DataType,
+    FieldSchema,
+    connections,
+    utility,
+)
+
+from ai_karen_engine.core.embedding_manager import record_metric
+
 
 class MilvusClient:
-    def __init__(self, collection="persona_embeddings", dim=384, host="localhost", port="19530"):
+    def __init__(
+        self,
+        collection: str = "persona_embeddings",
+        dim: int = 384,
+        host: str = "localhost",
+        port: str = "19530",
+        pool_size: int = 5,
+    ):
         self.collection_name = collection
         self.dim = dim
-        self._connect(host, port)
+        self._host = host
+        self._port = port
+        self.pool_size = pool_size
+        self._pool: queue.Queue[str] = queue.Queue(maxsize=pool_size)
+        self._connect()
         self._ensure_collection()
 
-    def _connect(self, host, port):
-        connections.connect(host=host, port=port)
+    def _connect(self) -> None:
+        for i in range(self.pool_size):
+            alias = f"{self.collection_name}_conn_{i}"
+            connections.connect(alias=alias, host=self._host, port=self._port)
+            self._pool.put(alias)
+
+    @contextmanager
+    def _using(self):
+        alias = self._pool.get()
+        try:
+            yield alias
+        finally:
+            self._pool.put(alias)
 
     def _ensure_collection(self):
-        if not utility.has_collection(self.collection_name):
-            fields = [
-                FieldSchema(name="user_id", dtype=DataType.VARCHAR, is_primary=True, auto_id=False, max_length=64),
-                FieldSchema(name="embedding", dtype=DataType.FLOAT_VECTOR, dim=self.dim),
-            ]
-            schema = CollectionSchema(fields, description="Persona Embeddings")
-            Collection(self.collection_name, schema)
-        self.col = Collection(self.collection_name)
+        with self._using() as alias:
+            if not utility.has_collection(self.collection_name, using=alias):
+                fields = [
+                    FieldSchema(
+                        name="user_id",
+                        dtype=DataType.VARCHAR,
+                        is_primary=True,
+                        auto_id=False,
+                        max_length=64,
+                    ),
+                    FieldSchema(
+                        name="embedding", dtype=DataType.FLOAT_VECTOR, dim=self.dim
+                    ),
+                ]
+                schema = CollectionSchema(fields, description="Persona Embeddings")
+                Collection(self.collection_name, schema, using=alias)
+
+    def pool_utilization(self) -> float:
+        used = self.pool_size - self._pool.qsize()
+        return used / self.pool_size if self.pool_size else 0.0
 
     def embed_persona(self, profile_dict):
         # Plug in your favorite embedding model (local!)
         from sentence_transformers import SentenceTransformer
+
         model = SentenceTransformer("all-MiniLM-L6-v2")
         text = f"{profile_dict.get('name','')}. {profile_dict.get('bio','')}. {' '.join(profile_dict.get('tags',[]))}"
         vec = model.encode([text])[0]
@@ -39,71 +85,104 @@ class MilvusClient:
 
     def upsert_persona_embedding(self, user_id, vec):
         entities = [[user_id], [vec]]
-        self.col.upsert(data=entities)
+        with self._using() as alias:
+            col = Collection(self.collection_name, using=alias)
+            col.upsert(data=entities)
+            record_metric("milvus_pool_utilization", self.pool_utilization())
 
     def get_reference_embedding(self, user_id):
         expr = f'user_id == "{user_id}"'
-        self.col.load()
-        res = self.col.query(expr, output_fields=["embedding"])
+        with self._using() as alias:
+            col = Collection(self.collection_name, using=alias)
+            col.load()
+            res = col.query(expr, output_fields=["embedding"])
+            record_metric("milvus_pool_utilization", self.pool_utilization())
         if not res:
             return None
         return np.array(res[0]["embedding"])
 
     def delete_persona_embedding(self, user_id):
         expr = f'user_id == "{user_id}"'
-        self.col.delete(expr)
+        with self._using() as alias:
+            col = Collection(self.collection_name, using=alias)
+            col.delete(expr)
+            record_metric("milvus_pool_utilization", self.pool_utilization())
 
     def cosine_similarity(self, vec1, vec2):
-        return float(np.dot(vec1, vec2) / (np.linalg.norm(vec1) * np.linalg.norm(vec2) + 1e-7))
+        return float(
+            np.dot(vec1, vec2) / (np.linalg.norm(vec1) * np.linalg.norm(vec2) + 1e-7)
+        )
 
     def search_topk(self, query_vec, k=10):
-        self.col.load()
-        res = self.col.search(
-            data=[query_vec], anns_field="embedding", param={"metric_type": "IP"}, limit=k,
-            output_fields=["user_id"]
+        with self._using() as alias:
+            col = Collection(self.collection_name, using=alias)
+            col.load()
+            res = col.search(
+                data=[query_vec],
+                anns_field="embedding",
+                param={"metric_type": "IP"},
+                limit=k,
+                output_fields=["user_id"],
+            )
+            record_metric("milvus_pool_utilization", self.pool_utilization())
+        return (
+            [(hit.entity.get("user_id"), hit.distance) for hit in res[0]] if res else []
         )
-        return [(hit.entity.get("user_id"), hit.distance) for hit in res[0]] if res else []
 
     async def insert(self, collection_name: str = None, data: dict = None, **kwargs):
         """Async wrapper for upsert operations to maintain contract compatibility."""
         try:
             # Use the existing upsert method for compatibility
-            if data and 'user_id' in data and 'embedding' in data:
-                self.upsert_persona_embedding(data['user_id'], data['embedding'])
-                return data.get('user_id', 'unknown')
+            if data and "user_id" in data and "embedding" in data:
+                self.upsert_persona_embedding(data["user_id"], data["embedding"])
+                return data.get("user_id", "unknown")
             else:
                 # Fallback for generic insert operations
                 entities = []
-                if 'user_id' in kwargs and 'embedding' in kwargs:
-                    entities = [[kwargs['user_id']], [kwargs['embedding']]]
-                    self.col.upsert(data=entities)
-                    return kwargs['user_id']
+                if "user_id" in kwargs and "embedding" in kwargs:
+                    entities = [[kwargs["user_id"]], [kwargs["embedding"]]]
+                    with self._using() as alias:
+                        col = Collection(self.collection_name, using=alias)
+                        col.upsert(data=entities)
+                        record_metric(
+                            "milvus_pool_utilization", self.pool_utilization()
+                        )
+                    return kwargs["user_id"]
                 return None
         except Exception as e:
             raise Exception(f"Milvus insert failed: {e}")
-    
-    async def search(self, collection_name: str = None, query_vectors: list = None, top_k: int = 10, metadata_filter: dict = None, **kwargs):
+
+    async def search(
+        self,
+        collection_name: str = None,
+        query_vectors: list = None,
+        top_k: int = 10,
+        metadata_filter: dict = None,
+        **kwargs,
+    ):
         """Async wrapper for search operations to maintain contract compatibility."""
         try:
             if not query_vectors or len(query_vectors) == 0:
                 return []
-            
+
             query_vec = query_vectors[0]  # Use first query vector
-            
+
             # Use the existing search method
             results = self.search_topk(query_vec, k=top_k)
-            
+
             # Convert to expected format
             formatted_results = []
             for user_id, distance in results:
-                formatted_results.append({
-                    'id': user_id,
-                    'distance': distance,
-                    'metadata': {'user_id': user_id}
-                })
-            
+                formatted_results.append(
+                    {
+                        "id": user_id,
+                        "distance": distance,
+                        "metadata": {"user_id": user_id},
+                    }
+                )
+
             return formatted_results
-            
+
         except Exception as e:
             # Return empty results instead of failing
             return []
@@ -111,7 +190,10 @@ class MilvusClient:
     # Health check
     def health(self):
         try:
-            self.col.load()
+            with self._using() as alias:
+                col = Collection(self.collection_name, using=alias)
+                col.load()
+                record_metric("milvus_pool_utilization", self.pool_utilization())
             return True
         except Exception:
             return False

--- a/src/ai_karen_engine/clients/database/redis_client.py
+++ b/src/ai_karen_engine/clients/database/redis_client.py
@@ -3,16 +3,18 @@ RedisClient: Handles volatile short-term memory, cache, session, fast flush.
 Production: Use redis-py, thread-safe, supports multiple namespaces.
 """
 
-import os
-import logging
-import redis
 import json
+import logging
+import os
+from typing import Any, Dict, Optional
 
-from typing import Optional
+import redis
 
 
 class RedisClient:
-    def __init__(self, url: Optional[str] = None, prefix: str = "kari"):
+    def __init__(
+        self, url: Optional[str] = None, prefix: str = "kari", pool_size: int = 10
+    ) -> None:
         """Initialize the Redis client.
 
         Parameters
@@ -23,52 +25,82 @@ class RedisClient:
             Key prefix for all operations.
         """
 
-        self.prefix = prefix
+        self.prefix: str = prefix
         conn_url = url or os.getenv("REDIS_URL")
-        self.r = None
+        self.pool: Optional[redis.ConnectionPool] = None
+        self.r: Optional[redis.Redis[Any]] = None
         if conn_url:
             try:
-                self.r = redis.Redis.from_url(conn_url)
+                self.pool = redis.ConnectionPool.from_url(
+                    conn_url, max_connections=pool_size
+                )
+                self.r = redis.Redis(connection_pool=self.pool)
                 self.r.ping()
             except Exception as ex:  # pragma: no cover - network may be down
                 logging.getLogger(__name__).warning(
                     "[RedisClient] connection failed: %s", ex
                 )
                 self.r = None
+                self.pool = None
 
-    def _k(self, tenant_id, user_id, kind):
+    def _k(self, tenant_id: str, user_id: str, kind: str) -> str:
         return f"{self.prefix}:{tenant_id}:{user_id}:{kind}"
 
-    def flush_short_term(self, tenant_id, user_id):
+    def flush_short_term(self, tenant_id: str, user_id: str) -> None:
         """Flush all short-term cache for user."""
+        if not self.r:
+            return
         keys = self.r.keys(self._k(tenant_id, user_id, "short_term*"))
         for k in keys:
             self.r.delete(k)
 
-    def flush_long_term(self, tenant_id, user_id):
+    def flush_long_term(self, tenant_id: str, user_id: str) -> None:
         """Flush all long-term cache for user."""
+        if not self.r:
+            return
         keys = self.r.keys(self._k(tenant_id, user_id, "long_term*"))
         for k in keys:
             self.r.delete(k)
 
-    def set_short_term(self, tenant_id, user_id, data):
+    def set_short_term(
+        self, tenant_id: str, user_id: str, data: Dict[str, Any]
+    ) -> None:
+        if not self.r:
+            return
         self.r.set(self._k(tenant_id, user_id, "short_term"), json.dumps(data))
 
-    def get_short_term(self, tenant_id, user_id):
+    def get_short_term(self, tenant_id: str, user_id: str) -> Optional[Dict[str, Any]]:
+        if not self.r:
+            return None
         val = self.r.get(self._k(tenant_id, user_id, "short_term"))
         return json.loads(val) if val else None
 
-    def set_session(self, tenant_id, user_id, sess_data):
+    def set_session(
+        self, tenant_id: str, user_id: str, sess_data: Dict[str, Any]
+    ) -> None:
+        if not self.r:
+            return
         self.r.set(self._k(tenant_id, user_id, "session"), json.dumps(sess_data))
 
-    def get_session(self, tenant_id, user_id):
+    def get_session(self, tenant_id: str, user_id: str) -> Optional[Dict[str, Any]]:
+        if not self.r:
+            return None
         val = self.r.get(self._k(tenant_id, user_id, "session"))
         return json.loads(val) if val else None
 
     # Health
-    def health(self):
+    def health(self) -> bool:
         try:
+            if not self.r:
+                return False
             self.r.ping()
             return True
         except Exception:
             return False
+
+    def pool_utilization(self) -> float:
+        if not self.pool:
+            return 0.0
+        used = self.pool._created_connections - len(self.pool._available_connections)  # type: ignore[attr-defined]
+        max_conn = getattr(self.pool, "max_connections", 0)
+        return used / float(max_conn) if max_conn else 0.0

--- a/src/ai_karen_engine/core/chat_memory_config.py
+++ b/src/ai_karen_engine/core/chat_memory_config.py
@@ -62,6 +62,11 @@ class ChatMemorySettings(BaseSettings):
     # Performance
     batch_size: int = Field(10, description="Batch size for vector ops")
     cache_ttl_seconds: int = Field(300, description="Cache TTL (seconds)")
+    cache_maxsize: int = Field(1000, description="Max cached queries")
+
+    # Connection pooling
+    redis_pool_size: int = Field(10, description="Redis connection pool size")
+    milvus_pool_size: int = Field(5, description="Milvus connection pool size")
 
     if V2:
         model_config = SettingsConfigDict(
@@ -94,9 +99,13 @@ class ProductionAuthSettings(BaseSettings):
     refresh_token_expire_days: int = Field(7, description="Refresh token TTL (days)")
 
     # Password hashing
-    password_hash_rounds: int = Field(12, description="Bcrypt rounds or Argon2 time cost")
+    password_hash_rounds: int = Field(
+        12, description="Bcrypt rounds or Argon2 time cost"
+    )
     password_hash_algorithm: str = Field(
-        "bcrypt", description="Password hashing algorithm (bcrypt or argon2)", json_schema_extra={"env": "AUTH_PASSWORD_HASH_ALGORITHM"}
+        "bcrypt",
+        description="Password hashing algorithm (bcrypt or argon2)",
+        json_schema_extra={"env": "AUTH_PASSWORD_HASH_ALGORITHM"},
     )
 
     # Session management

--- a/src/ai_karen_engine/core/milvus_client.py
+++ b/src/ai_karen_engine/core/milvus_client.py
@@ -53,6 +53,9 @@ class MilvusClient:
             OrderedDict() if cache_size > 0 else None
         )
 
+    def pool_utilization(self) -> float:
+        return 0.0
+
     async def connect(self) -> None:
         """Async connection hook for API compatibility."""
         self._connected = True
@@ -317,6 +320,9 @@ def recall_vectors(
     store = _get_store(tenant)
     metadata = {"user_id": user_id, "tenant_id": tenant}
     results = store.search_sync(vec, top_k=top_k, metadata_filter=metadata)
+    record_metric(
+        "milvus_pool_utilization", getattr(store, "pool_utilization", lambda: 0.0)()
+    )
     # Include vector id so external stores can reference metadata
     return [{"id": r["id"], **r["payload"]} for r in results]
 


### PR DESCRIPTION
## Summary
- add cache and pooling configuration
- wrap semantic search vector recall with TTL caching
- collect metrics for redis and milvus pool utilization

## Testing
- `pre-commit run --files src/ai_karen_engine/core/chat_memory_config.py src/ai_karen_engine/clients/database/redis_client.py src/ai_karen_engine/clients/database/milvus_client.py src/ai_karen_engine/chat/production_memory.py src/ai_karen_engine/core/milvus_client.py` *(fails: Missing library stubs and return type annotations)*
- `pytest -q` *(fails: collection errors)*

------
https://chatgpt.com/codex/tasks/task_e_689ba4e22d448324b8eac7d8137f7b11