### PR TITLE
Integrate latency metrics with Milvus and LLM utilities

### DIFF
--- a/monitoring/alert_rules.yml
+++ b/monitoring/alert_rules.yml
@@ -20,6 +20,7 @@ groups:
 
   - name: copilot_latency_slo
     rules:
+      # Vector search should stay under 50ms at p95
       - alert: VectorSearchLatencyHigh
         expr: histogram_quantile(0.95, sum(rate(vector_latency_seconds_bucket[5m])) by (le, operation)) > 0.05
         for: 10m
@@ -28,6 +29,7 @@ groups:
         annotations:
           summary: 'Vector search p95 latency above 50ms for {{ $labels.operation }}'
           description: '95th percentile vector search latency exceeded 50ms'
+      # LLM generation should emit first token within 1.2s at p95
       - alert: LLMGenerationLatencyHigh
         expr: histogram_quantile(0.95, sum(rate(llm_latency_seconds_bucket[5m])) by (le, provider, model)) > 1.2
         for: 10m
@@ -36,6 +38,7 @@ groups:
         annotations:
           summary: 'LLM generation p95 latency above 1.2s for {{ $labels.provider }}/{{ $labels.model }}'
           description: '95th percentile LLM generation latency exceeded 1.2s'
+      # End-to-end turn time should remain under 3s at p95
       - alert: TurnTimeHigh
         expr: histogram_quantile(0.95, sum(rate(total_turn_time_seconds_bucket[5m])) by (le, endpoint)) > 3
         for: 10m

--- a/src/ai_karen_engine/core/milvus_client.py
+++ b/src/ai_karen_engine/core/milvus_client.py
@@ -174,42 +174,59 @@ class MilvusClient:
                 return list(self._cache[cache_key])
 
         start = time.time()
-        with self._lock:
-            self._prune()
-            norm = math.sqrt(sum(v * v for v in vector))
-            results: List[Dict[str, Any]] = []
-            if self.index_type == "hnsw" and self._index is not None:
-                search_k = min(top_k * 5, max(len(self._data), top_k)) or top_k
-                labels, distances = self._index.knn_query(
-                    np.array([vector], dtype=np.float32), k=search_k
-                )
-                for label, dist in zip(labels[0], distances[0]):
-                    rec = self._data.get(int(label))
-                    if rec is None:
-                        continue
-                    if metadata_filter and any(
-                        rec.payload.get(k) != v for k, v in metadata_filter.items()
-                    ):
-                        continue
-                    sim = 1.0 - float(dist)
-                    results.append({"id": rec.id, "score": sim, "payload": rec.payload})
-            else:
-                for rec in self._data.values():
-                    if metadata_filter and any(
-                        rec.payload.get(k) != v for k, v in metadata_filter.items()
-                    ):
-                        continue
-                    sim = self._similarity(vector, norm, rec.vector, rec.norm)
-                    results.append({"id": rec.id, "score": sim, "payload": rec.payload})
-            results.sort(key=lambda r: r["score"], reverse=True)
-            results = results[:top_k]
+        status = "success"
+        try:
+            with self._lock:
+                self._prune()
+                norm = math.sqrt(sum(v * v for v in vector))
+                results: List[Dict[str, Any]] = []
+                if self.index_type == "hnsw" and self._index is not None:
+                    search_k = min(top_k * 5, max(len(self._data), top_k)) or top_k
+                    labels, distances = self._index.knn_query(
+                        np.array([vector], dtype=np.float32), k=search_k
+                    )
+                    for label, dist in zip(labels[0], distances[0]):
+                        rec = self._data.get(int(label))
+                        if rec is None:
+                            continue
+                        if metadata_filter and any(
+                            rec.payload.get(k) != v for k, v in metadata_filter.items()
+                        ):
+                            continue
+                        sim = 1.0 - float(dist)
+                        results.append(
+                            {"id": rec.id, "score": sim, "payload": rec.payload}
+                        )
+                else:
+                    for rec in self._data.values():
+                        if metadata_filter and any(
+                            rec.payload.get(k) != v for k, v in metadata_filter.items()
+                        ):
+                            continue
+                        sim = self._similarity(vector, norm, rec.vector, rec.norm)
+                        results.append(
+                            {"id": rec.id, "score": sim, "payload": rec.payload}
+                        )
+                results.sort(key=lambda r: r["score"], reverse=True)
+                results = results[:top_k]
 
-        if self._cache is not None and cache_key is not None:
-            self._cache[cache_key] = results
-            if len(self._cache) > self.cache_size:
-                self._cache.popitem(last=False)
-        record_metric("vector_search_latency_seconds", time.time() - start)
-        return results
+            if self._cache is not None and cache_key is not None:
+                self._cache[cache_key] = results
+                if len(self._cache) > self.cache_size:
+                    self._cache.popitem(last=False)
+            return results
+        except Exception:
+            status = "error"
+            raise
+        finally:
+            duration = time.time() - start
+            record_metric("vector_search_latency_seconds", duration)
+            try:
+                from ai_karen_engine.services.metrics_service import get_metrics_service
+
+                get_metrics_service().record_vector_latency(duration, status=status)
+            except Exception:
+                pass
 
     async def search(
         self,

--- a/tests/test_observability_infrastructure.py
+++ b/tests/test_observability_infrastructure.py
@@ -3,47 +3,63 @@ Test suite for Observability Infrastructure - Phase 4.1.d
 Comprehensive tests for metrics collection, correlation tracking, SLO monitoring, and structured logging.
 """
 
-import pytest
 import asyncio
 import json
 import time
 from datetime import datetime, timedelta
-from unittest.mock import Mock, patch, MagicMock
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+
 
 # Test metrics collection system
 def test_metrics_service_initialization():
     """Test metrics service initialization with fallback"""
-    from src.ai_karen_engine.services.metrics_service import MetricsService, get_metrics_service
-    
+    from src.ai_karen_engine.services.metrics_service import (
+        MetricsService,
+        get_metrics_service,
+    )
+
     # Test initialization
     metrics_service = MetricsService()
     assert metrics_service is not None
     assert metrics_service.fallback_collector is not None
-    
+
     # Test global instance
     global_service = get_metrics_service()
     assert global_service is not None
 
+
 def test_metrics_collection():
     """Test comprehensive metrics collection"""
     from src.ai_karen_engine.services.metrics_service import MetricsService
-    
+
     metrics_service = MetricsService()
-    
+
     # Test copilot request metrics
-    metrics_service.record_copilot_request("success", "test_user", "test_org", "test_correlation")
-    
+    metrics_service.record_copilot_request(
+        "success", "test_user", "test_org", "test_correlation"
+    )
+
     # Test memory query metrics
-    metrics_service.record_memory_query("search", "success", "test_user", "test_org", "test_correlation")
-    
+    metrics_service.record_memory_query(
+        "search", "success", "test_user", "test_org", "test_correlation"
+    )
+
     # Test memory commit metrics
-    metrics_service.record_memory_commit("success", "medium", "test_user", "test_org", "test_correlation")
-    
+    metrics_service.record_memory_commit(
+        "success", "medium", "test_user", "test_org", "test_correlation"
+    )
+
     # Test latency metrics
-    metrics_service.record_llm_latency(0.5, "local", "test_model", "success", "test_correlation")
+    metrics_service.record_llm_latency(
+        0.5, "local", "test_model", "success", "test_correlation"
+    )
     metrics_service.record_vector_latency(0.03, "search", "success", "test_correlation")
-    metrics_service.record_total_turn_time(1.2, "copilot_assist", "success", "test_correlation")
-    
+    metrics_service.record_total_turn_time(
+        1.2, "copilot_assist", "success", "test_correlation"
+    )
+
     # Test memory quality metrics
     metrics_service.update_memory_quality_metrics(
         context_usage_rate=0.8,
@@ -52,129 +68,152 @@ def test_metrics_collection():
         avg_relevance_score=0.85,
         user_id="test_user",
         org_id="test_org",
-        correlation_id="test_correlation"
+        correlation_id="test_correlation",
     )
-    
+
     # Verify fallback collector has data
     stats = metrics_service.fallback_collector.get_stats()
     assert len(stats["counters"]) > 0
     assert len(stats["histograms"]) > 0
     assert len(stats["gauges"]) > 0
 
+
 def test_correlation_service():
     """Test correlation ID service functionality"""
-    from src.ai_karen_engine.services.correlation_service import CorrelationService, CorrelationTracker
-    
+    from src.ai_karen_engine.services.correlation_service import (
+        CorrelationService,
+        CorrelationTracker,
+    )
+
     # Test correlation ID generation
     correlation_id = CorrelationService.generate_correlation_id()
     assert correlation_id is not None
     assert len(correlation_id) > 0
-    
+
     # Test header extraction
     headers = {"X-Correlation-Id": "test-correlation-123"}
     extracted_id = CorrelationService.extract_correlation_id(headers)
     assert extracted_id == "test-correlation-123"
-    
+
     # Test get or create
     new_id = CorrelationService.get_or_create_correlation_id(headers)
     assert new_id == "test-correlation-123"
-    
+
     # Test context setting
     CorrelationService.set_correlation_id("context-test-id")
     context_id = CorrelationService.get_correlation_id()
     assert context_id == "context-test-id"
-    
+
     # Test correlation tracker
     tracker = CorrelationTracker()
     tracker.start_trace("trace-123", "test_operation", {"test": "metadata"})
     tracker.add_span("trace-123", "test_span", 0.1, {"span": "data"})
     tracker.end_trace("trace-123", "success", {"result": "completed"})
 
+
 def test_slo_monitoring():
     """Test SLO monitoring and alerting"""
-    from src.ai_karen_engine.services.slo_monitoring import SLOMonitor, SLOTarget, SLOThreshold, AlertRule, AlertSeverity
-    
+    from src.ai_karen_engine.services.slo_monitoring import (
+        AlertRule,
+        AlertSeverity,
+        SLOMonitor,
+        SLOTarget,
+        SLOThreshold,
+    )
+
     # Test SLO monitor initialization
     slo_monitor = SLOMonitor()
     assert slo_monitor is not None
     assert len(slo_monitor.slo_targets) > 0  # Should have default SLOs
     assert len(slo_monitor.alert_rules) > 0  # Should have default alert rules
-    
+
     # Test metric recording
     slo_monitor.record_metric("vector_latency_seconds", 0.025)
     slo_monitor.record_metric("llm_latency_seconds", 0.8)
     slo_monitor.record_metric("total_turn_time_seconds", 2.1)
-    
+
     # Test SLO evaluation
     violations = slo_monitor.evaluate_slo_targets()
     # Should not have violations with good metrics
     assert len(violations) == 0
-    
+
     # Test with bad metrics
     slo_monitor.record_metric("vector_latency_seconds", 0.080)  # Above 50ms threshold
     violations = slo_monitor.evaluate_slo_targets()
     # Should have violations now
     assert len(violations) > 0
-    
+
     # Test SLO status
     status = slo_monitor.get_slo_status()
     assert "vector_query_latency" in status
     assert "first_token_latency" in status
     assert "e2e_turn_latency" in status
-    
+
     # Test dashboard data
     dashboard_data = slo_monitor.get_dashboard_data()
     assert "slo_status" in dashboard_data
     assert "active_alerts" in dashboard_data
     assert "recent_violations" in dashboard_data
 
+
 def test_structured_logging():
     """Test structured logging with PII redaction"""
     from src.ai_karen_engine.services.structured_logging import (
-        StructuredLoggingService, PIIRedactor, SecurityLogger, SecurityEventType
+        PIIRedactor,
+        SecurityEventType,
+        SecurityLogger,
+        StructuredLoggingService,
     )
-    
+
     # Test PII redaction
     text_with_pii = "Contact john.doe@example.com or call 555-123-4567"
     redacted_text = PIIRedactor.redact_pii(text_with_pii)
     assert "john.doe@example.com" not in redacted_text
     assert "555-123-4567" not in redacted_text
     assert "[REDACTED]" in redacted_text
-    
+
     # Test dict redaction
     data_with_pii = {
         "email": "user@example.com",
         "password": "secret123",
         "message": "Call me at 555-999-8888",
-        "safe_data": "This is safe"
+        "safe_data": "This is safe",
     }
     redacted_data = PIIRedactor.redact_dict(data_with_pii)
     assert redacted_data["email"] == "[REDACTED]"
     assert redacted_data["password"] == "[REDACTED]"
     assert "555-999-8888" not in redacted_data["message"]
     assert redacted_data["safe_data"] == "This is safe"
-    
+
     # Test structured logging service
     logging_service = StructuredLoggingService()
     assert logging_service is not None
     assert logging_service.configured is True
-    
+
     # Test security logger
     security_logger = SecurityLogger()
-    security_logger.log_authentication_failure("test_user", "192.168.1.1", "test_correlation")
-    security_logger.log_cross_tenant_access_attempt("user1", "org1", "org2", "test_correlation")
-    security_logger.log_rate_limit_violation("user1", "/api/test", 100, 150, "test_correlation")
-    
+    security_logger.log_authentication_failure(
+        "test_user", "192.168.1.1", "test_correlation"
+    )
+    security_logger.log_cross_tenant_access_attempt(
+        "user1", "org1", "org2", "test_correlation"
+    )
+    security_logger.log_rate_limit_violation(
+        "user1", "/api/test", 100, 150, "test_correlation"
+    )
+
     # Verify events were logged
     recent_events = security_logger.get_recent_events()
     assert len(recent_events) >= 3
 
+
 def test_security_middleware():
     """Test security middleware functionality"""
     from src.ai_karen_engine.middleware.security_middleware import (
-        SecurityConfig, SecurityMiddlewareStack
+        SecurityConfig,
+        SecurityMiddlewareStack,
     )
-    
+
     # Test security config
     config = SecurityConfig()
     assert config.enforce_https is True
@@ -182,58 +221,60 @@ def test_security_middleware():
     assert config.rate_limit_enabled is True
     assert len(config.security_headers) > 0
     assert len(config.suspicious_patterns) > 0
-    
+
     # Test middleware stack
     middleware_stack = SecurityMiddlewareStack(config)
     assert middleware_stack.config == config
+
 
 @pytest.mark.asyncio
 async def test_api_routes_integration():
     """Test API routes with observability integration"""
     from fastapi import FastAPI
     from fastapi.testclient import TestClient
+
     from src.ai_karen_engine.api_routes.copilot_routes import router as copilot_router
     from src.ai_karen_engine.api_routes.memory_routes import router as memory_router
     from src.ai_karen_engine.api_routes.slo_routes import router as slo_router
-    
+
     # Create test app
     app = FastAPI()
     app.include_router(copilot_router, prefix="/copilot")
     app.include_router(memory_router, prefix="/memory")
     app.include_router(slo_router, prefix="/slo")
-    
+
     client = TestClient(app)
-    
+
     # Test copilot assist endpoint
-    copilot_response = client.post("/copilot/assist", json={
-        "user_id": "test_user",
-        "message": "Test message",
-        "top_k": 3
-    }, headers={"X-Correlation-Id": "test-correlation-123"})
-    
+    copilot_response = client.post(
+        "/copilot/assist",
+        json={"user_id": "test_user", "message": "Test message", "top_k": 3},
+        headers={"X-Correlation-Id": "test-correlation-123"},
+    )
+
     assert copilot_response.status_code == 200
     data = copilot_response.json()
     assert "answer" in data
     assert "correlation_id" in data
     assert data["correlation_id"] == "test-correlation-123"
-    
+
     # Test memory search endpoint
-    memory_response = client.post("/memory/search", json={
-        "user_id": "test_user",
-        "query": "test query",
-        "top_k": 5
-    }, headers={"X-Correlation-Id": "test-correlation-456"})
-    
+    memory_response = client.post(
+        "/memory/search",
+        json={"user_id": "test_user", "query": "test query", "top_k": 5},
+        headers={"X-Correlation-Id": "test-correlation-456"},
+    )
+
     assert memory_response.status_code == 200
     data = memory_response.json()
     assert "hits" in data
     assert "correlation_id" in data
     assert data["correlation_id"] == "test-correlation-456"
-    
+
     # Test SLO status endpoint
     slo_response = client.get("/slo/status")
     assert slo_response.status_code == 200
-    
+
     # Test SLO dashboard endpoint
     dashboard_response = client.get("/slo/dashboard")
     assert dashboard_response.status_code == 200
@@ -241,7 +282,7 @@ async def test_api_routes_integration():
     assert "slo_status" in data
     assert "active_alerts" in data
     assert "recent_violations" in data
-    
+
     # Test metrics export endpoint
     metrics_response = client.get("/slo/metrics")
     assert metrics_response.status_code == 200
@@ -249,30 +290,31 @@ async def test_api_routes_integration():
     assert "content" in data
     assert "content_type" in data
 
+
 def test_performance_thresholds():
     """Test that SLO thresholds match requirements"""
     from src.ai_karen_engine.services.slo_monitoring import get_slo_monitor
-    
+
     slo_monitor = get_slo_monitor()
-    
+
     # Verify vector query latency threshold (p95 < 50ms)
     vector_slo = slo_monitor.slo_targets.get("vector_query_latency")
     assert vector_slo is not None
     assert vector_slo.target_value == 0.050  # 50ms
-    
+
     # Verify first token latency threshold (p95 < 1.2s)
     llm_slo = slo_monitor.slo_targets.get("first_token_latency")
     assert llm_slo is not None
     assert llm_slo.target_value == 1.2  # 1.2 seconds
-    
+
     # Verify end-to-end latency threshold (p95 < 3s)
     e2e_slo = slo_monitor.slo_targets.get("e2e_turn_latency")
     assert e2e_slo is not None
     assert e2e_slo.target_value == 3.0  # 3 seconds
 
 
-def test_latency_percentiles_under_high_load():
-    """Simulate high-load scenarios and verify p95 latency thresholds"""
+def test_high_load_p95_thresholds():
+    """Simulate high-load scenarios and verify p95 latency targets"""
     from src.ai_karen_engine.services import metrics_service as ms
 
     ms.PROMETHEUS_AVAILABLE = False
@@ -286,23 +328,30 @@ def test_latency_percentiles_under_high_load():
         metrics.record_total_turn_time(turn, "copilot_assist")
 
     stats = metrics.fallback_collector.get_stats()
-    vec_key = next(k for k in stats["histograms"] if k.startswith("vector_latency_seconds"))
+    vec_key = next(
+        k for k in stats["histograms"] if k.startswith("vector_latency_seconds")
+    )
     vec_p95 = stats["histograms"][vec_key]["p95"]
-    llm_key = next(k for k in stats["histograms"] if k.startswith("llm_latency_seconds"))
+    llm_key = next(
+        k for k in stats["histograms"] if k.startswith("llm_latency_seconds")
+    )
     llm_p95 = stats["histograms"][llm_key]["p95"]
-    turn_key = next(k for k in stats["histograms"] if k.startswith("total_turn_time_seconds"))
+    turn_key = next(
+        k for k in stats["histograms"] if k.startswith("total_turn_time_seconds")
+    )
     turn_p95 = stats["histograms"][turn_key]["p95"]
 
     assert vec_p95 < 0.05  # 50ms
     assert llm_p95 < 1.2
     assert turn_p95 < 3.0
 
+
 def test_memory_quality_tracking():
     """Test memory quality metrics tracking"""
     from src.ai_karen_engine.services.metrics_service import get_metrics_service
-    
+
     metrics_service = get_metrics_service()
-    
+
     # Test memory quality metrics
     metrics_service.update_memory_quality_metrics(
         context_usage_rate=0.75,
@@ -311,39 +360,43 @@ def test_memory_quality_tracking():
         avg_relevance_score=0.82,
         user_id="test_user",
         org_id="test_org",
-        correlation_id="test_correlation"
+        correlation_id="test_correlation",
     )
-    
+
     # Verify metrics were recorded
     stats = metrics_service.get_stats_summary()
     assert stats is not None
 
+
 def test_correlation_propagation():
     """Test correlation ID propagation through system layers"""
     from src.ai_karen_engine.services.correlation_service import (
-        CorrelationService, CorrelationHTTPClient, get_correlation_tracker
+        CorrelationHTTPClient,
+        CorrelationService,
+        get_correlation_tracker,
     )
-    
+
     # Test correlation ID propagation
     correlation_id = "test-propagation-123"
     CorrelationService.set_correlation_id(correlation_id)
-    
+
     # Verify context propagation
     retrieved_id = CorrelationService.get_correlation_id()
     assert retrieved_id == correlation_id
-    
+
     # Test HTTP client header propagation
     http_client = CorrelationHTTPClient()
     headers = http_client._add_correlation_headers({"Content-Type": "application/json"})
     assert "X-Correlation-Id" in headers
     assert headers["X-Correlation-Id"] == correlation_id
-    
+
     # Test trace tracking
     tracker = get_correlation_tracker()
     tracker.start_trace(correlation_id, "test_operation")
     trace = tracker.get_trace(correlation_id)
     assert trace is not None
     assert trace["correlation_id"] == correlation_id
+
 
 if __name__ == "__main__":
     # Run basic tests
@@ -356,7 +409,7 @@ if __name__ == "__main__":
     test_performance_thresholds()
     test_memory_quality_tracking()
     test_correlation_propagation()
-    
+
     print("✅ All observability infrastructure tests passed!")
     print("✅ Metrics collection system implemented")
     print("✅ Correlation ID tracking implemented")


### PR DESCRIPTION
## Summary
- hook in-memory Milvus client into MetricsService to record vector search latency and error status
- log provider/model latency for LLM generation and embedding calls
- add high-load latency test and document SLO alert rules

## Testing
- ⚠️ `pre-commit run --files monitoring/alert_rules.yml src/ai_karen_engine/core/milvus_client.py src/ai_karen_engine/integrations/llm_utils.py tests/test_observability_infrastructure.py` (fails: Function is missing a return type annotation and other mypy errors)
- ❌ `pytest tests/test_observability_infrastructure.py -q` (ModuleNotFoundError: No module named 'fastapi.middleware')
- ✅ `pytest tests/test_observability_infrastructure.py::test_high_load_p95_thresholds -q`


------
https://chatgpt.com/codex/tasks/task_e_689c245a77148324b1586b381c225a3b