### PR TITLE
feat: add confidence pct helper

### DIFF
--- a/ui_launchers/web_ui/src/lib/__tests__/computeConfidencePct.test.ts
+++ b/ui_launchers/web_ui/src/lib/__tests__/computeConfidencePct.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { computeConfidencePct } from "@/lib/utils";
+
+describe("computeConfidencePct", () => {
+  it("converts numeric values to percentage", () => {
+    expect(computeConfidencePct(0.85)).toBe(85);
+  });
+
+  it("converts numeric strings to percentage", () => {
+    expect(computeConfidencePct("0.501")).toBe(50);
+  });
+
+  it("returns null for invalid inputs", () => {
+    expect(computeConfidencePct("abc")).toBeNull();
+    expect(computeConfidencePct(null)).toBeNull();
+    expect(computeConfidencePct(NaN)).toBeNull();
+  });
+});

--- a/ui_launchers/web_ui/src/lib/utils.ts
+++ b/ui_launchers/web_ui/src/lib/utils.ts
@@ -30,3 +30,16 @@ export function widgetRefId(tag: string): string {
   const match = tag.match(/\uE200forecast\uE202(.*?)\uE201/);
   return match ? match[1] : '';
 }
+
+export function computeConfidencePct(value: unknown): number | null {
+  if (typeof value === 'number' && isFinite(value)) {
+    return Math.round(value * 100)
+  }
+  if (typeof value === 'string') {
+    const n = Number(value)
+    if (!Number.isNaN(n) && isFinite(n)) {
+      return Math.round(n * 100)
+    }
+  }
+  return null
+}


### PR DESCRIPTION
## Summary
- add computeConfidencePct utility to convert fractional confidence to percentage or null
- cover computeConfidencePct with unit tests for numbers, strings, invalid input

## Testing
- `npx --yes vitest run src/lib/__tests__/computeConfidencePct.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689ca11439fc8324a832d6799c68f80d