### PR TITLE
feat: add local-first model selector

### DIFF
--- a/src/core/response/orchestrator.py
+++ b/src/core/response/orchestrator.py
@@ -52,6 +52,8 @@ class ResponseOrchestrator:
         context = self.memory.fetch_context(conversation_id)
         prompt = self.build_prompt(user_input, context, analysis)
         llm_kwargs.setdefault("model", self.config.model)
+        if self.config.fallback_model is not None:
+            llm_kwargs.setdefault("fallback_model", self.config.fallback_model)
         response = self.llm_client.generate(prompt, **llm_kwargs)
         formatted = self.formatter.format(response)
         self.memory.store(conversation_id, user_input, formatted)

--- a/src/core/response/tests/test_response_pipeline.py
+++ b/src/core/response/tests/test_response_pipeline.py
@@ -1,6 +1,6 @@
 import pytest
 
-from src.core.response import PipelineConfig, ResponseOrchestrator, UnifiedLLMClient
+from core.response import PipelineConfig, ResponseOrchestrator, UnifiedLLMClient
 
 
 class StubAnalyzer:
@@ -65,7 +65,7 @@ def test_orchestrator_falls_back_to_secondary_model(base_components):
         memory,
         UnifiedLLMClient(primary, fallback),
     )
-    result = orchestrator.respond("conv", "hi")
+    result = orchestrator.respond("conv", "hi", cloud=True)
     assert result.endswith("fallback via secondary-model")
     assert primary.called_with[-1] == "primary-model"
     assert fallback.called_with[-1] == "secondary-model"

--- a/src/core/response/tests/test_unified_client.py
+++ b/src/core/response/tests/test_unified_client.py
@@ -1,0 +1,59 @@
+from core.response.unified_client import UnifiedLLMClient
+
+
+class DummyLLM:
+    def __init__(self, response: str, fail: bool = False) -> None:
+        self.response = response
+        self.fail = fail
+        self.calls = 0
+        self.last_kwargs: dict[str, object] | None = None
+
+    def generate(self, prompt: str, **kwargs: object) -> str:
+        self.calls += 1
+        self.last_kwargs = kwargs
+        if self.fail:
+            raise RuntimeError("fail")
+        return self.response
+
+
+def test_local_used_first() -> None:
+    local = DummyLLM("local")
+    remote = DummyLLM("remote")
+    client = UnifiedLLMClient(local_client=local, remote_client=remote, default_model="test-model")
+    assert client.generate("hi") == "local"
+    assert local.calls >= 1 and remote.calls == 0
+    assert local.last_kwargs is not None and local.last_kwargs.get("model") == "test-model"
+
+
+def test_remote_not_used_when_cloud_disabled() -> None:
+    local = DummyLLM("local", fail=True)
+    remote = DummyLLM("remote")
+    client = UnifiedLLMClient(local, remote)
+    assert client.generate("hi") == "No providers available"
+    assert remote.calls == 0
+
+
+def test_remote_used_when_cloud_enabled() -> None:
+    local = DummyLLM("local", fail=True)
+    remote = DummyLLM("remote")
+    client = UnifiedLLMClient(local, remote)
+    assert client.generate("hi", cloud=True) == "remote"
+    assert local.calls >= 1 and remote.calls == 1
+
+
+def test_remote_uses_fallback_model() -> None:
+    local = DummyLLM("local", fail=True)
+    remote = DummyLLM("remote")
+    client = UnifiedLLMClient(local, remote)
+    assert (
+        client.generate("hi", cloud=True, model="local-model", fallback_model="remote-model")
+        == "remote"
+    )
+    assert remote.last_kwargs is not None and remote.last_kwargs.get("model") == "remote-model"
+
+
+def test_fallback_when_all_fail() -> None:
+    local = DummyLLM("local", fail=True)
+    remote = DummyLLM("remote", fail=True)
+    client = UnifiedLLMClient(local, remote)
+    assert client.generate("hi", cloud=True) == "No providers available"

--- a/src/core/response/unified_client.py
+++ b/src/core/response/unified_client.py
@@ -1,9 +1,20 @@
-"""Local-first LLM client with optional remote fallback."""
+"""Local-first LLM client with optional remote/cloud routing.
+
+This module provides a small utility for favouring local LLM providers
+(e.g. TinyLLaMA via llama.cpp or an in-process Ollama model) while still
+allowing callers to explicitly opt in to cloud based models.  When both
+local and remote providers fail, a trivial fallback client is used to
+guarantee a response.
+"""
+
 from __future__ import annotations
 
-from typing import Any, Optional
+import logging
+from typing import Any, List, Optional
 
 from .protocols import LLMClient
+
+log = logging.getLogger(__name__)
 
 
 class FallbackLLM:
@@ -16,6 +27,30 @@ class FallbackLLM:
         return self.message
 
 
+class ModelSelector:
+    """Select which clients should be tried for a request.
+
+    Parameters
+    ----------
+    local_client:
+        Client that serves local models such as TinyLLaMA or Ollama.
+    remote_client:
+        Optional cloud based client.
+    """
+
+    def __init__(self, local_client: LLMClient, remote_client: Optional[LLMClient]) -> None:
+        self.local_client = local_client
+        self.remote_client = remote_client
+
+    def ordered(self, cloud_enabled: bool) -> List[LLMClient]:
+        """Return clients in the order they should be attempted."""
+
+        order = [self.local_client]
+        if cloud_enabled and self.remote_client is not None:
+            order.append(self.remote_client)
+        return order
+
+
 class UnifiedLLMClient:
     """Route requests to local models with optional remote fallback."""
 
@@ -26,11 +61,12 @@ class UnifiedLLMClient:
         *,
         default_model: str = "default-local",
         fallback_client: Optional[LLMClient] = None,
+        cloud_enabled: bool = False,
     ) -> None:
-        self.local_client = local_client
-        self.remote_client = remote_client
+        self.selector = ModelSelector(local_client, remote_client)
         self.fallback_client = fallback_client or FallbackLLM()
         self.default_model = default_model
+        self.cloud_enabled = cloud_enabled
         self._warmed = False
 
     def warmup(self) -> None:
@@ -38,20 +74,47 @@ class UnifiedLLMClient:
 
         if not self._warmed:
             try:  # pragma: no cover - non-critical
-                self.local_client.generate("warmup")
+                self.selector.local_client.generate("warmup")
             except Exception:
                 pass
             self._warmed = True
 
-    def generate(self, prompt: str, **kwargs: Any) -> str:
+    def generate(self, prompt: str, *, cloud: Optional[bool] = None, **kwargs: Any) -> str:
+        """Generate a response from the selected model.
+
+        Parameters
+        ----------
+        prompt:
+            Prompt to send to the LLM.
+        cloud:
+            If ``True`` the remote/cloud model will be attempted after the
+            local model fails.  By default cloud usage follows the setting
+            provided at construction time.
+        fallback_model:
+            Optional name of the model to use when the remote provider is
+            invoked.  This allows callers to specify different local and
+            remote model identifiers.
+        """
+
         self.warmup()
         kwargs.setdefault("model", self.default_model)
-        try:
-            return self.local_client.generate(prompt, **kwargs)
-        except Exception:
-            if self.remote_client is not None:
-                try:
-                    return self.remote_client.generate(prompt, **kwargs)
-                except Exception:
-                    pass
-            return self.fallback_client.generate(prompt, **kwargs)
+        fallback_model = kwargs.pop("fallback_model", None)
+        cloud_enabled = self.cloud_enabled if cloud is None else cloud
+
+        clients = self.selector.ordered(cloud_enabled)
+        models = [kwargs["model"]]
+        if len(clients) > 1:
+            models.append(fallback_model or kwargs["model"])
+
+        for client, model_name in zip(clients, models):
+            call_kwargs = dict(kwargs)
+            call_kwargs["model"] = model_name
+            try:
+                return client.generate(prompt, **call_kwargs)
+            except Exception:  # pragma: no cover - simple retry logic
+                continue
+
+        log.warning("All LLM providers failed; using fallback client")
+        final_kwargs = dict(kwargs)
+        final_kwargs["model"] = fallback_model or kwargs["model"]
+        return self.fallback_client.generate(prompt, **final_kwargs)


### PR DESCRIPTION
## Summary
- implement `ModelSelector` to prioritize local TinyLLaMA/Ollama models
- allow optional cloud routing with warm-up and fallback logic
- pass pipeline `fallback_model` automatically and add tests for local-first routing

## Testing
- `pytest src/core/response/tests/test_unified_client.py src/core/response/tests/test_response_pipeline.py`

------
https://chatgpt.com/codex/tasks/task_e_68ab988c59dc83248090e23ed1d570e8