### PR TITLE
Add core response pipeline scaffolding

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,3 @@
+[mypy]
+mypy_path = src
+explicit_package_bases = true

--- a/src/core/response/__init__.py
+++ b/src/core/response/__init__.py
@@ -1,0 +1,13 @@
+"""Core response pipeline components."""
+
+from .config import PipelineConfig
+from .orchestrator import ResponseOrchestrator
+from .protocols import Analyzer, LLMClient, Memory
+
+__all__ = [
+    "Analyzer",
+    "LLMClient",
+    "Memory",
+    "PipelineConfig",
+    "ResponseOrchestrator",
+]

--- a/src/core/response/config.py
+++ b/src/core/response/config.py
@@ -1,0 +1,15 @@
+"""Configuration for the response pipeline."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List
+
+
+@dataclass
+class PipelineConfig:
+    """Settings that control response generation."""
+
+    model: str = "default"
+    max_history: int = 5
+    system_prompts: List[str] = field(default_factory=list)

--- a/src/core/response/orchestrator.py
+++ b/src/core/response/orchestrator.py
@@ -1,0 +1,43 @@
+"""Response orchestration for the chat pipeline."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from .config import PipelineConfig
+from .protocols import Analyzer, LLMClient, Memory
+
+
+class ResponseOrchestrator:
+    """Coordinates analysis, memory, and model generation."""
+
+    def __init__(
+        self,
+        config: PipelineConfig,
+        analyzer: Analyzer,
+        memory: Memory,
+        llm_client: LLMClient,
+    ) -> None:
+        self.config = config
+        self.analyzer = analyzer
+        self.memory = memory
+        self.llm_client = llm_client
+
+    def build_prompt(
+        self, user_input: str, context: List[str], analysis: Dict[str, Any]
+    ) -> str:
+        """Create a simple prompt from context, input, and analysis."""
+
+        _ = analysis  # placeholder for future prompt logic
+        segments = context[-self.config.max_history :] + [user_input]
+        return "\n".join(self.config.system_prompts + segments)
+
+    def respond(self, conversation_id: str, user_input: str, **llm_kwargs: Any) -> str:
+        """Generate a model response for *user_input* in *conversation_id*."""
+
+        analysis = self.analyzer.analyze(user_input)
+        context = self.memory.fetch_context(conversation_id)
+        prompt = self.build_prompt(user_input, context, analysis)
+        response = self.llm_client.generate(prompt, **llm_kwargs)
+        self.memory.store(conversation_id, user_input, response)
+        return response

--- a/src/core/response/protocols.py
+++ b/src/core/response/protocols.py
@@ -1,0 +1,29 @@
+"""Protocol definitions for the response pipeline."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Protocol
+
+
+class Analyzer(Protocol):
+    """Analyzes user input to extract conversational signals."""
+
+    def analyze(self, text: str) -> Dict[str, Any]:
+        """Return structured analysis data for *text*."""
+
+
+class Memory(Protocol):
+    """Stores and retrieves conversational context."""
+
+    def fetch_context(self, conversation_id: str) -> List[str]:
+        """Return a list of relevant context strings."""
+
+    def store(self, conversation_id: str, user_input: str, response: str) -> None:
+        """Persist the exchange for future retrieval."""
+
+
+class LLMClient(Protocol):
+    """Generates model responses from prompts."""
+
+    def generate(self, prompt: str, **kwargs: Any) -> str:
+        """Return a model-generated response for *prompt*."""

--- a/tests/core/test_response_orchestrator.py
+++ b/tests/core/test_response_orchestrator.py
@@ -1,0 +1,55 @@
+"""Tests for the :mod:`core.response` package."""
+
+from core.response import PipelineConfig, ResponseOrchestrator
+
+
+class DummyAnalyzer:
+    def __init__(self) -> None:
+        self.last_input: str | None = None
+
+    def analyze(self, text: str) -> dict[str, str]:
+        self.last_input = text
+        return {"intent": "test"}
+
+
+class DummyMemory:
+    def __init__(self) -> None:
+        self.fetch_called_with: str | None = None
+        self.store_calls: list[tuple[str, str, str]] = []
+
+    def fetch_context(self, conversation_id: str) -> list[str]:
+        self.fetch_called_with = conversation_id
+        return ["hi"]
+
+    def store(self, conversation_id: str, user_input: str, response: str) -> None:
+        self.store_calls.append((conversation_id, user_input, response))
+
+
+class DummyLLM:
+    def __init__(self) -> None:
+        self.last_prompt: str | None = None
+
+    def generate(self, prompt: str, **kwargs: object) -> str:
+        self.last_prompt = prompt
+        return "response"
+
+
+def test_orchestrator_flow() -> None:
+    config = PipelineConfig(system_prompts=["sys"])
+    analyzer = DummyAnalyzer()
+    memory = DummyMemory()
+    llm = DummyLLM()
+    orchestrator = ResponseOrchestrator(
+        config=config,
+        analyzer=analyzer,
+        memory=memory,
+        llm_client=llm,
+    )
+
+    result = orchestrator.respond("c1", "hello")
+    assert result == "response"
+    assert analyzer.last_input == "hello"
+    assert memory.fetch_called_with == "c1"
+    assert memory.store_calls == [("c1", "hello", "response")]
+    assert llm.last_prompt is not None and "hello" in llm.last_prompt
+    assert llm.last_prompt is not None and "hi" in llm.last_prompt


### PR DESCRIPTION
## Summary
- introduce response pipeline package with Analyzer, Memory, and LLMClient protocols
- add configurable ResponseOrchestrator with simple prompt builder
- include targeted unit test and mypy configuration

## Testing
- `pre-commit run --files src/core/response/__init__.py src/core/response/config.py src/core/response/protocols.py src/core/response/orchestrator.py tests/core/test_response_orchestrator.py mypy.ini`
- `pytest --confcutdir=tests/core tests/core/test_response_orchestrator.py`

------
https://chatgpt.com/codex/tasks/task_e_68ab710570388324b4fb702c8e504d9f