### PR TITLE
Add modular response pipeline components

### DIFF
--- a/src/core/response/__init__.py
+++ b/src/core/response/__init__.py
@@ -1,13 +1,21 @@
 """Core response pipeline components."""
 
 from .config import PipelineConfig
+from .formatter import DRYFormatter
 from .orchestrator import ResponseOrchestrator
+from .prompt_builder import PromptBuilder
 from .protocols import Analyzer, LLMClient, Memory
+from .spacy_analyzer import SpaCyAnalyzer
+from .unified_client import UnifiedLLMClient
 
 __all__ = [
     "Analyzer",
     "LLMClient",
     "Memory",
     "PipelineConfig",
+    "PromptBuilder",
+    "DRYFormatter",
+    "SpaCyAnalyzer",
+    "UnifiedLLMClient",
     "ResponseOrchestrator",
 ]

--- a/src/core/response/config.py
+++ b/src/core/response/config.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import List
 
 
@@ -13,3 +14,6 @@ class PipelineConfig:
     model: str = "default"
     max_history: int = 5
     system_prompts: List[str] = field(default_factory=list)
+    template_dir: Path = field(
+        default_factory=lambda: Path(__file__).parent / "templates"
+    )

--- a/src/core/response/formatter.py
+++ b/src/core/response/formatter.py
@@ -1,0 +1,27 @@
+"""DRY formatter with optional CopilotKit integration."""
+from __future__ import annotations
+
+from typing import Any
+
+try:  # pragma: no cover - optional dependency
+    from copilotkit import enhance_text  # type: ignore
+except Exception:  # pragma: no cover
+    enhance_text = None  # type: ignore
+
+
+class DRYFormatter:
+    """Format responses consistently with optional CopilotKit hooks."""
+
+    def __init__(self, enable_copilotkit: bool = True) -> None:
+        self.enable_copilotkit = enable_copilotkit and enhance_text is not None
+
+    def format(self, text: str, **_: Any) -> str:
+        """Return formatted text with graceful degradation."""
+
+        result = f"## Response\n\n{text.strip()}"
+        if self.enable_copilotkit and enhance_text is not None:
+            try:
+                result = enhance_text(result)
+            except Exception:
+                pass
+        return result

--- a/src/core/response/orchestrator.py
+++ b/src/core/response/orchestrator.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from typing import Any, Dict, List
 
 from .config import PipelineConfig
+from .formatter import DRYFormatter
+from .prompt_builder import PromptBuilder
 from .protocols import Analyzer, LLMClient, Memory
 
 
@@ -17,20 +19,33 @@ class ResponseOrchestrator:
         analyzer: Analyzer,
         memory: Memory,
         llm_client: LLMClient,
+        prompt_builder: PromptBuilder | None = None,
+        formatter: DRYFormatter | None = None,
     ) -> None:
         self.config = config
         self.analyzer = analyzer
         self.memory = memory
         self.llm_client = llm_client
+        self.prompt_builder = prompt_builder or PromptBuilder(config.template_dir)
+        self.formatter = formatter or DRYFormatter()
 
     def build_prompt(
         self, user_input: str, context: List[str], analysis: Dict[str, Any]
     ) -> str:
         """Create a simple prompt from context, input, and analysis."""
 
-        _ = analysis  # placeholder for future prompt logic
-        segments = context[-self.config.max_history :] + [user_input]
-        return "\n".join(self.config.system_prompts + segments)
+        persona = analysis.get("persona", "assistant")
+        parts = [self.prompt_builder.render("system_base", persona=persona)]
+        for msg in context[-self.config.max_history :]:
+            parts.append(self.prompt_builder.render("user_frame", user_input=msg))
+        parts.append(self.prompt_builder.render("user_frame", user_input=user_input))
+        if analysis.get("profile_gaps"):
+            parts.append(
+                self.prompt_builder.render(
+                    "onboarding", gaps=analysis["profile_gaps"]
+                )
+            )
+        return "\n".join(self.config.system_prompts + parts)
 
     def respond(self, conversation_id: str, user_input: str, **llm_kwargs: Any) -> str:
         """Generate a model response for *user_input* in *conversation_id*."""
@@ -39,5 +54,6 @@ class ResponseOrchestrator:
         context = self.memory.fetch_context(conversation_id)
         prompt = self.build_prompt(user_input, context, analysis)
         response = self.llm_client.generate(prompt, **llm_kwargs)
-        self.memory.store(conversation_id, user_input, response)
-        return response
+        formatted = self.formatter.format(response)
+        self.memory.store(conversation_id, user_input, formatted)
+        return formatted

--- a/src/core/response/prompt_builder.py
+++ b/src/core/response/prompt_builder.py
@@ -1,0 +1,26 @@
+"""Jinja2-based prompt construction utilities."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from jinja2 import Environment, FileSystemLoader, select_autoescape
+
+
+class PromptBuilder:
+    """Load and render Jinja2 templates for prompts."""
+
+    def __init__(self, template_dir: Path | str) -> None:
+        self.template_dir = Path(template_dir)
+        self.env = Environment(
+            loader=FileSystemLoader(str(self.template_dir)),
+            autoescape=False,
+            trim_blocks=True,
+            lstrip_blocks=True,
+        )
+
+    def render(self, template_name: str, **data: Any) -> str:
+        """Render ``template_name`` with the provided ``data``."""
+
+        template = self.env.get_template(f"{template_name}.j2")
+        return template.render(**data)

--- a/src/core/response/spacy_analyzer.py
+++ b/src/core/response/spacy_analyzer.py
@@ -1,0 +1,73 @@
+"""spaCy-based analyzer with persona logic and profile gap detection."""
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+try:
+    import spacy  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    spacy = None  # type: ignore
+
+
+class SpaCyAnalyzer:
+    """Perform lightweight analysis using spaCy when available."""
+
+    def __init__(self) -> None:
+        if spacy is not None:
+            try:
+                self.nlp = spacy.load("en_core_web_sm")
+            except Exception:  # pragma: no cover - model may be missing
+                self.nlp = spacy.blank("en")
+        else:
+            self.nlp = None
+
+        # simple persona mapping based on intent and sentiment
+        self.persona_map = {
+            ("greeting", "positive"): "cheerful",
+            ("greeting", "negative"): "formal",
+            ("request", "positive"): "helpful",
+            ("request", "negative"): "direct",
+        }
+
+    # --- helpers -----------------------------------------------------
+    def _detect_intent(self, text: str) -> str:
+        lower = text.lower()
+        if any(g in lower for g in ["hi", "hello", "hey"]):
+            return "greeting"
+        if any(f in lower for f in ["bye", "goodbye"]):
+            return "farewell"
+        if "?" in text or "please" in lower or "could you" in lower:
+            return "request"
+        return "statement"
+
+    def _sentiment(self, text: str) -> str:
+        positives = {"good", "great", "awesome", "thanks"}
+        negatives = {"bad", "hate", "terrible", "no"}
+        tokens = set(text.lower().split())
+        score = len(tokens & positives) - len(tokens & negatives)
+        return "positive" if score >= 0 else "negative"
+
+    # --- public API --------------------------------------------------
+    def analyze(self, text: str) -> Dict[str, Any]:
+        """Return analysis data for ``text``."""
+
+        doc = self.nlp(text) if self.nlp is not None else None
+        entities: List[Tuple[str, str]] = []
+        if doc is not None:
+            entities = [(ent.text, ent.label_) for ent in doc.ents]
+
+        intent = self._detect_intent(text)
+        sentiment = self._sentiment(text)
+        persona = self.persona_map.get((intent, sentiment), "neutral")
+
+        profile_gaps: List[str] = []
+        if intent == "greeting" and "name" not in text.lower():
+            profile_gaps.append("name")
+
+        return {
+            "intent": intent,
+            "sentiment": sentiment,
+            "entities": entities,
+            "persona": persona,
+            "profile_gaps": profile_gaps,
+        }

--- a/src/core/response/templates/onboarding.j2
+++ b/src/core/response/templates/onboarding.j2
@@ -1,0 +1,1 @@
+Please provide the following information: {{ gaps|join(', ') }}.

--- a/src/core/response/templates/system_base.j2
+++ b/src/core/response/templates/system_base.j2
@@ -1,0 +1,1 @@
+You are {{ persona }}.

--- a/src/core/response/templates/user_frame.j2
+++ b/src/core/response/templates/user_frame.j2
@@ -1,0 +1,1 @@
+{{ user_input }}

--- a/src/core/response/unified_client.py
+++ b/src/core/response/unified_client.py
@@ -1,0 +1,38 @@
+"""Local-first LLM client with optional remote fallback."""
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from .protocols import LLMClient
+
+
+class UnifiedLLMClient:
+    """Route requests to local models with optional remote fallback."""
+
+    def __init__(
+        self,
+        local_client: LLMClient,
+        remote_client: Optional[LLMClient] = None,
+    ) -> None:
+        self.local_client = local_client
+        self.remote_client = remote_client
+        self._warmed = False
+
+    def warmup(self) -> None:
+        """Perform a lightweight generation to warm local models."""
+
+        if not self._warmed:
+            try:  # pragma: no cover - non-critical
+                self.local_client.generate("warmup")
+            except Exception:
+                pass
+            self._warmed = True
+
+    def generate(self, prompt: str, **kwargs: Any) -> str:
+        self.warmup()
+        try:
+            return self.local_client.generate(prompt, **kwargs)
+        except Exception:
+            if self.remote_client is not None:
+                return self.remote_client.generate(prompt, **kwargs)
+            raise

--- a/tests/core/test_response_orchestrator.py
+++ b/tests/core/test_response_orchestrator.py
@@ -47,9 +47,9 @@ def test_orchestrator_flow() -> None:
     )
 
     result = orchestrator.respond("c1", "hello")
-    assert result == "response"
+    assert result == "## Response\n\nresponse"
     assert analyzer.last_input == "hello"
     assert memory.fetch_called_with == "c1"
-    assert memory.store_calls == [("c1", "hello", "response")]
+    assert memory.store_calls == [("c1", "hello", "## Response\n\nresponse")]
     assert llm.last_prompt is not None and "hello" in llm.last_prompt
     assert llm.last_prompt is not None and "hi" in llm.last_prompt

--- a/tests/core/test_spacy_analyzer.py
+++ b/tests/core/test_spacy_analyzer.py
@@ -1,0 +1,10 @@
+from core.response.spacy_analyzer import SpaCyAnalyzer
+
+
+def test_spacy_analyzer_outputs() -> None:
+    analyzer = SpaCyAnalyzer()
+    result = analyzer.analyze("Hello there")
+    assert result["intent"] == "greeting"
+    assert "persona" in result
+    assert "sentiment" in result
+    assert "entities" in result


### PR DESCRIPTION
## Summary
- Implement spaCy-based analyzer with persona mapping and profile gap detection
- Add Jinja2 prompt builder and DRY formatter
- Extend response orchestrator and provide unified local-first LLM client

## Testing
- `pytest temp_tests/test_response_orchestrator.py temp_tests/test_spacy_analyzer.py`

------
https://chatgpt.com/codex/tasks/task_e_68ab7350289c8324ac3dab623ee55b37