### PR TITLE
feat: add meta bar component

### DIFF
--- a/ui_launchers/web_ui/src/__tests__/meta-bar.test.tsx
+++ b/ui_launchers/web_ui/src/__tests__/meta-bar.test.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { MetaBar } from '@/components/chat';
+
+describe('MetaBar', () => {
+  it('renders provided metadata badges', () => {
+    render(<MetaBar model="gpt-4" latencyMs={123} confidence={0.9} annotations={2} />);
+
+    expect(screen.getByText('Model: gpt-4')).toBeInTheDocument();
+    expect(screen.getByText('Latency: 123ms')).toBeInTheDocument();
+    expect(screen.getByText('Confidence: 0.9')).toBeInTheDocument();
+    expect(screen.getByText('Annotations: 2')).toBeInTheDocument();
+  });
+
+  it('hides badges for absent fields', () => {
+    render(<MetaBar model="gpt-4" />);
+
+    expect(screen.getByText('Model: gpt-4')).toBeInTheDocument();
+    expect(screen.queryByText(/Latency:/)).toBeNull();
+    expect(screen.queryByText(/Confidence:/)).toBeNull();
+    expect(screen.queryByText(/Annotations:/)).toBeNull();
+  });
+});

--- a/ui_launchers/web_ui/src/app/chat/page.tsx
+++ b/ui_launchers/web_ui/src/app/chat/page.tsx
@@ -14,7 +14,7 @@ import {
 } from "lucide-react";
 import { ProtectedRoute } from "@/components/auth/ProtectedRoute";
 import { AuthenticatedHeader } from "@/components/layout/AuthenticatedHeader";
-import MetaBar from "@/components/chat/MetaBar";
+import { MetaBar } from "@/components/chat";
 import InputBox from "@/components/chat/InputBox";
 import { CopilotChat } from "@/components/copilot";
 import { webUIConfig } from "@/lib/config";
@@ -148,7 +148,7 @@ function ChatView() {
           )}
 
           <SidebarInset className="flex-1 flex flex-col min-h-0">
-            <MetaBar title="Chat" />
+            <MetaBar />
             <main className="flex-1 flex flex-col min-h-0 p-4 md:p-6 overflow-y-auto">
               <CopilotChat className="flex-1" />
             </main>

--- a/ui_launchers/web_ui/src/components/chat/MetaBar.tsx
+++ b/ui_launchers/web_ui/src/components/chat/MetaBar.tsx
@@ -1,17 +1,62 @@
 'use client';
 
 import React from 'react';
+import { Badge } from '@/components/ui/badge';
 
 interface MetaBarProps {
-  title?: string;
-  children?: React.ReactNode;
+  confidence?: number;
+  annotations?: number;
+  latencyMs?: number;
+  model?: string;
 }
 
-export const MetaBar: React.FC<MetaBarProps> = ({ title = 'Chat', children }) => {
+export const MetaBar: React.FC<MetaBarProps> = ({
+  confidence,
+  annotations,
+  latencyMs,
+  model,
+}) => {
+  const items: React.ReactNode[] = [];
+
+  if (model) {
+    items.push(
+      <Badge key="model" variant="secondary" className="text-xs">
+        Model: {model}
+      </Badge>,
+    );
+  }
+
+  if (typeof latencyMs === 'number') {
+    items.push(
+      <Badge key="latency" variant="secondary" className="text-xs">
+        Latency: {latencyMs}ms
+      </Badge>,
+    );
+  }
+
+  if (typeof confidence === 'number') {
+    items.push(
+      <Badge key="confidence" variant="secondary" className="text-xs">
+        Confidence: {confidence}
+      </Badge>,
+    );
+  }
+
+  if (typeof annotations === 'number') {
+    items.push(
+      <Badge key="annotations" variant="secondary" className="text-xs">
+        Annotations: {annotations}
+      </Badge>,
+    );
+  }
+
+  if (items.length === 0) {
+    return null;
+  }
+
   return (
-    <div className="flex items-center justify-between border-b border-border px-4 py-2">
-      <h2 className="text-lg font-semibold tracking-tight">{title}</h2>
-      {children}
+    <div className="flex items-center gap-2 border-b border-border px-4 py-2">
+      {items}
     </div>
   );
 };

--- a/ui_launchers/web_ui/src/components/chat/index.ts
+++ b/ui_launchers/web_ui/src/components/chat/index.ts
@@ -7,6 +7,7 @@ export { default as LegacyChatInterface } from './ChatInterface';
 
 // Export supporting components
 export { MessageBubble } from './MessageBubble';
+export { MetaBar } from './MetaBar';
 
 // Export AG-UI components
 export { ConversationGrid } from './ConversationGrid';


### PR DESCRIPTION
## Summary
- add MetaBar React component showing model, latency, confidence and annotations badges
- export MetaBar from chat components barrel and use it on chat page
- test conditional badge rendering

## Testing
- `npx vitest run src/__tests__/meta-bar.test.tsx` *(fails: Directory import '@mui/utils/composeClasses' is not supported)*

------
https://chatgpt.com/codex/tasks/task_e_689cbbc0e55c8324aeb33d84a59a34e0