### PR TITLE
Add provider settings routes and Next.js proxy

### DIFF
--- a/main.py
+++ b/main.py
@@ -47,6 +47,7 @@ from ai_karen_engine.api_routes.tool_routes import router as tool_router
 from ai_karen_engine.api_routes.web_api_compatibility import router as web_api_router
 from ai_karen_engine.api_routes.websocket_routes import router as websocket_router
 from ai_karen_engine.api_routes.chat_runtime import router as chat_runtime_router
+from ai_karen_engine.api_routes.settings_routes import router as settings_router
 from ai_karen_engine.server.middleware import configure_middleware
 from ai_karen_engine.server.plugin_loader import ENABLED_PLUGINS, PLUGIN_MAP
 from ai_karen_engine.server.startup import create_lifespan
@@ -330,6 +331,7 @@ def create_app() -> FastAPI:
     app.include_router(file_attachment_router, prefix="/api/files", tags=["files"])
     app.include_router(code_execution_router, prefix="/api/code", tags=["code"])
     app.include_router(chat_runtime_router, prefix="/api", tags=["chat-runtime"])
+    app.include_router(settings_router)
 
     # Setup developer API with enhanced debugging capabilities
     setup_developer_api(app)

--- a/src/ai_karen_engine/api_routes/settings_routes.py
+++ b/src/ai_karen_engine/api_routes/settings_routes.py
@@ -1,0 +1,35 @@
+from fastapi import APIRouter, Depends
+from ai_karen_engine.integrations.llm_registry import get_registry
+from ai_karen_engine.core.user_prefs import get_user_prefs, UserPrefs
+
+router = APIRouter(prefix="/api", tags=["settings"])
+
+
+@router.get("/providers")
+async def list_providers():
+    reg = get_registry()
+    return {
+        "providers": [
+            {
+                "id": p.id,
+                "models": [m.name for m in reg.models(p.id)],
+                "enabled": getattr(p, "enabled", True),
+            }
+            for p in reg.providers()
+        ]
+    }
+
+
+@router.get("/llm/providers")
+async def legacy_list_providers():
+    """Backward compatible endpoint for old /api/llm/providers path."""
+    return await list_providers()
+
+
+@router.get("/settings")
+async def get_settings(user: UserPrefs = Depends(get_user_prefs)):
+    return {
+        "preferred_model": user.preferred_model,
+        "degraded_banner": user.show_degraded_banner,
+        "ui": user.ui,
+    }

--- a/src/ai_karen_engine/core/user_prefs.py
+++ b/src/ai_karen_engine/core/user_prefs.py
@@ -1,0 +1,16 @@
+from dataclasses import dataclass
+from typing import Dict, Any
+
+
+@dataclass
+class UserPrefs:
+    preferred_model: str = "ollama:llama3.2"
+    show_degraded_banner: bool = False
+    ui: Dict[str, Any] | None = None
+
+
+def get_user_prefs() -> UserPrefs:
+    """Return default user preferences.
+    This is a simple placeholder until a real implementation is provided.
+    """
+    return UserPrefs(ui={"theme": "light"})

--- a/ui_launchers/web_ui/src/app/api/karen/[...proxy]/route.ts
+++ b/ui_launchers/web_ui/src/app/api/karen/[...proxy]/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const UPSTREAM = process.env.KAREN_API_BASE ?? 'http://127.0.0.1:8000';
+
+export async function GET(req: NextRequest, { params }: { params: { proxy: string[] } }) {
+  return forward(req, params);
+}
+export async function POST(req: NextRequest, { params }: { params: { proxy: string[] } }) {
+  return forward(req, params);
+}
+export async function PUT(req: NextRequest, { params }: { params: { proxy: string[] } }) {
+  return forward(req, params);
+}
+export async function PATCH(req: NextRequest, { params }: { params: { proxy: string[] } }) {
+  return forward(req, params);
+}
+export async function DELETE(req: NextRequest, { params }: { params: { proxy: string[] } }) {
+  return forward(req, params);
+}
+
+async function forward(req: NextRequest, { proxy }: { proxy: string[] }) {
+  const path = `/${proxy.join('/')}${req.nextUrl.search || ''}`;
+  const url = `${UPSTREAM}${path}`;
+
+  const init: RequestInit = {
+    method: req.method,
+    headers: stripHost(req.headers),
+    body: ['GET', 'HEAD'].includes(req.method) ? undefined : await req.arrayBuffer(),
+  };
+  const upstream = await fetch(url, init);
+  const body = upstream.body ? upstream.body : null;
+  return new NextResponse(body, {
+    status: upstream.status,
+    headers: cloneHeaders(upstream.headers),
+  });
+}
+
+function stripHost(headers: Headers) {
+  const out = new Headers(headers);
+  out.delete('host');
+  return out;
+}
+
+function cloneHeaders(headers: Headers) {
+  const out = new Headers();
+  headers.forEach((v, k) => out.set(k, v));
+  return out;
+}

--- a/ui_launchers/web_ui/src/lib/karen-backend.ts
+++ b/ui_launchers/web_ui/src/lib/karen-backend.ts
@@ -276,6 +276,7 @@ class KarenBackendService {
         clearTimeout(timeoutId);
 
         if (!response.ok) {
+          console.error('KarenBackendService 4xx/5xx', response.status, url);
           // Try to parse structured error response
           let errorDetails: WebUIErrorResponse | undefined;
           try {


### PR DESCRIPTION
## Summary
- add FastAPI settings router exposing `/api/providers` and `/api/settings`
- add Next.js proxy to forward `/api/karen/*` to backend
- log failing request URLs and handle provider 404s gracefully in UI settings

## Testing
- `pytest tests/test_llm_providers.py::test_llm_providers_list -q` *(fails: not found)*
- `pytest tests/test_llm_routes.py::test_list_providers -q` *(fails: not found)*
- `npm test` *(fails: 26 test files failed, 97 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_689fdc46e10483248a2ac4beaaf3251b