### PR TITLE
Fix plugin manifest dependency specification

### DIFF
--- a/plugin_marketplace/ai/copilotkit-code-reviewer/plugin_manifest.json
+++ b/plugin_marketplace/ai/copilotkit-code-reviewer/plugin_manifest.json
@@ -35,8 +35,16 @@
     "ruby"
   ],
   "dependencies": [
-    "copilotkit>=1.0.0",
-    "ai_karen_engine>=1.0.0"
+    {
+      "name": "copilotkit",
+      "min_version": "1.0.0",
+      "optional": true
+    },
+    {
+      "name": "ai_karen_engine",
+      "min_version": "1.0.0",
+      "optional": true
+    }
   ],
   "permissions": {
     "data_access": [

--- a/plugin_marketplace/ai/copilotkit-debug-assistant/plugin_manifest.json
+++ b/plugin_marketplace/ai/copilotkit-debug-assistant/plugin_manifest.json
@@ -31,8 +31,16 @@
     "go"
   ],
   "dependencies": [
-    "copilotkit>=1.0.0",
-    "ai_karen_engine>=1.0.0"
+    {
+      "name": "copilotkit",
+      "min_version": "1.0.0",
+      "optional": true
+    },
+    {
+      "name": "ai_karen_engine",
+      "min_version": "1.0.0",
+      "optional": true
+    }
   ],
   "hooks": {
     "pre_execution": [


### PR DESCRIPTION
## Summary
- update CopilotKit code reviewer plugin manifest to use structured dependency objects
- update CopilotKit debug assistant plugin manifest to use structured dependency objects

## Testing
- `pre-commit run --files plugin_marketplace/ai/copilotkit-code-reviewer/plugin_manifest.json plugin_marketplace/ai/copilotkit-debug-assistant/plugin_manifest.json`
- `pytest tests/test_copilotkit_code_reviewer.py tests/test_copilotkit_debug_assistant.py plugin_marketplace/tests/test_hello_world_memory.py` *(fails: ImportError: cannot import name 'get_orchestrator' from 'ai_karen_engine.llm_orchestrator')*

------
https://chatgpt.com/codex/tasks/task_e_689fcfe4d2108324b5b7a6aef7eb773f