### PR TITLE
Add user filtering fields to MemoryQuery

### DIFF
--- a/src/ai_karen_engine/services/memory_service.py
+++ b/src/ai_karen_engine/services/memory_service.py
@@ -90,22 +90,16 @@ class WebUIMemoryQuery(BaseModel):
     
     def to_memory_query(self) -> MemoryQuery:
         """Convert to base MemoryQuery for compatibility."""
-        # Build metadata filter to include user_id, session_id, and tags
-        metadata_filter = {}
-        if self.user_id:
-            metadata_filter["user_id"] = self.user_id
-        if self.session_id:
-            metadata_filter["session_id"] = self.session_id
-        if self.tags:
-            metadata_filter["tags"] = self.tags
-            
         return MemoryQuery(
             text=self.text,
-            metadata_filter=metadata_filter,
+            user_id=self.user_id,
+            session_id=self.session_id,
+            conversation_id=self.conversation_id,
+            tags=self.tags,
             time_range=self.time_range,
             top_k=self.top_k,
             similarity_threshold=self.similarity_threshold,
-            include_embeddings=self.include_embeddings
+            include_embeddings=self.include_embeddings,
         )
 
 


### PR DESCRIPTION
## Summary
- extend `MemoryQuery` with user, session, conversation, and tag fields
- propagate new fields through metadata filtering and Web UI query conversion

## Testing
- `pytest tests/services/test_memory_service.py::TestWebUIMemoryService::test_webui_memory_query_to_memory_query -q`
- `pytest tests/test_database_integration.py::TestMemoryManager::test_memory_query_creation -q` *(fails: ImportError: cannot import name 'User' from 'ai_karen_engine.database.models')*


------
https://chatgpt.com/codex/tasks/task_e_689ff7b11d4c8324ad82b42c72ebd97e