### PR TITLE
Await asynchronous CopilotKit suggestions in chat orchestrator

### DIFF
--- a/src/ai_karen_engine/chat/chat_orchestrator.py
+++ b/src/ai_karen_engine/chat/chat_orchestrator.py
@@ -958,11 +958,11 @@ class ChatOrchestrator:
             # Check if this is a code-related request for CopilotKit code assistance
             if self._is_code_related_message(message):
                 # Get code suggestions from CopilotKit if available
-                code_suggestions = orchestrator.get_code_suggestions(
-                    enhanced_prompt, 
+                code_suggestions = await orchestrator.get_code_suggestions(
+                    enhanced_prompt,
                     language=self._detect_programming_language(message)
                 )
-                
+
                 if code_suggestions:
                     # Use CopilotKit for code-related responses
                     copilot_response = orchestrator.route_with_copilotkit(
@@ -983,8 +983,8 @@ class ChatOrchestrator:
                     return copilot_response
             
             # Get contextual suggestions from CopilotKit
-            contextual_suggestions = orchestrator.get_contextual_suggestions(
-                enhanced_prompt, 
+            contextual_suggestions = await orchestrator.get_contextual_suggestions(
+                enhanced_prompt,
                 integrated_context.to_dict() if integrated_context else {}
             )
             
@@ -1140,11 +1140,11 @@ class ChatOrchestrator:
             # Check if this is a code-related request for CopilotKit code assistance
             if self._is_code_related_message(message):
                 # Get code suggestions from CopilotKit if available
-                code_suggestions = orchestrator.get_code_suggestions(
-                    message, 
+                code_suggestions = await orchestrator.get_code_suggestions(
+                    message,
                     language=self._detect_programming_language(message)
                 )
-                
+
                 if code_suggestions:
                     # Use CopilotKit for code-related responses
                     copilot_response = orchestrator.route_with_copilotkit(
@@ -1165,8 +1165,8 @@ class ChatOrchestrator:
                     return copilot_response
             
             # Get contextual suggestions from CopilotKit
-            contextual_suggestions = orchestrator.get_contextual_suggestions(
-                message, 
+            contextual_suggestions = await orchestrator.get_contextual_suggestions(
+                message,
                 context or {}
             )
             


### PR DESCRIPTION
## Summary
- await CopilotKit `get_code_suggestions` and `get_contextual_suggestions` calls inside ChatOrchestrator
- ensure CopilotKit suggestion helpers execute properly instead of returning unawaited coroutines

## Testing
- `pytest` *(fails: AttributeError 'APIRouter' object has no attribute 'head')*

------
https://chatgpt.com/codex/tasks/task_e_689df4b19b6883248bc418fb3f1a6a45