### PR TITLE
Refactor RBAC middleware and fix error response serialization

### DIFF
--- a/src/ai_karen_engine/api_routes/ai_orchestrator_routes.py
+++ b/src/ai_karen_engine/api_routes/ai_orchestrator_routes.py
@@ -124,7 +124,7 @@ async def process_flow(
         )
         raise HTTPException(
             status_code=get_http_status_for_error_code(WebAPIErrorCode.AI_ORCHESTRATOR_ERROR),
-            detail=error_response.dict(),
+            detail=error_response.model_dump(mode="json"),
         )
 
 
@@ -165,7 +165,7 @@ async def decide_action(
         )
         raise HTTPException(
             status_code=get_http_status_for_error_code(WebAPIErrorCode.AI_ORCHESTRATOR_ERROR),
-            detail=error_response.dict(),
+            detail=error_response.model_dump(mode="json"),
         )
 
 
@@ -213,7 +213,7 @@ async def conversation_processing(
         )
         raise HTTPException(
             status_code=get_http_status_for_error_code(WebAPIErrorCode.AI_ORCHESTRATOR_ERROR),
-            detail=error_response.dict(),
+            detail=error_response.model_dump(mode="json"),
         )
 
 
@@ -250,7 +250,7 @@ async def get_available_flows(
         )
         raise HTTPException(
             status_code=get_http_status_for_error_code(WebAPIErrorCode.AI_ORCHESTRATOR_ERROR),
-            detail=error_response.dict(),
+            detail=error_response.model_dump(mode="json"),
         )
 
 
@@ -281,7 +281,7 @@ async def get_flow_metrics(
         )
         raise HTTPException(
             status_code=get_http_status_for_error_code(WebAPIErrorCode.AI_ORCHESTRATOR_ERROR),
-            detail=error_response.dict(),
+            detail=error_response.model_dump(mode="json"),
         )
 
 
@@ -316,7 +316,7 @@ async def generate_starter_prompts_get():
         )
         raise HTTPException(
             status_code=get_http_status_for_error_code(WebAPIErrorCode.AI_ORCHESTRATOR_ERROR),
-            detail=error_response.dict(),
+            detail=error_response.model_dump(mode="json"),
         )
 
 
@@ -338,7 +338,7 @@ async def generate_starter_prompts_post(body: Optional[Dict[str, Any]] = None):
         )
         raise HTTPException(
             status_code=get_http_status_for_error_code(WebAPIErrorCode.AI_ORCHESTRATOR_ERROR),
-            detail=error_response.dict(),
+            detail=error_response.model_dump(mode="json"),
         )
 
 

--- a/src/ai_karen_engine/api_routes/code_execution_routes.py
+++ b/src/ai_karen_engine/api_routes/code_execution_routes.py
@@ -139,7 +139,7 @@ async def execute_code(
             status_code=get_http_status_for_error_code(
                 WebAPIErrorCode.INTERNAL_SERVER_ERROR
             ),
-            detail=error_response.dict(),
+            detail=error_response.model_dump(mode="json"),
         )
 
 
@@ -180,7 +180,7 @@ async def get_supported_languages(
             status_code=get_http_status_for_error_code(
                 WebAPIErrorCode.INTERNAL_SERVER_ERROR
             ),
-            detail=error_response.dict(),
+            detail=error_response.model_dump(mode="json"),
         )
 
 
@@ -217,7 +217,7 @@ async def get_execution_history(
             status_code=get_http_status_for_error_code(
                 WebAPIErrorCode.INTERNAL_SERVER_ERROR
             ),
-            detail=error_response.dict(),
+            detail=error_response.model_dump(mode="json"),
         )
 
 
@@ -239,7 +239,7 @@ async def cancel_execution(
             )
             raise HTTPException(
                 status_code=get_http_status_for_error_code(WebAPIErrorCode.NOT_FOUND),
-                detail=error_response.dict(),
+                detail=error_response.model_dump(mode="json"),
             )
 
         return {"success": True, "message": "Execution cancelled successfully"}
@@ -262,7 +262,7 @@ async def cancel_execution(
             status_code=get_http_status_for_error_code(
                 WebAPIErrorCode.INTERNAL_SERVER_ERROR
             ),
-            detail=error_response.dict(),
+            detail=error_response.model_dump(mode="json"),
         )
 
 
@@ -307,7 +307,7 @@ async def execute_tool(
             status_code=get_http_status_for_error_code(
                 WebAPIErrorCode.INTERNAL_SERVER_ERROR
             ),
-            detail=error_response.dict(),
+            detail=error_response.model_dump(mode="json"),
         )
 
 
@@ -350,7 +350,7 @@ async def list_tools(
             status_code=get_http_status_for_error_code(
                 WebAPIErrorCode.INTERNAL_SERVER_ERROR
             ),
-            detail=error_response.dict(),
+            detail=error_response.model_dump(mode="json"),
         )
 
 
@@ -374,7 +374,7 @@ async def get_tool_info(
             )
             raise HTTPException(
                 status_code=get_http_status_for_error_code(WebAPIErrorCode.NOT_FOUND),
-                detail=error_response.dict(),
+                detail=error_response.model_dump(mode="json"),
             )
 
         return tool_info
@@ -397,7 +397,7 @@ async def get_tool_info(
             status_code=get_http_status_for_error_code(
                 WebAPIErrorCode.INTERNAL_SERVER_ERROR
             ),
-            detail=error_response.dict(),
+            detail=error_response.model_dump(mode="json"),
         )
 
 
@@ -437,7 +437,7 @@ async def get_tool_execution_history(
             status_code=get_http_status_for_error_code(
                 WebAPIErrorCode.INTERNAL_SERVER_ERROR
             ),
-            detail=error_response.dict(),
+            detail=error_response.model_dump(mode="json"),
         )
 
 
@@ -473,7 +473,7 @@ async def get_service_stats(
             status_code=get_http_status_for_error_code(
                 WebAPIErrorCode.INTERNAL_SERVER_ERROR
             ),
-            detail=error_response.dict(),
+            detail=error_response.model_dump(mode="json"),
         )
 
 
@@ -526,5 +526,5 @@ async def get_security_levels():
             status_code=get_http_status_for_error_code(
                 WebAPIErrorCode.INTERNAL_SERVER_ERROR
             ),
-            detail=error_response.dict(),
+            detail=error_response.model_dump(mode="json"),
         )

--- a/src/ai_karen_engine/api_routes/conversation_routes.py
+++ b/src/ai_karen_engine/api_routes/conversation_routes.py
@@ -287,7 +287,7 @@ async def create_conversation(
                 status_code=get_http_status_for_error_code(
                     WebAPIErrorCode.INTERNAL_SERVER_ERROR
                 ),
-                detail=error_response.dict(),
+                detail=error_response.model_dump(mode="json"),
             )
 
         return CreateConversationResponse(
@@ -308,7 +308,7 @@ async def create_conversation(
             status_code=get_http_status_for_error_code(
                 WebAPIErrorCode.INTERNAL_SERVER_ERROR
             ),
-            detail=error_response.dict(),
+            detail=error_response.model_dump(mode="json"),
         )
 
 
@@ -335,7 +335,7 @@ async def get_conversation(
             )
             raise HTTPException(
                 status_code=get_http_status_for_error_code(WebAPIErrorCode.NOT_FOUND),
-                detail=error_response.dict(),
+                detail=error_response.model_dump(mode="json"),
             )
 
         return _convert_conversation_to_response(conversation)
@@ -354,7 +354,7 @@ async def get_conversation(
             status_code=get_http_status_for_error_code(
                 WebAPIErrorCode.INTERNAL_SERVER_ERROR
             ),
-            detail=error_response.dict(),
+            detail=error_response.model_dump(mode="json"),
         )
 
 
@@ -390,7 +390,7 @@ async def add_message(
                 status_code=get_http_status_for_error_code(
                     WebAPIErrorCode.INTERNAL_SERVER_ERROR
                 ),
-                detail=error_response.dict(),
+                detail=error_response.model_dump(mode="json"),
             )
 
         message_dict = message.to_dict()
@@ -428,7 +428,7 @@ async def add_message(
             status_code=get_http_status_for_error_code(
                 WebAPIErrorCode.INTERNAL_SERVER_ERROR
             ),
-            detail=error_response.dict(),
+            detail=error_response.model_dump(mode="json"),
         )
 
 
@@ -462,7 +462,7 @@ async def build_context(
             status_code=get_http_status_for_error_code(
                 WebAPIErrorCode.INTERNAL_SERVER_ERROR
             ),
-            detail=error_response.dict(),
+            detail=error_response.model_dump(mode="json"),
         )
 
 
@@ -489,7 +489,7 @@ async def update_ui_context(
             )
             raise HTTPException(
                 status_code=get_http_status_for_error_code(WebAPIErrorCode.NOT_FOUND),
-                detail=error_response.dict(),
+                detail=error_response.model_dump(mode="json"),
             )
 
         return {"success": True, "message": "UI context updated successfully"}
@@ -508,7 +508,7 @@ async def update_ui_context(
             status_code=get_http_status_for_error_code(
                 WebAPIErrorCode.INTERNAL_SERVER_ERROR
             ),
-            detail=error_response.dict(),
+            detail=error_response.model_dump(mode="json"),
         )
 
 
@@ -535,7 +535,7 @@ async def update_ai_insights(
             )
             raise HTTPException(
                 status_code=get_http_status_for_error_code(WebAPIErrorCode.NOT_FOUND),
-                detail=error_response.dict(),
+                detail=error_response.model_dump(mode="json"),
             )
 
         return {"success": True, "message": "AI insights updated successfully"}
@@ -554,7 +554,7 @@ async def update_ai_insights(
             status_code=get_http_status_for_error_code(
                 WebAPIErrorCode.INTERNAL_SERVER_ERROR
             ),
-            detail=error_response.dict(),
+            detail=error_response.model_dump(mode="json"),
         )
 
 
@@ -581,7 +581,7 @@ async def add_tags(
             )
             raise HTTPException(
                 status_code=get_http_status_for_error_code(WebAPIErrorCode.NOT_FOUND),
-                detail=error_response.dict(),
+                detail=error_response.model_dump(mode="json"),
             )
 
         return {
@@ -603,7 +603,7 @@ async def add_tags(
             status_code=get_http_status_for_error_code(
                 WebAPIErrorCode.INTERNAL_SERVER_ERROR
             ),
-            detail=error_response.dict(),
+            detail=error_response.model_dump(mode="json"),
         )
 
 
@@ -663,7 +663,7 @@ async def list_conversations(
             status_code=get_http_status_for_error_code(
                 WebAPIErrorCode.INTERNAL_SERVER_ERROR
             ),
-            detail=error_response.dict(),
+            detail=error_response.model_dump(mode="json"),
         )
 
 
@@ -692,7 +692,7 @@ async def update_conversation(
             )
             raise HTTPException(
                 status_code=get_http_status_for_error_code(WebAPIErrorCode.NOT_FOUND),
-                detail=error_response.dict(),
+                detail=error_response.model_dump(mode="json"),
             )
 
         return {"success": True, "message": "Conversation updated successfully"}
@@ -711,7 +711,7 @@ async def update_conversation(
             status_code=get_http_status_for_error_code(
                 WebAPIErrorCode.INTERNAL_SERVER_ERROR
             ),
-            detail=error_response.dict(),
+            detail=error_response.model_dump(mode="json"),
         )
 
 
@@ -736,7 +736,7 @@ async def delete_conversation(
             )
             raise HTTPException(
                 status_code=get_http_status_for_error_code(WebAPIErrorCode.NOT_FOUND),
-                detail=error_response.dict(),
+                detail=error_response.model_dump(mode="json"),
             )
 
         return {"success": True, "message": "Conversation deleted successfully"}
@@ -755,7 +755,7 @@ async def delete_conversation(
             status_code=get_http_status_for_error_code(
                 WebAPIErrorCode.INTERNAL_SERVER_ERROR
             ),
-            detail=error_response.dict(),
+            detail=error_response.model_dump(mode="json"),
         )
 
 
@@ -798,7 +798,7 @@ async def get_analytics(
             status_code=get_http_status_for_error_code(
                 WebAPIErrorCode.INTERNAL_SERVER_ERROR
             ),
-            detail=error_response.dict(),
+            detail=error_response.model_dump(mode="json"),
         )
 
 
@@ -833,7 +833,7 @@ async def get_conversation_stats(
             status_code=get_http_status_for_error_code(
                 WebAPIErrorCode.INTERNAL_SERVER_ERROR
             ),
-            detail=error_response.dict(),
+            detail=error_response.model_dump(mode="json"),
         )
 
 
@@ -867,7 +867,7 @@ async def cleanup_inactive_conversations(
             status_code=get_http_status_for_error_code(
                 WebAPIErrorCode.INTERNAL_SERVER_ERROR
             ),
-            detail=error_response.dict(),
+            detail=error_response.model_dump(mode="json"),
         )
 
 

--- a/src/ai_karen_engine/api_routes/copilot_routes.py
+++ b/src/ai_karen_engine/api_routes/copilot_routes.py
@@ -245,7 +245,7 @@ async def copilot_assist(request: AssistRequest, http_request: Request):
             path=str(http_request.url.path),
             message="Insufficient permissions for copilot assistance",
         )
-        raise HTTPException(status_code=403, detail=error_response.dict())
+        raise HTTPException(status_code=403, detail=error_response.model_dump(mode="json"))
 
     try:
         with turn_timer:
@@ -643,7 +643,7 @@ Please provide a helpful response and suggest relevant actions."""
         error_response = ErrorHandler.create_internal_error_response(
             correlation_id=correlation_id, path=str(http_request.url.path), error=e
         )
-        raise HTTPException(status_code=500, detail=error_response.dict())
+        raise HTTPException(status_code=500, detail=error_response.model_dump(mode="json"))
 
 
 @router.get("/health")

--- a/src/ai_karen_engine/api_routes/enhanced_file_attachment_routes.py
+++ b/src/ai_karen_engine/api_routes/enhanced_file_attachment_routes.py
@@ -135,7 +135,7 @@ async def enhanced_upload_file(
                 status_code=get_http_status_for_error_code(
                     WebAPIErrorCode.VALIDATION_ERROR
                 ),
-                detail=error_response.dict(),
+                detail=error_response.model_dump(mode="json"),
             )
 
         # Stream file content to temporary file to enforce size limits
@@ -159,7 +159,7 @@ async def enhanced_upload_file(
                         status_code=get_http_status_for_error_code(
                             WebAPIErrorCode.VALIDATION_ERROR
                         ),
-                        detail=error_response.dict(),
+                        detail=error_response.model_dump(mode="json"),
                     )
                 tmp.write(chunk)
 
@@ -195,7 +195,7 @@ async def enhanced_upload_file(
                 status_code=get_http_status_for_error_code(
                     WebAPIErrorCode.INTERNAL_SERVER_ERROR
                 ),
-                detail=error_response.dict(),
+                detail=error_response.model_dump(mode="json"),
             )
 
         # Enhance response with UI metadata
@@ -241,7 +241,7 @@ async def enhanced_upload_file(
             status_code=get_http_status_for_error_code(
                 WebAPIErrorCode.INTERNAL_SERVER_ERROR
             ),
-            detail=error_response.dict(),
+            detail=error_response.model_dump(mode="json"),
         )
 
 
@@ -371,7 +371,7 @@ async def enhanced_list_files(
             status_code=get_http_status_for_error_code(
                 WebAPIErrorCode.INTERNAL_SERVER_ERROR
             ),
-            detail=error_response.dict(),
+            detail=error_response.model_dump(mode="json"),
         )
 
 
@@ -390,7 +390,7 @@ async def get_file_analysis(file_id: str):
             )
             raise HTTPException(
                 status_code=get_http_status_for_error_code(WebAPIErrorCode.NOT_FOUND),
-                detail=error_response.dict(),
+                detail=error_response.model_dump(mode="json"),
             )
 
         # Extract specific analysis components
@@ -424,7 +424,7 @@ async def get_file_analysis(file_id: str):
             status_code=get_http_status_for_error_code(
                 WebAPIErrorCode.INTERNAL_SERVER_ERROR
             ),
-            detail=error_response.dict(),
+            detail=error_response.model_dump(mode="json"),
         )
 
 
@@ -445,7 +445,7 @@ async def enhanced_process_multimedia(
             )
             raise HTTPException(
                 status_code=get_http_status_for_error_code(WebAPIErrorCode.NOT_FOUND),
-                detail=error_response.dict(),
+                detail=error_response.model_dump(mode="json"),
             )
 
         # Get file metadata to determine media type
@@ -461,7 +461,7 @@ async def enhanced_process_multimedia(
                 status_code=get_http_status_for_error_code(
                     WebAPIErrorCode.INTERNAL_SERVER_ERROR
                 ),
-                detail=error_response.dict(),
+                detail=error_response.model_dump(mode="json"),
             )
 
         # Determine media type
@@ -482,7 +482,7 @@ async def enhanced_process_multimedia(
                 status_code=get_http_status_for_error_code(
                     WebAPIErrorCode.VALIDATION_ERROR
                 ),
-                detail=error_response.dict(),
+                detail=error_response.model_dump(mode="json"),
             )
 
         # Create enhanced processing request
@@ -528,7 +528,7 @@ async def enhanced_process_multimedia(
             status_code=get_http_status_for_error_code(
                 WebAPIErrorCode.INTERNAL_SERVER_ERROR
             ),
-            detail=error_response.dict(),
+            detail=error_response.model_dump(mode="json"),
         )
 
 
@@ -594,7 +594,7 @@ async def get_file_statistics_dashboard():
             status_code=get_http_status_for_error_code(
                 WebAPIErrorCode.INTERNAL_SERVER_ERROR
             ),
-            detail=error_response.dict(),
+            detail=error_response.model_dump(mode="json"),
         )
 
 

--- a/src/ai_karen_engine/api_routes/file_attachment_routes.py
+++ b/src/ai_karen_engine/api_routes/file_attachment_routes.py
@@ -97,7 +97,7 @@ async def upload_file(
                 status_code=get_http_status_for_error_code(
                     WebAPIErrorCode.VALIDATION_ERROR
                 ),
-                detail=error_response.dict(),
+                detail=error_response.model_dump(mode="json"),
             )
 
         # Stream file content to temporary file to enforce size limits
@@ -121,7 +121,7 @@ async def upload_file(
                         status_code=get_http_status_for_error_code(
                             WebAPIErrorCode.VALIDATION_ERROR
                         ),
-                        detail=error_response.dict(),
+                        detail=error_response.model_dump(mode="json"),
                     )
                 tmp.write(chunk)
 
@@ -152,7 +152,7 @@ async def upload_file(
                 status_code=get_http_status_for_error_code(
                     WebAPIErrorCode.INTERNAL_SERVER_ERROR
                 ),
-                detail=error_response.dict(),
+                detail=error_response.model_dump(mode="json"),
             )
 
         return result
@@ -171,7 +171,7 @@ async def upload_file(
             status_code=get_http_status_for_error_code(
                 WebAPIErrorCode.INTERNAL_SERVER_ERROR
             ),
-            detail=error_response.dict(),
+            detail=error_response.model_dump(mode="json"),
         )
 
 
@@ -190,7 +190,7 @@ async def get_file_info(file_id: str):
             )
             raise HTTPException(
                 status_code=get_http_status_for_error_code(WebAPIErrorCode.NOT_FOUND),
-                detail=error_response.dict(),
+                detail=error_response.model_dump(mode="json"),
             )
 
         return result
@@ -209,7 +209,7 @@ async def get_file_info(file_id: str):
             status_code=get_http_status_for_error_code(
                 WebAPIErrorCode.INTERNAL_SERVER_ERROR
             ),
-            detail=error_response.dict(),
+            detail=error_response.model_dump(mode="json"),
         )
 
 
@@ -228,7 +228,7 @@ async def download_file(file_id: str):
             )
             raise HTTPException(
                 status_code=get_http_status_for_error_code(WebAPIErrorCode.NOT_FOUND),
-                detail=error_response.dict(),
+                detail=error_response.model_dump(mode="json"),
             )
 
         # Get file content
@@ -242,7 +242,7 @@ async def download_file(file_id: str):
             )
             raise HTTPException(
                 status_code=get_http_status_for_error_code(WebAPIErrorCode.NOT_FOUND),
-                detail=error_response.dict(),
+                detail=error_response.model_dump(mode="json"),
             )
 
         # Get file metadata for proper response
@@ -278,7 +278,7 @@ async def download_file(file_id: str):
             status_code=get_http_status_for_error_code(
                 WebAPIErrorCode.INTERNAL_SERVER_ERROR
             ),
-            detail=error_response.dict(),
+            detail=error_response.model_dump(mode="json"),
         )
 
 
@@ -297,7 +297,7 @@ async def get_file_thumbnail(file_id: str):
             )
             raise HTTPException(
                 status_code=get_http_status_for_error_code(WebAPIErrorCode.NOT_FOUND),
-                detail=error_response.dict(),
+                detail=error_response.model_dump(mode="json"),
             )
 
         def generate():
@@ -325,7 +325,7 @@ async def get_file_thumbnail(file_id: str):
             status_code=get_http_status_for_error_code(
                 WebAPIErrorCode.INTERNAL_SERVER_ERROR
             ),
-            detail=error_response.dict(),
+            detail=error_response.model_dump(mode="json"),
         )
 
 
@@ -344,7 +344,7 @@ async def process_multimedia(file_id: str, request: MultimediaProcessingRequest)
             )
             raise HTTPException(
                 status_code=get_http_status_for_error_code(WebAPIErrorCode.NOT_FOUND),
-                detail=error_response.dict(),
+                detail=error_response.model_dump(mode="json"),
             )
 
         # Get file metadata to determine media type
@@ -360,7 +360,7 @@ async def process_multimedia(file_id: str, request: MultimediaProcessingRequest)
                 status_code=get_http_status_for_error_code(
                     WebAPIErrorCode.INTERNAL_SERVER_ERROR
                 ),
-                detail=error_response.dict(),
+                detail=error_response.model_dump(mode="json"),
             )
 
         # Determine media type
@@ -381,7 +381,7 @@ async def process_multimedia(file_id: str, request: MultimediaProcessingRequest)
                 status_code=get_http_status_for_error_code(
                     WebAPIErrorCode.VALIDATION_ERROR
                 ),
-                detail=error_response.dict(),
+                detail=error_response.model_dump(mode="json"),
             )
 
         # Create processing request
@@ -415,7 +415,7 @@ async def process_multimedia(file_id: str, request: MultimediaProcessingRequest)
             status_code=get_http_status_for_error_code(
                 WebAPIErrorCode.INTERNAL_SERVER_ERROR
             ),
-            detail=error_response.dict(),
+            detail=error_response.model_dump(mode="json"),
         )
 
 
@@ -484,7 +484,7 @@ async def list_files(
             status_code=get_http_status_for_error_code(
                 WebAPIErrorCode.INTERNAL_SERVER_ERROR
             ),
-            detail=error_response.dict(),
+            detail=error_response.model_dump(mode="json"),
         )
 
 
@@ -503,7 +503,7 @@ async def delete_file(file_id: str):
             )
             raise HTTPException(
                 status_code=get_http_status_for_error_code(WebAPIErrorCode.NOT_FOUND),
-                detail=error_response.dict(),
+                detail=error_response.model_dump(mode="json"),
             )
 
         return {"success": True, "message": "File deleted successfully"}
@@ -522,7 +522,7 @@ async def delete_file(file_id: str):
             status_code=get_http_status_for_error_code(
                 WebAPIErrorCode.INTERNAL_SERVER_ERROR
             ),
-            detail=error_response.dict(),
+            detail=error_response.model_dump(mode="json"),
         )
 
 
@@ -551,7 +551,7 @@ async def get_multimedia_capabilities():
             status_code=get_http_status_for_error_code(
                 WebAPIErrorCode.INTERNAL_SERVER_ERROR
             ),
-            detail=error_response.dict(),
+            detail=error_response.model_dump(mode="json"),
         )
 
 
@@ -575,5 +575,5 @@ async def get_file_storage_stats():
             status_code=get_http_status_for_error_code(
                 WebAPIErrorCode.INTERNAL_SERVER_ERROR
             ),
-            detail=error_response.dict(),
+            detail=error_response.model_dump(mode="json"),
         )

--- a/src/ai_karen_engine/api_routes/memory_routes.py
+++ b/src/ai_karen_engine/api_routes/memory_routes.py
@@ -280,7 +280,7 @@ async def memory_search(request: MemQuery, http_request: Request):
             path=str(http_request.url.path),
             message="Insufficient permissions for memory search",
         )
-        raise HTTPException(status_code=403, detail=error_response.dict())
+        raise HTTPException(status_code=403, detail=error_response.model_dump(mode="json"))
 
     try:
         # Apply tenant filtering
@@ -464,7 +464,7 @@ async def memory_search(request: MemQuery, http_request: Request):
         error_response = ErrorHandler.create_internal_error_response(
             correlation_id=correlation_id, path=str(http_request.url.path), error=e
         )
-        raise HTTPException(status_code=500, detail=error_response.dict())
+        raise HTTPException(status_code=500, detail=error_response.model_dump(mode="json"))
 
 
 @router.post("/commit", response_model=MemCommitResponse)
@@ -493,7 +493,7 @@ async def memory_commit(request: MemCommit, http_request: Request):
             path=str(http_request.url.path),
             message="Insufficient permissions for memory commit",
         )
-        raise HTTPException(status_code=403, detail=error_response.dict())
+        raise HTTPException(status_code=403, detail=error_response.model_dump(mode="json"))
 
     try:
         # Field validations
@@ -525,7 +525,7 @@ async def memory_commit(request: MemCommit, http_request: Request):
                     )
                 ],
             )
-            raise HTTPException(status_code=422, detail=error_response.dict())
+            raise HTTPException(status_code=422, detail=error_response.model_dump(mode="json"))
 
         try:
             request.tags = ValidationUtils.validate_tags(request.tags)
@@ -555,7 +555,7 @@ async def memory_commit(request: MemCommit, http_request: Request):
                     )
                 ],
             )
-            raise HTTPException(status_code=422, detail=error_response.dict())
+            raise HTTPException(status_code=422, detail=error_response.model_dump(mode="json"))
 
         try:
             request.importance = ValidationUtils.validate_importance(request.importance)
@@ -585,7 +585,7 @@ async def memory_commit(request: MemCommit, http_request: Request):
                     )
                 ],
             )
-            raise HTTPException(status_code=422, detail=error_response.dict())
+            raise HTTPException(status_code=422, detail=error_response.model_dump(mode="json"))
 
         # Apply tenant filtering
         tenant_filters = apply_tenant_filtering(request.user_id, request.org_id)
@@ -667,7 +667,7 @@ async def memory_commit(request: MemCommit, http_request: Request):
         error_response = ErrorHandler.create_internal_error_response(
             correlation_id=correlation_id, path=str(http_request.url.path), error=e
         )
-        raise HTTPException(status_code=500, detail=error_response.dict())
+        raise HTTPException(status_code=500, detail=error_response.model_dump(mode="json"))
 
 
 @router.put("/{memory_id}", response_model=MemUpdateResponse)
@@ -696,7 +696,7 @@ async def memory_update(
             path=str(http_request.url.path),
             message="Insufficient permissions for memory update",
         )
-        raise HTTPException(status_code=403, detail=error_response.dict())
+        raise HTTPException(status_code=403, detail=error_response.model_dump(mode="json"))
 
     try:
         # Field validations
@@ -729,7 +729,7 @@ async def memory_update(
                         )
                     ],
                 )
-                raise HTTPException(status_code=422, detail=error_response.dict())
+                raise HTTPException(status_code=422, detail=error_response.model_dump(mode="json"))
 
         if request.tags is not None:
             try:
@@ -760,7 +760,7 @@ async def memory_update(
                         )
                     ],
                 )
-                raise HTTPException(status_code=422, detail=error_response.dict())
+                raise HTTPException(status_code=422, detail=error_response.model_dump(mode="json"))
 
         if request.importance is not None:
             try:
@@ -791,7 +791,7 @@ async def memory_update(
                         )
                     ],
                 )
-                raise HTTPException(status_code=422, detail=error_response.dict())
+                raise HTTPException(status_code=422, detail=error_response.model_dump(mode="json"))
 
         # Apply tenant filtering
         tenant_filters = apply_tenant_filtering(user_id, org_id)
@@ -875,7 +875,7 @@ async def memory_update(
         error_response = ErrorHandler.create_internal_error_response(
             correlation_id=correlation_id, path=str(http_request.url.path), error=e
         )
-        raise HTTPException(status_code=500, detail=error_response.dict())
+        raise HTTPException(status_code=500, detail=error_response.model_dump(mode="json"))
 
 
 @router.delete("/{memory_id}", response_model=MemDeleteResponse)
@@ -904,7 +904,7 @@ async def memory_delete(
             path=str(http_request.url.path),
             message="Insufficient permissions for memory deletion",
         )
-        raise HTTPException(status_code=403, detail=error_response.dict())
+        raise HTTPException(status_code=403, detail=error_response.model_dump(mode="json"))
 
     try:
         # Apply tenant filtering
@@ -974,7 +974,7 @@ async def memory_delete(
         error_response = ErrorHandler.create_internal_error_response(
             correlation_id=correlation_id, path=str(http_request.url.path), error=e
         )
-        raise HTTPException(status_code=500, detail=error_response.dict())
+        raise HTTPException(status_code=500, detail=error_response.model_dump(mode="json"))
 
 
 @router.get("/health")

--- a/src/ai_karen_engine/api_routes/plugin_routes.py
+++ b/src/ai_karen_engine/api_routes/plugin_routes.py
@@ -172,7 +172,7 @@ async def list_plugins(
         )
         raise HTTPException(
             status_code=get_http_status_for_error_code(WebAPIErrorCode.PLUGIN_ERROR),
-            detail=error_response.dict(),
+            detail=error_response.model_dump(mode="json"),
         )
 
 
@@ -193,7 +193,7 @@ async def get_plugin_info(
             )
             raise HTTPException(
                 status_code=get_http_status_for_error_code(WebAPIErrorCode.NOT_FOUND),
-                detail=error_response.dict(),
+                detail=error_response.model_dump(mode="json"),
             )
 
         return PluginInfoResponse(
@@ -228,7 +228,7 @@ async def get_plugin_info(
         )
         raise HTTPException(
             status_code=get_http_status_for_error_code(WebAPIErrorCode.PLUGIN_ERROR),
-            detail=error_response.dict(),
+            detail=error_response.model_dump(mode="json"),
         )
 
 
@@ -276,7 +276,7 @@ async def execute_plugin(
         )
         raise HTTPException(
             status_code=get_http_status_for_error_code(WebAPIErrorCode.PLUGIN_ERROR),
-            detail=error_response.dict(),
+            detail=error_response.model_dump(mode="json"),
         )
 
 
@@ -310,7 +310,7 @@ async def validate_plugin_parameters(
         )
         raise HTTPException(
             status_code=get_http_status_for_error_code(WebAPIErrorCode.PLUGIN_ERROR),
-            detail=error_response.dict(),
+            detail=error_response.model_dump(mode="json"),
         )
 
 
@@ -335,7 +335,7 @@ async def enable_plugin(
             )
             raise HTTPException(
                 status_code=get_http_status_for_error_code(WebAPIErrorCode.NOT_FOUND),
-                detail=error_response.dict(),
+                detail=error_response.model_dump(mode="json"),
             )
 
         return {
@@ -359,7 +359,7 @@ async def enable_plugin(
         )
         raise HTTPException(
             status_code=get_http_status_for_error_code(WebAPIErrorCode.PLUGIN_ERROR),
-            detail=error_response.dict(),
+            detail=error_response.model_dump(mode="json"),
         )
 
 
@@ -384,7 +384,7 @@ async def disable_plugin(
             )
             raise HTTPException(
                 status_code=get_http_status_for_error_code(WebAPIErrorCode.NOT_FOUND),
-                detail=error_response.dict(),
+                detail=error_response.model_dump(mode="json"),
             )
 
         return {
@@ -408,7 +408,7 @@ async def disable_plugin(
         )
         raise HTTPException(
             status_code=get_http_status_for_error_code(WebAPIErrorCode.PLUGIN_ERROR),
-            detail=error_response.dict(),
+            detail=error_response.model_dump(mode="json"),
         )
 
 
@@ -448,7 +448,7 @@ async def get_plugin_categories(
         )
         raise HTTPException(
             status_code=get_http_status_for_error_code(WebAPIErrorCode.PLUGIN_ERROR),
-            detail=error_response.dict(),
+            detail=error_response.model_dump(mode="json"),
         )
 
 
@@ -486,7 +486,7 @@ async def get_plugin_metrics(
         )
         raise HTTPException(
             status_code=get_http_status_for_error_code(WebAPIErrorCode.PLUGIN_ERROR),
-            detail=error_response.dict(),
+            detail=error_response.model_dump(mode="json"),
         )
 
 
@@ -523,7 +523,7 @@ async def reload_plugins(
         )
         raise HTTPException(
             status_code=get_http_status_for_error_code(WebAPIErrorCode.PLUGIN_ERROR),
-            detail=error_response.dict(),
+            detail=error_response.model_dump(mode="json"),
         )
 
 

--- a/src/ai_karen_engine/api_routes/privacy_routes.py
+++ b/src/ai_karen_engine/api_routes/privacy_routes.py
@@ -123,7 +123,7 @@ if FASTAPI_AVAILABLE:
                 path=str(http_request.url.path),
                 message="Insufficient permissions for data export"
             )
-            raise HTTPException(status_code=403, detail=error_response.dict())
+            raise HTTPException(status_code=403, detail=error_response.model_dump(mode="json"))
         
         try:
             # Create privacy request
@@ -150,7 +150,7 @@ if FASTAPI_AVAILABLE:
                 path=str(http_request.url.path),
                 error=e
             )
-            raise HTTPException(status_code=500, detail=error_response.dict())
+            raise HTTPException(status_code=500, detail=error_response.model_dump(mode="json"))
     
     @router.post("/erasure/request", response_model=PrivacyRequestResponse)
     async def request_data_erasure(
@@ -173,7 +173,7 @@ if FASTAPI_AVAILABLE:
                 path=str(http_request.url.path),
                 message="Insufficient permissions for data erasure"
             )
-            raise HTTPException(status_code=403, detail=error_response.dict())
+            raise HTTPException(status_code=403, detail=error_response.model_dump(mode="json"))
         
         try:
             # Create privacy request
@@ -204,7 +204,7 @@ if FASTAPI_AVAILABLE:
                 path=str(http_request.url.path),
                 error=e
             )
-            raise HTTPException(status_code=500, detail=error_response.dict())
+            raise HTTPException(status_code=500, detail=error_response.model_dump(mode="json"))
     
     @router.get("/request/{request_id}/status", response_model=PrivacyRequestStatusResponse)
     async def get_privacy_request_status(
@@ -226,7 +226,7 @@ if FASTAPI_AVAILABLE:
                 path=str(http_request.url.path),
                 message="Insufficient permissions to view privacy requests"
             )
-            raise HTTPException(status_code=403, detail=error_response.dict())
+            raise HTTPException(status_code=403, detail=error_response.model_dump(mode="json"))
         
         try:
             privacy_request = privacy_service.get_privacy_request_status(request_id)
@@ -237,7 +237,7 @@ if FASTAPI_AVAILABLE:
                     path=str(http_request.url.path),
                     resource="Privacy request"
                 )
-                raise HTTPException(status_code=404, detail=error_response.dict())
+                raise HTTPException(status_code=404, detail=error_response.model_dump(mode="json"))
             
             return PrivacyRequestStatusResponse(
                 request_id=privacy_request.request_id,
@@ -261,7 +261,7 @@ if FASTAPI_AVAILABLE:
                 path=str(http_request.url.path),
                 error=e
             )
-            raise HTTPException(status_code=500, detail=error_response.dict())
+            raise HTTPException(status_code=500, detail=error_response.model_dump(mode="json"))
     
     @router.post("/request/{request_id}/process")
     async def process_privacy_request(
@@ -284,7 +284,7 @@ if FASTAPI_AVAILABLE:
                 path=str(http_request.url.path),
                 message="Insufficient permissions to process privacy requests"
             )
-            raise HTTPException(status_code=403, detail=error_response.dict())
+            raise HTTPException(status_code=403, detail=error_response.model_dump(mode="json"))
         
         try:
             privacy_request = privacy_service.get_privacy_request_status(request_id)
@@ -295,7 +295,7 @@ if FASTAPI_AVAILABLE:
                     path=str(http_request.url.path),
                     resource="Privacy request"
                 )
-                raise HTTPException(status_code=404, detail=error_response.dict())
+                raise HTTPException(status_code=404, detail=error_response.model_dump(mode="json"))
             
             # Verify token
             if privacy_request.verification_token != verification_token:
@@ -304,7 +304,7 @@ if FASTAPI_AVAILABLE:
                     path=str(http_request.url.path),
                     message="Invalid verification token"
                 )
-                raise HTTPException(status_code=403, detail=error_response.dict())
+                raise HTTPException(status_code=403, detail=error_response.model_dump(mode="json"))
             
             # Process based on request type
             if privacy_request.request_type == "export":
@@ -345,7 +345,7 @@ if FASTAPI_AVAILABLE:
                 path=str(http_request.url.path),
                 error=e
             )
-            raise HTTPException(status_code=500, detail=error_response.dict())
+            raise HTTPException(status_code=500, detail=error_response.model_dump(mode="json"))
     
     @router.post("/content/sanitize")
     async def sanitize_content(
@@ -368,7 +368,7 @@ if FASTAPI_AVAILABLE:
                 path=str(http_request.url.path),
                 message="Insufficient permissions to sanitize content"
             )
-            raise HTTPException(status_code=403, detail=error_response.dict())
+            raise HTTPException(status_code=403, detail=error_response.model_dump(mode="json"))
         
         try:
             safe_preview = privacy_service.create_safe_content_preview(content)
@@ -387,7 +387,7 @@ if FASTAPI_AVAILABLE:
                 path=str(http_request.url.path),
                 error=e
             )
-            raise HTTPException(status_code=500, detail=error_response.dict())
+            raise HTTPException(status_code=500, detail=error_response.model_dump(mode="json"))
     
     @router.get("/health")
     async def privacy_health_check():

--- a/src/ai_karen_engine/api_routes/slo_routes.py
+++ b/src/ai_karen_engine/api_routes/slo_routes.py
@@ -172,7 +172,7 @@ async def get_slo_status(request: Request):
         )
         raise HTTPException(
             status_code=500,
-            detail=error_response.dict()
+            detail=error_response.model_dump(mode="json")
         )
 
 @router.get("/dashboard", response_model=SLODashboardResponse)
@@ -291,7 +291,7 @@ async def get_slo_dashboard(request: Request):
         )
         raise HTTPException(
             status_code=500,
-            detail=error_response.dict()
+            detail=error_response.model_dump(mode="json")
         )
 
 @router.get("/metrics", response_model=MetricsExportResponse)
@@ -343,7 +343,7 @@ async def export_metrics(request: Request):
         )
         raise HTTPException(
             status_code=500,
-            detail=error_response.dict()
+            detail=error_response.model_dump(mode="json")
         )
 
 @router.post("/alerts/{alert_id}/resolve")
@@ -388,7 +388,7 @@ async def resolve_alert(alert_id: str, request: Request):
         )
         raise HTTPException(
             status_code=500,
-            detail=error_response.dict()
+            detail=error_response.model_dump(mode="json")
         )
 
 @router.get("/health")

--- a/src/ai_karen_engine/api_routes/unified_schemas.py
+++ b/src/ai_karen_engine/api_routes/unified_schemas.py
@@ -364,7 +364,7 @@ if FASTAPI_AVAILABLE:
         
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail=error_response.dict()
+            detail=error_response.model_dump(mode="json")
         )
 
     async def http_exception_handler(request: Request, exc: HTTPException):
@@ -409,7 +409,7 @@ if FASTAPI_AVAILABLE:
         
         raise HTTPException(
             status_code=exc.status_code,
-            detail=error_response.dict()
+            detail=error_response.model_dump(mode="json")
         )
 else:
     # Fallback handlers when FastAPI is not available

--- a/src/ai_karen_engine/api_routes/web_api_compatibility.py
+++ b/src/ai_karen_engine/api_routes/web_api_compatibility.py
@@ -87,7 +87,7 @@ def handle_service_error(
     # Get appropriate HTTP status code
     status_code = get_http_status_for_error_code(error_code)
 
-    return HTTPException(status_code=status_code, detail=error_response.dict())
+    return HTTPException(status_code=status_code, detail=error_response.model_dump(mode="json"))
 
 
 def create_fallback_chat_response(
@@ -651,7 +651,7 @@ async def memory_store_compatibility(
             )
             raise HTTPException(
                 status_code=get_http_status_for_error_code(error_response.type),
-                detail=error_response.dict(),
+                detail=error_response.model_dump(mode="json"),
             )
 
         # Database schema validation - check if memory_entries table exists
@@ -682,7 +682,7 @@ async def memory_store_compatibility(
             )
             raise HTTPException(
                 status_code=get_http_status_for_error_code(error_response.type),
-                detail=error_response.dict(),
+                detail=error_response.model_dump(mode="json"),
             )
 
         # Transform request to backend format
@@ -705,7 +705,7 @@ async def memory_store_compatibility(
             )
             raise HTTPException(
                 status_code=get_http_status_for_error_code(error_response.type),
-                detail=error_response.dict(),
+                detail=error_response.model_dump(mode="json"),
             )
 
         # Validate user ID - store anonymously if not a valid UUID
@@ -838,7 +838,7 @@ async def memory_store_compatibility(
 
             raise HTTPException(
                 status_code=get_http_status_for_error_code(error_response.type),
-                detail=error_response.dict(),
+                detail=error_response.model_dump(mode="json"),
             )
 
         storage_time = (datetime.utcnow() - start_time).total_seconds() * 1000
@@ -901,7 +901,7 @@ async def memory_store_compatibility(
         )
         raise HTTPException(
             status_code=get_http_status_for_error_code(error_response.type),
-            detail=error_response.dict(),
+            detail=error_response.model_dump(mode="json"),
         )
 
     except ValueError as e:
@@ -915,7 +915,7 @@ async def memory_store_compatibility(
         )
         raise HTTPException(
             status_code=get_http_status_for_error_code(error_response.type),
-            detail=error_response.dict(),
+            detail=error_response.model_dump(mode="json"),
         )
 
     except Exception as e:
@@ -931,7 +931,7 @@ async def memory_store_compatibility(
         )
         raise HTTPException(
             status_code=get_http_status_for_error_code(error_response.type),
-            detail=error_response.dict(),
+            detail=error_response.model_dump(mode="json"),
         )
 
 

--- a/src/ai_karen_engine/core/error_handler.py
+++ b/src/ai_karen_engine/core/error_handler.py
@@ -17,4 +17,4 @@ def handle_api_exception(error: Exception, user_message: str | None = None) -> J
     if user_message:
         error_response.message = user_message
     status_code = handler.get_http_status_code(error_response.error_code)
-    return JSONResponse(status_code=status_code, content=error_response.dict())
+    return JSONResponse(status_code=status_code, content=error_response.model_dump(mode="json"))

--- a/src/ai_karen_engine/core/errors/middleware.py
+++ b/src/ai_karen_engine/core/errors/middleware.py
@@ -72,7 +72,7 @@ class ErrorHandlingMiddleware(BaseHTTPMiddleware):
             # Return JSON error response
             return JSONResponse(
                 status_code=status_code,
-                content=error_response.dict(),
+                content=error_response.model_dump(mode="json"),
                 headers={
                     "X-Request-ID": request_id,
                     "X-Trace-ID": trace_id

--- a/src/ai_karen_engine/middleware/__init__.py
+++ b/src/ai_karen_engine/middleware/__init__.py
@@ -3,11 +3,11 @@
 from ai_karen_engine.middleware.auth import auth_middleware
 from ai_karen_engine.middleware.error_counter import error_counter_middleware
 from ai_karen_engine.middleware.rate_limit import rate_limit_middleware
-from ai_karen_engine.middleware.rbac import rbac_middleware, require_scopes
+from ai_karen_engine.middleware.rbac import setup_rbac, require_scopes
 
 __all__ = [
     "auth_middleware",
-    "rbac_middleware",
+    "setup_rbac",
     "require_scopes",
     "error_counter_middleware",
     "rate_limit_middleware",

--- a/src/ai_karen_engine/pydantic_stub/__init__.py
+++ b/src/ai_karen_engine/pydantic_stub/__init__.py
@@ -61,7 +61,7 @@ class BaseModel:
         return self.__dict__.copy()
 
     # Pydantic v2 compatible name
-    def model_dump(self) -> dict[str, Any]:
+    def model_dump(self, *args, **kwargs) -> dict[str, Any]:
         return self.dict()
 
 

--- a/src/ai_karen_engine/server/middleware.py
+++ b/src/ai_karen_engine/server/middleware.py
@@ -11,6 +11,7 @@ from starlette.middleware.sessions import SessionMiddleware
 
 from ai_karen_engine.middleware.error_counter import error_counter_middleware
 from ai_karen_engine.middleware.rate_limit import rate_limit_middleware
+from ai_karen_engine.middleware.rbac import setup_rbac
 from .http_validator import HTTPRequestValidator, ValidationConfig
 
 logger = logging.getLogger(__name__)
@@ -47,6 +48,10 @@ def configure_middleware(
     )
 
     app.add_middleware(GZipMiddleware, minimum_size=1000)
+
+    # RBAC middleware configured based on environment
+    development_mode = getattr(settings, "environment", "").lower() != "production"
+    setup_rbac(app, development_mode=development_mode)
 
     # Register custom middlewares
     app.middleware("http")(rate_limit_middleware)

--- a/tests/test_rbac_middleware.py
+++ b/tests/test_rbac_middleware.py
@@ -1,0 +1,52 @@
+import asyncio
+from types import SimpleNamespace
+
+from fastapi.responses import JSONResponse
+
+from ai_karen_engine.middleware.rbac import RBACMiddleware, setup_rbac
+
+
+def _make_request():
+    return SimpleNamespace(
+        headers={},
+        state=SimpleNamespace(),
+        url=SimpleNamespace(path="/"),
+        method="GET",
+        client=SimpleNamespace(host="127.0.0.1"),
+    )
+
+
+def test_development_mode_allows_request():
+    rbac = RBACMiddleware(development_mode=True)
+    req = _make_request()
+    result = asyncio.run(rbac.validate_scopes(req, {"chat:write"}))
+    assert result is True
+
+
+def test_production_mode_requires_authentication():
+    rbac = RBACMiddleware(development_mode=False)
+    req = _make_request()
+    result = asyncio.run(rbac.validate_scopes(req, {"chat:write"}))
+    assert result is False
+    error_response = rbac.create_rbac_error_response(req, "Authentication required", 401)
+    resp = JSONResponse(status_code=401, content=error_response.model_dump(mode="json"))
+    assert resp.status_code == 401
+
+
+def test_app_instances_are_isolated():
+    class DummyApp:
+        def __init__(self):
+            self.state = SimpleNamespace()
+
+        def middleware(self, _type):
+            def decorator(func):
+                return func
+
+            return decorator
+
+    app1 = DummyApp()
+    app2 = DummyApp()
+    setup_rbac(app1, development_mode=True)
+    setup_rbac(app2, development_mode=False)
+    assert app1.state.rbac is not app2.state.rbac
+


### PR DESCRIPTION
## Summary
- use `model_dump(mode="json")` for error responses so datetime fields serialize
- refactor RBAC middleware to avoid global state and configure via FastAPI app state
- derive RBAC development mode from settings during startup
- add tests for RBAC development mode and instance isolation

## Testing
- `python -m pytest tests/test_rbac_middleware.py -vv`


------
https://chatgpt.com/codex/tasks/task_e_689c8cd97ddc83249d6e6d65f60b1af1