### PR TITLE
Expose LLM profile API routes

### DIFF
--- a/main.py
+++ b/main.py
@@ -47,6 +47,7 @@ from ai_karen_engine.api_routes.tool_routes import router as tool_router
 from ai_karen_engine.api_routes.web_api_compatibility import router as web_api_router
 from ai_karen_engine.api_routes.websocket_routes import router as websocket_router
 from ai_karen_engine.api_routes.chat_runtime import router as chat_runtime_router
+from ai_karen_engine.api_routes.llm_routes import router as llm_router
 from ai_karen_engine.api_routes.settings_routes import router as settings_router
 from ai_karen_engine.server.middleware import configure_middleware
 from ai_karen_engine.server.plugin_loader import ENABLED_PLUGINS, PLUGIN_MAP
@@ -331,6 +332,7 @@ def create_app() -> FastAPI:
     app.include_router(file_attachment_router, prefix="/api/files", tags=["files"])
     app.include_router(code_execution_router, prefix="/api/code", tags=["code"])
     app.include_router(chat_runtime_router, prefix="/api", tags=["chat-runtime"])
+    app.include_router(llm_router, prefix="/api/llm", tags=["llm"])
     app.include_router(settings_router)
 
     # Setup developer API with enhanced debugging capabilities

--- a/src/ai_karen_engine/api_routes/settings_routes.py
+++ b/src/ai_karen_engine/api_routes/settings_routes.py
@@ -19,13 +19,6 @@ async def list_providers():
         ]
     }
 
-
-@router.get("/llm/providers")
-async def legacy_list_providers():
-    """Backward compatible endpoint for old /api/llm/providers path."""
-    return await list_providers()
-
-
 @router.get("/settings")
 async def get_settings(user: UserPrefs = Depends(get_user_prefs)):
     return {


### PR DESCRIPTION
## Summary
- add dedicated LLM router to backend to serve /api/llm provider and profile endpoints
- remove obsolete legacy provider path from settings routes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi.exceptions')*

------
https://chatgpt.com/codex/tasks/task_e_689fe2382fa08324be53625a51d87174