### PR TITLE
chore: update LLM provider endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,8 +175,11 @@ curl -X PUT "http://localhost:9200/ai_karen_index"
 ### 4. Start Backend API
 
 ```bash
-# Start FastAPI server
+# Start FastAPI server (recommended)
 uvicorn main:create_app --factory --reload --host 0.0.0.0 --port 8000
+
+# Or use the helper script
+python start_server.py
 
 # Verify API is running
 curl http://localhost:8000/health

--- a/src/ai_karen_engine/api_routes/settings_routes.py
+++ b/src/ai_karen_engine/api_routes/settings_routes.py
@@ -1,23 +1,7 @@
 from fastapi import APIRouter, Depends
-from ai_karen_engine.integrations.llm_registry import get_registry
 from ai_karen_engine.core.user_prefs import get_user_prefs, UserPrefs
 
 router = APIRouter(prefix="/api", tags=["settings"])
-
-
-@router.get("/providers")
-async def list_providers():
-    reg = get_registry()
-    return {
-        "providers": [
-            {
-                "id": p.id,
-                "models": [m.name for m in reg.models(p.id)],
-                "enabled": getattr(p, "enabled", True),
-            }
-            for p in reg.providers()
-        ]
-    }
 
 @router.get("/settings")
 async def get_settings(user: UserPrefs = Depends(get_user_prefs)):

--- a/tests/test_llm_endpoints.py
+++ b/tests/test_llm_endpoints.py
@@ -1,89 +1,32 @@
-#!/usr/bin/env python3
-"""
-Test LLM endpoints directly without server
-"""
-
 import sys
-import os
-import asyncio
-import json
 
-# Add the src directory to the path
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'src'))
+import pytest
 
-async def test_llm_endpoints():
-    """Test LLM endpoints directly"""
-    print("🧪 Testing LLM endpoints directly...")
-    
-    try:
-        # Import the LLM routes
-        from ai_karen_engine.api_routes.llm_routes import list_providers, list_profiles, health_check_providers
-        from ai_karen_engine.integrations.llm_registry import get_registry
-        
-        print("\n1. Testing provider listing...")
-        registry = get_registry()
-        providers_result = await list_providers(registry)
-        print(f"✅ Found {len(providers_result['providers'])} providers:")
-        
-        # Convert to JSON-serializable format for display
-        providers_json = []
-        for provider in providers_result['providers']:
-            provider_dict = {
-                'name': provider.name,
-                'description': provider.description,
-                'supports_streaming': provider.supports_streaming,
-                'supports_embeddings': provider.supports_embeddings,
-                'requires_api_key': provider.requires_api_key,
-                'default_model': provider.default_model,
-                'health_status': provider.health_status
-            }
-            providers_json.append(provider_dict)
-            print(f"   - {provider.name}: {provider.description}")
-        
-        print(f"\n📄 JSON Response for /api/llm/providers:")
-        print(json.dumps({'providers': providers_json}, indent=2))
-        
-        print("\n2. Testing profile listing...")
-        profiles_result = await list_profiles()
-        print(f"✅ Found {len(profiles_result['profiles'])} profiles:")
-        
-        # Convert to JSON-serializable format
-        profiles_json = []
-        for profile in profiles_result['profiles']:
-            profile_dict = {
-                'name': profile.name,
-                'providers': profile.providers,
-                'fallback': profile.fallback
-            }
-            profiles_json.append(profile_dict)
-            print(f"   - {profile.name}: chat={profile.providers['chat']}, code={profile.providers['code']}")
-        
-        print(f"\n📄 JSON Response for /api/llm/profiles:")
-        print(json.dumps({'profiles': profiles_json}, indent=2))
-        
-        print("\n3. Testing health check...")
-        health_result = await health_check_providers(None, registry)
-        print(f"✅ Health check completed for {len(health_result['results'])} providers:")
-        
-        for name, result in health_result['results'].items():
-            status = result.get('status', 'unknown')
-            print(f"   - {name}: {status}")
-        
-        print(f"\n📄 JSON Response for /api/llm/health-check:")
-        print(json.dumps(health_result, indent=2))
-        
-        print("\n🎉 All LLM endpoints working correctly!")
-        print("\n💡 The web UI should be able to use these endpoints once the server is running.")
-        print("   The fallback data in the web UI matches this structure, so it will work offline too.")
-        
-        return True
-        
-    except Exception as e:
-        print(f"❌ Error testing LLM endpoints: {e}")
-        import traceback
-        traceback.print_exc()
-        return False
+# Restore real FastAPI/Pydantic implementations instead of test stubs
+sys.modules.pop("fastapi", None)
+sys.modules.pop("pydantic", None)
+sys.modules.pop("fastapi.testclient", None)
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from ai_karen_engine.api_routes.llm_routes import router as llm_router
 
-if __name__ == "__main__":
-    success = asyncio.run(test_llm_endpoints())
-    sys.exit(0 if success else 1)
+
+@pytest.fixture(scope="module")
+def client():
+    app = FastAPI()
+    app.include_router(llm_router, prefix="/api/llm")
+    with TestClient(app) as c:
+        yield c
+
+def test_list_providers(client):
+    response = client.get("/api/llm/providers")
+    assert response.status_code == 200
+    data = response.json()
+    assert isinstance(data.get("providers"), list)
+
+
+def test_list_profiles(client):
+    response = client.get("/api/llm/profiles")
+    assert response.status_code == 200
+    data = response.json()
+    assert isinstance(data.get("profiles"), list)

--- a/ui_launchers/web_ui/src/lib/extensions/constants.ts
+++ b/ui_launchers/web_ui/src/lib/extensions/constants.ts
@@ -110,7 +110,8 @@ export const DEFAULT_RATE_LIMITS = {
 export const API_ENDPOINTS = {
   EXTENSIONS: '/api/extensions',
   PLUGINS: '/api/plugins',
-  PROVIDERS: '/api/providers',
+  PROVIDERS: '/api/llm/providers',
+  LLM_PROFILES: '/api/llm/profiles',
   MODELS: '/api/models',
   MARKETPLACE: '/api/marketplace',
   HEALTH: '/api/health',


### PR DESCRIPTION
## Summary
- switch web UI provider lookups to `/api/llm/providers`
- centralize provider/profile endpoints in `API_ENDPOINTS`
- remove deprecated `/api/providers` route
- add tests for `/api/llm/providers` and `/api/llm/profiles`
- document recommended server start commands

## Testing
- `pytest tests/test_llm_endpoints.py -q`
- `npm test` *(fails: TypeError: Cannot read properties of undefined)*

------
https://chatgpt.com/codex/tasks/task_e_689fe9c582348324bdfc52ee76fa020c