### PR TITLE
Use unified API prefix for extensions

### DIFF
--- a/extensions/README.md
+++ b/extensions/README.md
@@ -310,7 +310,7 @@ class TaskManagerExtension(BaseExtension):
     
     def create_api_router(self) -> APIRouter:
         """Create API routes for the Task Manager Extension."""
-        router = APIRouter(prefix=f"/extensions/{self.manifest.name}")
+        router = APIRouter(prefix=f"/api/extensions/{self.manifest.name}")
         
         @router.get("/tasks")
         async def list_tasks(status: str = "all", priority: str = None):

--- a/extensions/automation/workflow-builder/__init__.py
+++ b/extensions/automation/workflow-builder/__init__.py
@@ -227,7 +227,7 @@ class WorkflowBuilderExtension(BaseExtension):
         if not FASTAPI_AVAILABLE:
             return None
         
-        router = APIRouter(prefix=f"/extensions/{self.manifest.name}")
+        router = APIRouter(prefix=f"/api/extensions/{self.manifest.name}")
         
         @router.get("/workflows")
         async def list_workflows():

--- a/extensions/examples/hello-extension/__init__.py
+++ b/extensions/examples/hello-extension/__init__.py
@@ -107,7 +107,7 @@ class HelloExtension(BaseExtension):
         if not FASTAPI_AVAILABLE:
             return None
         
-        router = APIRouter(prefix=f"/extensions/{self.manifest.name}")
+        router = APIRouter(prefix=f"/api/extensions/{self.manifest.name}")
         
         @router.get("/hello")
         async def get_hello():

--- a/src/ai_karen_engine/extensions/base.py
+++ b/src/ai_karen_engine/extensions/base.py
@@ -176,7 +176,7 @@ class BaseExtension(ABC, HookMixin):
         if not FASTAPI_AVAILABLE:
             self.logger.warning("FastAPI not available, cannot create API router")
             return None
-        return APIRouter(prefix=f"/extensions/{self.manifest.name}")
+        return APIRouter(prefix=f"/api/extensions/{self.manifest.name}")
 
     def create_background_tasks(self) -> List[BackgroundTask]:
         """

--- a/tests/test_extension_routing.py
+++ b/tests/test_extension_routing.py
@@ -1,0 +1,63 @@
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Ensure src is on path
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from ai_karen_engine.extensions.base import BaseExtension
+from ai_karen_engine.extensions.models import ExtensionManifest, ExtensionContext
+
+
+class DummyExtension(BaseExtension):
+    async def _initialize(self) -> None:
+        pass
+
+
+def _build_manifest(name: str) -> ExtensionManifest:
+    return ExtensionManifest(
+        name=name,
+        version="0.1.0",
+        display_name=name.title(),
+        description="test",
+        author="tester",
+        license="MIT",
+        category="example",
+    )
+
+
+def test_base_extension_router_prefix() -> None:
+    with patch("ai_karen_engine.extensions.base.ExtensionDataManager") as dm, \
+            patch("ai_karen_engine.extensions.base.PluginOrchestrator") as po:
+        dm.return_value = MagicMock()
+        po.return_value = MagicMock()
+        manifest = _build_manifest("dummy")
+        context = ExtensionContext(plugin_router=MagicMock(), db_session=None, app_instance=None)
+        ext = DummyExtension(manifest, context)
+        router = ext.create_api_router()
+        assert router and router.prefix == "/api/extensions/dummy"
+
+
+def test_hello_extension_router_prefix() -> None:
+    with patch("ai_karen_engine.extensions.base.ExtensionDataManager") as dm, \
+            patch("ai_karen_engine.extensions.base.PluginOrchestrator") as po:
+        dm.return_value = MagicMock()
+        po.return_value = MagicMock()
+
+        import importlib.util
+
+        ext_path = Path("extensions/examples/hello-extension/__init__.py")
+        spec = importlib.util.spec_from_file_location("hello_extension", ext_path)
+        module = importlib.util.module_from_spec(spec)
+        assert spec and spec.loader
+        spec.loader.exec_module(module)  # type: ignore
+        HelloExtension = module.HelloExtension
+
+        manifest_path = Path("extensions/examples/hello-extension/extension.json")
+        manifest = ExtensionManifest.from_file(manifest_path)
+        context = ExtensionContext(plugin_router=MagicMock(), db_session=None, app_instance=None)
+        extension = HelloExtension(manifest, context)
+        router = extension.create_api_router()
+        assert router and router.prefix == "/api/extensions/hello-extension"


### PR DESCRIPTION
## Summary
- switch extension routers to `/api/extensions/{name}` prefix
- update example extensions and docs to match new API design
- add tests confirming unified routing path

## Testing
- `pytest tests/test_extension_routing.py -q`
- `pytest tests/test_extension_discovery.py::test_extension_discovery -q` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_689bad5825848324b2b2b1fff201c8d3