### PR TITLE
Implement memory write-back for copilot responses

### DIFF
--- a/src/ai_karen_engine/api_routes/copilot_routes.py
+++ b/src/ai_karen_engine/api_routes/copilot_routes.py
@@ -11,11 +11,14 @@ from typing import Any, Dict, List, Optional
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel, Field
 
+from ai_karen_engine.services.memory_writeback import InteractionType
+
 logger = logging.getLogger(__name__)
 
 # Graceful imports with fallback mechanisms
 try:
     from ai_karen_engine.services.memory_service import WebUIMemoryService
+
     MEMORY_SERVICE_AVAILABLE = True
 except ImportError:
     logger.warning("Memory service not available, using fallback")
@@ -23,6 +26,7 @@ except ImportError:
 
 try:
     from ai_karen_engine.integrations.llm_registry import get_llm_registry
+
     LLM_REGISTRY_AVAILABLE = True
 except ImportError:
     logger.warning("LLM registry not available, using fallback")
@@ -30,6 +34,7 @@ except ImportError:
 
 try:
     from ai_karen_engine.core.rbac import check_scope, require_scopes
+
     RBAC_AVAILABLE = True
 except ImportError:
     logger.warning("RBAC not available, using fallback")
@@ -37,14 +42,17 @@ except ImportError:
 
 try:
     from ai_karen_engine.services.metrics_service import get_metrics_service
+
     METRICS_AVAILABLE = True
 except ImportError:
     logger.warning("Metrics service not available, using fallback")
     METRICS_AVAILABLE = False
 
+
 # Unified request/response models according to design spec
 class ContextHit(BaseModel):
     """Unified memory hit representation"""
+
     id: str
     text: str
     score: float
@@ -58,42 +66,50 @@ class ContextHit(BaseModel):
     user_id: str
     org_id: Optional[str] = None
 
+
 class SuggestedAction(BaseModel):
     """Copilot action suggestions"""
-    type: str = Field(..., examples=["add_task", "pin_memory", "open_doc", "export_note"])
+
+    type: str = Field(
+        ..., examples=["add_task", "pin_memory", "open_doc", "export_note"]
+    )
     params: Dict[str, Any] = Field(default_factory=dict)
     confidence: float = Field(0.8, ge=0.0, le=1.0)
     description: Optional[str] = None
 
+
 class AssistRequest(BaseModel):
     """Primary copilot assist request schema"""
+
     user_id: str = Field(..., min_length=1)
     org_id: Optional[str] = None
     message: str = Field(..., min_length=1, max_length=8000)
     top_k: int = Field(6, ge=1, le=50)
     context: Dict[str, Any] = Field(default_factory=dict)
 
+
 class AssistResponse(BaseModel):
     """Primary copilot assist response schema"""
+
     answer: str
     context: List[ContextHit] = Field(default_factory=list)
     actions: List[SuggestedAction] = Field(default_factory=list)
     timings: Dict[str, float]
     correlation_id: str
 
+
 # Import unified schemas
-from .unified_schemas import (
-    ErrorResponse,
-    ErrorHandler,
-    ErrorType,
-    ValidationUtils
-)
+from .unified_schemas import ErrorHandler, ErrorResponse, ErrorType, ValidationUtils
 
 # Create router
 router = APIRouter(tags=["copilot"])
 
 try:
-    from ai_karen_engine.services.correlation_service import CorrelationService, create_correlation_logger
+    from ai_karen_engine.services.correlation_service import (
+        CorrelationService,
+        create_correlation_logger,
+    )
+
     CORRELATION_AVAILABLE = True
     # Use correlation-aware logger
     logger = create_correlation_logger(__name__)
@@ -102,11 +118,15 @@ except ImportError:
     CORRELATION_AVAILABLE = False
 
 try:
-    from ai_karen_engine.services.structured_logging import get_structured_logging_service
+    from ai_karen_engine.services.structured_logging import (
+        get_structured_logging_service,
+    )
+
     STRUCTURED_LOGGING_AVAILABLE = True
 except ImportError:
     logger.warning("Structured logging not available, using fallback")
     STRUCTURED_LOGGING_AVAILABLE = False
+
 
 def get_correlation_id(request: Request) -> str:
     """Extract or generate correlation ID for request tracking"""
@@ -115,6 +135,7 @@ def get_correlation_id(request: Request) -> str:
         return CorrelationService.get_or_create_correlation_id(headers)
     else:
         return request.headers.get("X-Correlation-Id", str(uuid.uuid4()))
+
 
 async def check_rbac_scope(request: Request, scope: str) -> bool:
     """Check RBAC scope with graceful fallback"""
@@ -128,11 +149,12 @@ async def check_rbac_scope(request: Request, scope: str) -> bool:
         logger.warning(f"RBAC check failed for {scope}: {e}")
         raise HTTPException(status_code=403, detail="RBAC error")
 
+
 async def get_memory_service() -> Optional[WebUIMemoryService]:
     """Get memory service with graceful fallback"""
     if not MEMORY_SERVICE_AVAILABLE:
         return None
-    
+
     try:
         # This would normally be injected via dependency
         # For now, return None to indicate unavailable
@@ -141,11 +163,12 @@ async def get_memory_service() -> Optional[WebUIMemoryService]:
         logger.warning(f"Memory service unavailable: {e}")
         return None
 
+
 async def get_llm_provider():
     """Get LLM provider with graceful fallback"""
     if not LLM_REGISTRY_AVAILABLE:
         return None
-    
+
     try:
         registry = get_llm_registry()
         return registry.get_default_provider()
@@ -153,70 +176,78 @@ async def get_llm_provider():
         logger.warning(f"LLM provider unavailable: {e}")
         return None
 
-def record_metrics(status: str, duration: float, user_id: str = "", org_id: str = "", 
-                  correlation_id: Optional[str] = None):
+
+def record_metrics(
+    status: str,
+    duration: float,
+    user_id: str = "",
+    org_id: str = "",
+    correlation_id: Optional[str] = None,
+):
     """Record metrics with graceful fallback"""
     if not METRICS_AVAILABLE:
         return
-    
+
     try:
         metrics_service = get_metrics_service()
         metrics_service.record_copilot_request(status, user_id, org_id, correlation_id)
-        metrics_service.record_total_turn_time(duration, "copilot_assist", status, correlation_id)
+        metrics_service.record_total_turn_time(
+            duration, "copilot_assist", status, correlation_id
+        )
     except Exception as e:
         logger.warning(f"Metrics recording failed: {e}")
 
+
 @router.post("/assist", response_model=AssistResponse)
-async def copilot_assist(
-    request: AssistRequest,
-    http_request: Request
-):
+async def copilot_assist(request: AssistRequest, http_request: Request):
     """
     Primary copilot assistance endpoint - unified interface for all copilot functionality.
-    
+
     This endpoint consolidates memory search, LLM generation, action suggestions,
     and response composition into a single, production-ready interface.
     """
     start_time = datetime.utcnow()
     correlation_id = get_correlation_id(http_request)
-    
+
     # Set correlation ID in context for propagation
     if CORRELATION_AVAILABLE:
         CorrelationService.set_correlation_id(correlation_id)
-        
+
         # Start trace tracking
         from ai_karen_engine.services.correlation_service import get_correlation_tracker
+
         tracker = get_correlation_tracker()
-        tracker.start_trace(correlation_id, "copilot_assist", {
-            "user_id": request.user_id,
-            "org_id": request.org_id,
-            "message_length": len(request.message),
-            "top_k": request.top_k
-        })
-    
+        tracker.start_trace(
+            correlation_id,
+            "copilot_assist",
+            {
+                "user_id": request.user_id,
+                "org_id": request.org_id,
+                "message_length": len(request.message),
+                "top_k": request.top_k,
+            },
+        )
+
     # Check RBAC permissions
     if not await check_rbac_scope(http_request, "chat:write"):
         record_metrics("forbidden", 0)
         error_response = ErrorHandler.create_authorization_error_response(
             correlation_id=correlation_id,
             path=str(http_request.url.path),
-            message="Insufficient permissions for copilot assistance"
+            message="Insufficient permissions for copilot assistance",
         )
-        raise HTTPException(
-            status_code=403,
-            detail=error_response.dict()
-        )
-    
+        raise HTTPException(status_code=403, detail=error_response.dict())
+
     try:
         timings = {}
         context_hits = []
         suggested_actions = []
         metrics_service = get_metrics_service() if METRICS_AVAILABLE else None
-        
+
         # 1. Memory search with tenant filtering
         memory_start = datetime.utcnow()
         memory_service = await get_memory_service()
-        
+
         if memory_service:
             try:
                 # This would use the unified memory service
@@ -231,52 +262,64 @@ async def copilot_assist(
                         decay_tier="medium",
                         created_at=datetime.utcnow(),
                         user_id=request.user_id,
-                        org_id=request.org_id
+                        org_id=request.org_id,
                     )
                     for i in range(min(request.top_k, 3))
                 ]
-                
+
                 # Record vector search latency
                 vector_duration = (datetime.utcnow() - memory_start).total_seconds()
                 if metrics_service:
                     metrics_service.record_vector_latency(
                         vector_duration, "search", "success", correlation_id
                     )
-                
+
                 # Add trace span
                 if CORRELATION_AVAILABLE:
-                    tracker.add_span(correlation_id, "memory_search", vector_duration, {
-                        "hits_count": len(context_hits),
-                        "top_k": request.top_k,
-                        "status": "success"
-                    })
-                    
+                    tracker.add_span(
+                        correlation_id,
+                        "memory_search",
+                        vector_duration,
+                        {
+                            "hits_count": len(context_hits),
+                            "top_k": request.top_k,
+                            "status": "success",
+                        },
+                    )
+
             except Exception as e:
                 logger.warning(f"Memory search failed: {e}")
                 context_hits = []
-                
+
                 # Record failed vector search
                 vector_duration = (datetime.utcnow() - memory_start).total_seconds()
                 if metrics_service:
                     metrics_service.record_vector_latency(
                         vector_duration, "search", "error", correlation_id
                     )
-                
+
                 # Add error trace span
                 if CORRELATION_AVAILABLE:
-                    tracker.add_span(correlation_id, "memory_search", vector_duration, {
-                        "hits_count": 0,
-                        "top_k": request.top_k,
-                        "status": "error",
-                        "error": str(e)
-                    })
-        
-        timings["memory_search_ms"] = (datetime.utcnow() - memory_start).total_seconds() * 1000
-        
+                    tracker.add_span(
+                        correlation_id,
+                        "memory_search",
+                        vector_duration,
+                        {
+                            "hits_count": 0,
+                            "top_k": request.top_k,
+                            "status": "error",
+                            "error": str(e),
+                        },
+                    )
+
+        timings["memory_search_ms"] = (
+            datetime.utcnow() - memory_start
+        ).total_seconds() * 1000
+
         # 2. LLM generation with local-first routing
         llm_start = datetime.utcnow()
         llm_provider = await get_llm_provider()
-        
+
         # Compose prompt with context
         context_text = "\n".join([hit.text for hit in context_hits[:3]])
         enhanced_prompt = f"""Context from memory:
@@ -285,119 +328,196 @@ async def copilot_assist(
 User message: {request.message}
 
 Please provide a helpful response and suggest relevant actions."""
-        
+
         if llm_provider:
             try:
                 # This would use the actual LLM provider
                 answer = f"Based on your message '{request.message}', here's my response with context from {len(context_hits)} relevant memories."
-                
+
                 # Record successful LLM generation
                 llm_duration = (datetime.utcnow() - llm_start).total_seconds()
                 if metrics_service:
                     metrics_service.record_llm_latency(
                         llm_duration, "local", "fallback", "success", correlation_id
                     )
-                
+
                 # Add trace span
                 if CORRELATION_AVAILABLE:
-                    tracker.add_span(correlation_id, "llm_generation", llm_duration, {
-                        "provider": "local",
-                        "model": "fallback",
-                        "status": "success",
-                        "response_length": len(answer)
-                    })
-                    
+                    tracker.add_span(
+                        correlation_id,
+                        "llm_generation",
+                        llm_duration,
+                        {
+                            "provider": "local",
+                            "model": "fallback",
+                            "status": "success",
+                            "response_length": len(answer),
+                        },
+                    )
+
             except Exception as e:
                 logger.warning(f"LLM generation failed: {e}")
                 answer = f"I understand you're asking about: {request.message}. I'm currently operating in fallback mode."
-                
+
                 # Record failed LLM generation
                 llm_duration = (datetime.utcnow() - llm_start).total_seconds()
                 if metrics_service:
                     metrics_service.record_llm_latency(
                         llm_duration, "local", "fallback", "error", correlation_id
                     )
-                
+
                 # Add error trace span
                 if CORRELATION_AVAILABLE:
-                    tracker.add_span(correlation_id, "llm_generation", llm_duration, {
-                        "provider": "local",
-                        "model": "fallback",
-                        "status": "error",
-                        "error": str(e)
-                    })
+                    tracker.add_span(
+                        correlation_id,
+                        "llm_generation",
+                        llm_duration,
+                        {
+                            "provider": "local",
+                            "model": "fallback",
+                            "status": "error",
+                            "error": str(e),
+                        },
+                    )
         else:
             answer = f"I understand you're asking about: {request.message}. I'm currently operating in fallback mode."
-            
+
             # Record fallback LLM generation
             llm_duration = (datetime.utcnow() - llm_start).total_seconds()
             if metrics_service:
                 metrics_service.record_llm_latency(
                     llm_duration, "fallback", "none", "fallback", correlation_id
                 )
-            
+
             # Add fallback trace span
             if CORRELATION_AVAILABLE:
-                tracker.add_span(correlation_id, "llm_generation", llm_duration, {
-                    "provider": "fallback",
-                    "model": "none",
-                    "status": "fallback",
-                    "response_length": len(answer)
-                })
-        
-        timings["llm_generation_ms"] = (datetime.utcnow() - llm_start).total_seconds() * 1000
-        
+                tracker.add_span(
+                    correlation_id,
+                    "llm_generation",
+                    llm_duration,
+                    {
+                        "provider": "fallback",
+                        "model": "none",
+                        "status": "fallback",
+                        "response_length": len(answer),
+                    },
+                )
+
+        timings["llm_generation_ms"] = (
+            datetime.utcnow() - llm_start
+        ).total_seconds() * 1000
+
         # 3. Action suggestion derivation
         action_start = datetime.utcnow()
-        
+
         # Generate suggested actions based on message content
         message_lower = request.message.lower()
         if any(word in message_lower for word in ["task", "todo", "remind"]):
-            suggested_actions.append(SuggestedAction(
-                type="add_task",
-                params={"title": request.message[:100], "user_id": request.user_id},
-                confidence=0.8,
-                description="Add this as a task"
-            ))
-        
+            suggested_actions.append(
+                SuggestedAction(
+                    type="add_task",
+                    params={"title": request.message[:100], "user_id": request.user_id},
+                    confidence=0.8,
+                    description="Add this as a task",
+                )
+            )
+
         if any(word in message_lower for word in ["important", "remember", "save"]):
-            suggested_actions.append(SuggestedAction(
-                type="pin_memory",
-                params={"content": request.message, "user_id": request.user_id},
-                confidence=0.7,
-                description="Pin this to memory"
-            ))
-        
+            suggested_actions.append(
+                SuggestedAction(
+                    type="pin_memory",
+                    params={"content": request.message, "user_id": request.user_id},
+                    confidence=0.7,
+                    description="Pin this to memory",
+                )
+            )
+
         if any(word in message_lower for word in ["document", "doc", "file"]):
-            suggested_actions.append(SuggestedAction(
-                type="open_doc",
-                params={"query": request.message},
-                confidence=0.6,
-                description="Find related documents"
-            ))
-        
-        timings["action_generation_ms"] = (datetime.utcnow() - action_start).total_seconds() * 1000
-        
+            suggested_actions.append(
+                SuggestedAction(
+                    type="open_doc",
+                    params={"query": request.message},
+                    confidence=0.6,
+                    description="Find related documents",
+                )
+            )
+
+        timings["action_generation_ms"] = (
+            datetime.utcnow() - action_start
+        ).total_seconds() * 1000
+
         # 4. Memory write-back with decay policy
         writeback_start = datetime.utcnow()
-        
+
         if memory_service:
             try:
-                # This would store the interaction for future context
-                pass
+                response_id = str(uuid.uuid4())
+
+                shard_links = await memory_service.link_response_to_shards(
+                    response_id=response_id,
+                    response_content=answer,
+                    source_context_hits=context_hits,
+                    user_id=request.user_id,
+                    org_id=request.org_id,
+                    correlation_id=correlation_id,
+                )
+
+                await memory_service.queue_interaction_writeback(
+                    content=answer,
+                    interaction_type=InteractionType.COPILOT_RESPONSE,
+                    user_id=request.user_id,
+                    org_id=request.org_id,
+                    source_shards=shard_links,
+                    tags=["copilot_assist"],
+                    correlation_id=correlation_id,
+                )
+
+                if metrics_service:
+                    metrics_service.record_memory_commit(
+                        "success",
+                        user_id=request.user_id,
+                        org_id=request.org_id or "",
+                        correlation_id=correlation_id,
+                    )
             except Exception as e:
                 logger.warning(f"Memory write-back failed: {e}")
-        
-        timings["memory_writeback_ms"] = (datetime.utcnow() - writeback_start).total_seconds() * 1000
-        
+                if metrics_service:
+                    metrics_service.record_memory_commit(
+                        "error",
+                        user_id=request.user_id,
+                        org_id=request.org_id or "",
+                        correlation_id=correlation_id,
+                    )
+                error_response = ErrorHandler.create_internal_error_response(
+                    correlation_id=correlation_id,
+                    path=str(http_request.url.path),
+                    error=e,
+                )
+                logger.debug(
+                    f"Write-back error response: {error_response.message}",
+                    extra={"correlation_id": correlation_id},
+                )
+
+        timings["memory_writeback_ms"] = (
+            datetime.utcnow() - writeback_start
+        ).total_seconds() * 1000
+
         # 5. Update memory quality metrics
         if metrics_service and context_hits:
             # Calculate memory quality metrics
-            context_usage_rate = len([hit for hit in context_hits if hit.score > 0.7]) / len(context_hits)
-            ignored_top_hit_rate = 1.0 if context_hits and context_hits[0].score < 0.5 else 0.0
+            context_usage_rate = len(
+                [hit for hit in context_hits if hit.score > 0.7]
+            ) / len(context_hits)
+            ignored_top_hit_rate = (
+                1.0 if context_hits and context_hits[0].score < 0.5 else 0.0
+            )
             used_shard_rate = len(context_hits) / max(request.top_k, 1)
-            avg_relevance_score = sum(hit.score for hit in context_hits) / len(context_hits) if context_hits else 0.0
-            
+            avg_relevance_score = (
+                sum(hit.score for hit in context_hits) / len(context_hits)
+                if context_hits
+                else 0.0
+            )
+
             metrics_service.update_memory_quality_metrics(
                 context_usage_rate=context_usage_rate,
                 ignored_top_hit_rate=ignored_top_hit_rate,
@@ -405,16 +525,22 @@ Please provide a helpful response and suggest relevant actions."""
                 avg_relevance_score=avg_relevance_score,
                 user_id=request.user_id,
                 org_id=request.org_id or "",
-                correlation_id=correlation_id
+                correlation_id=correlation_id,
             )
-        
+
         # Calculate total time
         total_duration = (datetime.utcnow() - start_time).total_seconds()
         timings["total_ms"] = total_duration * 1000
-        
+
         # Record comprehensive metrics
-        record_metrics("success", total_duration, request.user_id, request.org_id or "", correlation_id)
-        
+        record_metrics(
+            "success",
+            total_duration,
+            request.user_id,
+            request.org_id or "",
+            correlation_id,
+        )
+
         # Log API request with structured logging
         if STRUCTURED_LOGGING_AVAILABLE:
             try:
@@ -426,67 +552,85 @@ Please provide a helpful response and suggest relevant actions."""
                     duration_ms=total_duration * 1000,
                     user_id=request.user_id,
                     org_id=request.org_id,
-                    ip_address=http_request.client.host if http_request.client else None,
+                    ip_address=http_request.client.host
+                    if http_request.client
+                    else None,
                     user_agent=http_request.headers.get("user-agent"),
                     correlation_id=correlation_id,
                     context_hits=len(context_hits),
-                    suggested_actions=len(suggested_actions)
+                    suggested_actions=len(suggested_actions),
                 )
             except Exception as e:
                 logger.warning(f"Structured logging failed: {e}")
-        
+
         # End trace tracking
         if CORRELATION_AVAILABLE:
-            tracker.end_trace(correlation_id, "success", {
-                "total_duration": total_duration,
-                "context_hits": len(context_hits),
-                "suggested_actions": len(suggested_actions),
-                "user_id": request.user_id,
-                "org_id": request.org_id
-            })
-        
+            tracker.end_trace(
+                correlation_id,
+                "success",
+                {
+                    "total_duration": total_duration,
+                    "context_hits": len(context_hits),
+                    "suggested_actions": len(suggested_actions),
+                    "user_id": request.user_id,
+                    "org_id": request.org_id,
+                },
+            )
+
         return AssistResponse(
             answer=answer,
             context=context_hits,
             actions=suggested_actions,
             timings=timings,
-            correlation_id=correlation_id
+            correlation_id=correlation_id,
         )
-        
+
     except HTTPException:
         # End trace for HTTP exceptions
         if CORRELATION_AVAILABLE:
             total_duration = (datetime.utcnow() - start_time).total_seconds()
-            tracker.end_trace(correlation_id, "http_error", {
-                "total_duration": total_duration,
-                "user_id": request.user_id,
-                "org_id": request.org_id
-            })
+            tracker.end_trace(
+                correlation_id,
+                "http_error",
+                {
+                    "total_duration": total_duration,
+                    "user_id": request.user_id,
+                    "org_id": request.org_id,
+                },
+            )
         raise
     except Exception as e:
         total_duration = (datetime.utcnow() - start_time).total_seconds()
-        record_metrics("error", total_duration, request.user_id, request.org_id or "", correlation_id)
-        
+        record_metrics(
+            "error",
+            total_duration,
+            request.user_id,
+            request.org_id or "",
+            correlation_id,
+        )
+
         # End trace for general exceptions
         if CORRELATION_AVAILABLE:
-            tracker.end_trace(correlation_id, "error", {
-                "total_duration": total_duration,
-                "error": str(e),
-                "user_id": request.user_id,
-                "org_id": request.org_id
-            })
-        
-        logger.error(f"Copilot assist failed: {e}", extra={"correlation_id": correlation_id})
-        
+            tracker.end_trace(
+                correlation_id,
+                "error",
+                {
+                    "total_duration": total_duration,
+                    "error": str(e),
+                    "user_id": request.user_id,
+                    "org_id": request.org_id,
+                },
+            )
+
+        logger.error(
+            f"Copilot assist failed: {e}", extra={"correlation_id": correlation_id}
+        )
+
         error_response = ErrorHandler.create_internal_error_response(
-            correlation_id=correlation_id,
-            path=str(http_request.url.path),
-            error=e
+            correlation_id=correlation_id, path=str(http_request.url.path), error=e
         )
-        raise HTTPException(
-            status_code=500,
-            detail=error_response.dict()
-        )
+        raise HTTPException(status_code=500, detail=error_response.dict())
+
 
 @router.get("/health")
 async def health_check():
@@ -498,10 +642,11 @@ async def health_check():
             "memory_service": MEMORY_SERVICE_AVAILABLE,
             "llm_registry": LLM_REGISTRY_AVAILABLE,
             "rbac": RBAC_AVAILABLE,
-            "metrics": METRICS_AVAILABLE
+            "metrics": METRICS_AVAILABLE,
         },
-        "timestamp": datetime.utcnow().isoformat()
+        "timestamp": datetime.utcnow().isoformat(),
     }
+
 
 # Export router for inclusion in main FastAPI app
 __all__ = ["router"]

--- a/tests/test_copilot_memory_writeback.py
+++ b/tests/test_copilot_memory_writeback.py
@@ -1,0 +1,55 @@
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+from fastapi import Request
+
+from ai_karen_engine.services.memory_writeback import InteractionType
+from src.ai_karen_engine.api_routes.copilot_routes import AssistRequest, copilot_assist
+
+
+@pytest.mark.asyncio
+async def test_assist_triggers_memory_writeback():
+    req = AssistRequest(
+        user_id="user1",
+        org_id="org1",
+        message="hello",
+        top_k=2,
+    )
+    http_request = Request()
+
+    memory_mock = Mock()
+    memory_mock.link_response_to_shards = AsyncMock(return_value=["shard"])
+    memory_mock.queue_interaction_writeback = AsyncMock(return_value="id")
+    metrics_mock = Mock()
+
+    with (
+        patch(
+            "src.ai_karen_engine.api_routes.copilot_routes.check_rbac_scope",
+            new=AsyncMock(return_value=True),
+        ),
+        patch(
+            "src.ai_karen_engine.api_routes.copilot_routes.get_llm_provider",
+            new=AsyncMock(return_value=None),
+        ),
+        patch(
+            "src.ai_karen_engine.api_routes.copilot_routes.get_memory_service",
+            new=AsyncMock(return_value=memory_mock),
+        ),
+        patch(
+            "src.ai_karen_engine.api_routes.copilot_routes.get_metrics_service",
+            return_value=metrics_mock,
+        ),
+    ):
+        response = await copilot_assist(req, http_request)
+
+    assert response.answer
+    memory_mock.link_response_to_shards.assert_awaited_once()
+    memory_mock.queue_interaction_writeback.assert_awaited_once()
+    args, kwargs = memory_mock.queue_interaction_writeback.await_args
+    assert kwargs["source_shards"] == ["shard"]
+    assert kwargs["interaction_type"] == InteractionType.COPILOT_RESPONSE
+    assert "copilot_assist" in kwargs["tags"]
+
+    metrics_mock.record_memory_commit.assert_called()
+    commit_args, _ = metrics_mock.record_memory_commit.call_args
+    assert commit_args[0] == "success"


### PR DESCRIPTION
## Summary
- link copilot responses to memory shards and queue write-back entries
- capture write-back metrics and route errors through ErrorHandler
- add test ensuring copilot assist triggers memory write-back

## Testing
- `pre-commit run --files src/ai_karen_engine/api_routes/copilot_routes.py tests/test_copilot_memory_writeback.py`
- `pytest tests/test_copilot_memory_writeback.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689bcb7053a88324a0069bc179170337