### PR TITLE
Improve copilot streaming and backend resilience

### DIFF
--- a/ui_launchers/web_ui/src/components/chat/ChatGPTInterface.tsx
+++ b/ui_launchers/web_ui/src/components/chat/ChatGPTInterface.tsx
@@ -330,12 +330,16 @@ export const ChatGPTInterface: React.FC<ChatGPTInterfaceProps> = ({
     const initializeChat = async () => {
       if (user && !sessionId && !conversationId) {
         try {
-          const { conversationId: newConversationId, sessionId: newSessionId } = 
+          const { conversationId: newConversationId, sessionId: newSessionId } =
             await chatService.createConversationSession(user.user_id);
           setSessionId(newSessionId);
           setConversationId(newConversationId);
-        } catch (error) {
+        } catch (error: any) {
           console.error('Failed to create conversation session:', error);
+          const info = error?.errorInfo;
+          if (info) {
+            toast({ title: info.title, description: info.message, variant: 'destructive' });
+          }
         }
       }
 

--- a/ui_launchers/web_ui/src/components/settings/LLMSettings.tsx
+++ b/ui_launchers/web_ui/src/components/settings/LLMSettings.tsx
@@ -95,12 +95,13 @@ export default function LLMSettings() {
         loadProfiles()
       ]);
 
-    } catch (error) {
+    } catch (error: any) {
       console.error('Failed to load LLM settings:', error);
+      const info = error?.errorInfo;
       toast({
-        title: "Error Loading Settings",
-        description: "Could not load LLM provider settings. Using defaults.",
-        variant: "destructive",
+        title: info?.title || 'Error Loading Settings',
+        description: info?.message || 'Could not load LLM provider settings. Using defaults.',
+        variant: 'destructive',
       });
     } finally {
       setLoading(false);
@@ -111,8 +112,12 @@ export default function LLMSettings() {
     try {
       const response = await backend.makeRequestPublic<{ providers: LLMProvider[] }>('/api/llm/providers');
       setProviders(response.providers || []);
-    } catch (error) {
+    } catch (error: any) {
       console.error('Failed to load providers:', error);
+      const info = error?.errorInfo;
+      if (info) {
+        toast({ title: info.title, description: info.message, variant: 'destructive' });
+      }
       // Use fallback providers if backend is unavailable
       setProviders([
         {
@@ -153,8 +158,12 @@ export default function LLMSettings() {
     try {
       const response = await backend.makeRequestPublic<{ profiles: LLMProfile[] }>('/api/llm/profiles');
       setProfiles(response.profiles || []);
-    } catch (error) {
+    } catch (error: any) {
       console.error('Failed to load profiles:', error);
+      const info = error?.errorInfo;
+      if (info) {
+        toast({ title: info.title, description: info.message, variant: 'destructive' });
+      }
       // Use fallback profiles
       setProfiles([
         {


### PR DESCRIPTION
## Summary
- handle HTTP errors and partial SSE lines in CopilotChat
- add abortable streaming and offline queue to backend requests
- surface backend ErrorHandler messages in UI toasts

## Testing
- `npm test` *(fails: Tests failed. Watching for file changes...)*

------
https://chatgpt.com/codex/tasks/task_e_689dbb03d1e88324a186ba4aff179690