### PR TITLE
fix: ensure router rate limit handler

### DIFF
--- a/verify_error_response_implementation.py
+++ b/verify_error_response_implementation.py
@@ -138,8 +138,8 @@ def main():
             "async def get_cache_stats("
         ],
         "Rate Limiting Error Handler": [
-            "@router.exception_handler(RateLimitExceeded)",
-            "async def rate_limit_handler("
+            "async def rate_limit_handler(",
+            "router.add_exception_handler(RateLimitExceeded, rate_limit_handler)"
         ]
     }
     


### PR DESCRIPTION
## Summary
- replace unsupported `@router.exception_handler` decorator with dedicated handler function
- register rate limit handler using version-compatible API
- update verification script to reflect handler registration change

## Testing
- `pytest tests/test_error_response_routes_simple.py tests/test_error_response_endpoint_basic.py tests/test_error_response_api_integration.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa5f1f5dc083249f40bd8747b74881