### PR TITLE
feat: improve health checks and diagnostics

### DIFF
--- a/ui_launchers/web_ui/src/lib/__tests__/karen-backend.test.ts
+++ b/ui_launchers/web_ui/src/lib/__tests__/karen-backend.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { KarenBackendService } from '../karen-backend';
+
+vi.mock('../config', () => ({
+  webUIConfig: {
+    backendUrl: 'http://localhost:8000',
+    apiKey: '',
+    apiTimeout: 5000,
+    cacheTtl: 1000,
+    debugLogging: false,
+    requestLogging: false,
+    performanceMonitoring: false,
+    logLevel: 'info',
+    maxRetries: 3,
+    retryDelay: 100,
+  },
+}));
+
+vi.mock('../performance-monitor', () => ({
+  getPerformanceMonitor: () => ({
+    trackRequest: vi.fn(),
+    trackError: vi.fn(),
+  }),
+}));
+
+const mockFetch = vi.fn();
+(global as any).fetch = mockFetch;
+
+describe('KarenBackendService', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  it('retrieves plugin list from cache after first fetch', async () => {
+    const service = new KarenBackendService();
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ plugins: [{ name: 'test', description: '', category: '', enabled: true, version: '1.0' }] }),
+    } as any);
+
+    const first = await service.getAvailablePlugins();
+    expect(first.length).toBe(1);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    const second = await service.getAvailablePlugins();
+    expect(second.length).toBe(1);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+});
+

--- a/ui_launchers/web_ui/src/lib/__tests__/network-diagnostics.test.ts
+++ b/ui_launchers/web_ui/src/lib/__tests__/network-diagnostics.test.ts
@@ -204,6 +204,26 @@ describe('NetworkDiagnostics', () => {
       );
     });
 
+    it('should send body when provided', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        headers: new Map(),
+      });
+
+      const body = JSON.stringify({ ping: true });
+      await networkDiagnostics.testEndpointConnectivity('/api/ping', 'POST', 5000, undefined, body);
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:8000/api/ping',
+        expect.objectContaining({
+          method: 'POST',
+          body,
+        })
+      );
+    });
+
     it('should handle full URLs', async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,

--- a/ui_launchers/web_ui/src/lib/health-monitor.ts
+++ b/ui_launchers/web_ui/src/lib/health-monitor.ts
@@ -203,8 +203,9 @@ class HealthMonitor {
       // Check AI conversation processing endpoint (lightweight test)
       await this.checkEndpoint('/api/ai/conversation-processing', async (signal) => {
         const response = await fetch(`${webUIConfig.backendUrl}/api/ai/conversation-processing`, {
-          method: 'HEAD',
+          method: 'POST',
           headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ messages: [] }),
           signal,
         });
         return { status: response.ok ? 'healthy' : 'error' };

--- a/ui_launchers/web_ui/src/lib/network-diagnostics.ts
+++ b/ui_launchers/web_ui/src/lib/network-diagnostics.ts
@@ -14,6 +14,7 @@ export interface NetworkTest {
   expectedStatus?: number;
   timeout?: number;
   headers?: Record<string, string>;
+  body?: string;
 }
 
 export interface NetworkTestResult {
@@ -74,7 +75,8 @@ class NetworkDiagnostics {
     endpoint: string,
     method: string = 'GET',
     timeout: number = 5000,
-    headers?: Record<string, string>
+    headers?: Record<string, string>,
+    body?: string
   ): Promise<NetworkDiagnostic> {
     const startTime = Date.now();
     const fullUrl = endpoint.startsWith('http') ? endpoint : `${webUIConfig.backendUrl}${endpoint}`;
@@ -89,6 +91,7 @@ class NetworkDiagnostics {
           'Content-Type': 'application/json',
           ...headers,
         },
+        body,
         signal: controller.signal,
       });
 
@@ -227,7 +230,8 @@ class NetworkDiagnostics {
         name: 'Chat Endpoint',
         description: 'Test chat endpoint availability',
         endpoint: '/api/ai/conversation-processing',
-        method: 'HEAD',
+        method: 'POST',
+        body: JSON.stringify({ messages: [] }),
       },
       {
         name: 'Memory Endpoint Options',
@@ -270,7 +274,9 @@ class NetworkDiagnostics {
         const diagnostic = await this.testEndpointConnectivity(
           test.endpoint,
           test.method,
-          test.timeout || 10000
+          test.timeout || 10000,
+          test.headers,
+          test.body
         );
 
         const success = diagnostic.status === 'success' && 


### PR DESCRIPTION
## Summary
- use POST for conversation-processing health checks
- support request bodies in network diagnostics tests
- cache plugin list using updated path

## Testing
- `npm test` *(fails: Network Scenarios End-to-End Tests, memory components, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689ceeff34348324a215024a3ae4d6aa