### PR TITLE
feat: add fallback model support to response pipeline

### DIFF
--- a/src/core/response/config.py
+++ b/src/core/response/config.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import List
+from typing import List, Optional
 
 
 @dataclass
@@ -12,6 +12,7 @@ class PipelineConfig:
     """Settings that control response generation."""
 
     model: str = "default"
+    fallback_model: Optional[str] = None
     max_history: int = 5
     system_prompts: List[str] = field(default_factory=list)
     template_dir: Path = field(

--- a/src/core/response/orchestrator.py
+++ b/src/core/response/orchestrator.py
@@ -53,7 +53,12 @@ class ResponseOrchestrator:
         analysis = self.analyzer.analyze(user_input)
         context = self.memory.fetch_context(conversation_id)
         prompt = self.build_prompt(user_input, context, analysis)
-        response = self.llm_client.generate(prompt, **llm_kwargs)
+        response = self.llm_client.generate(
+            prompt,
+            model=self.config.model,
+            fallback_model=self.config.fallback_model,
+            **llm_kwargs,
+        )
         formatted = self.formatter.format(response)
         self.memory.store(conversation_id, user_input, formatted)
         return formatted

--- a/src/core/response/tests/test_response_pipeline.py
+++ b/src/core/response/tests/test_response_pipeline.py
@@ -1,0 +1,72 @@
+import pytest
+
+from src.core.response import PipelineConfig, ResponseOrchestrator, UnifiedLLMClient
+
+
+class StubAnalyzer:
+    def analyze(self, text: str):
+        return {}
+
+
+class StubMemory:
+    def __init__(self):
+        self.records = []
+
+    def fetch_context(self, conversation_id: str):
+        return []
+
+    def store(self, conversation_id: str, user_input: str, response: str) -> None:
+        self.records.append((conversation_id, user_input, response))
+
+
+class StubLLMClient:
+    def __init__(self, response: str, fail: bool = False):
+        self.response = response
+        self.fail = fail
+        self.called_with = []
+
+    def generate(self, prompt: str, model: str | None = None, **_: str) -> str:
+        self.called_with.append(model)
+        if self.fail:
+            raise RuntimeError("failure")
+        return f"{self.response} via {model}"
+
+
+@pytest.fixture
+def base_components():
+    analyzer = StubAnalyzer()
+    memory = StubMemory()
+    return analyzer, memory
+
+
+def test_orchestrator_uses_default_model(base_components):
+    analyzer, memory = base_components
+    primary = StubLLMClient("primary")
+    orchestrator = ResponseOrchestrator(
+        PipelineConfig(model="primary-model"),
+        analyzer,
+        memory,
+        UnifiedLLMClient(primary),
+    )
+    result = orchestrator.respond("conv", "hi")
+    assert result.endswith("primary via primary-model")
+    assert primary.called_with[-1] == "primary-model"
+    assert memory.records[0][2] == result
+
+
+def test_orchestrator_falls_back_to_secondary_model(base_components):
+    analyzer, memory = base_components
+    primary = StubLLMClient("primary", fail=True)
+    fallback = StubLLMClient("fallback")
+    config = PipelineConfig(model="primary-model", fallback_model="secondary-model")
+    orchestrator = ResponseOrchestrator(
+        config,
+        analyzer,
+        memory,
+        UnifiedLLMClient(primary, fallback),
+    )
+    result = orchestrator.respond("conv", "hi")
+    assert result.endswith("fallback via secondary-model")
+    assert primary.called_with[-1] == "primary-model"
+    assert fallback.called_with[-1] == "secondary-model"
+    assert memory.records[0][2] == result


### PR DESCRIPTION
## Summary
- expand PipelineConfig with optional fallback_model
- allow UnifiedLLMClient to try a primary model before falling back
- wire ResponseOrchestrator to pass default and fallback model names
- test orchestrator flow for default and fallback models

## Testing
- `PYTHONPATH=. pytest src/core/response/tests/test_response_pipeline.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68ab8798ed78832489429f7b726a71f5