### PR TITLE
feat: add reusable DRY formatter with CopilotKit hooks

### DIFF
--- a/src/core/response/formatter.py
+++ b/src/core/response/formatter.py
@@ -1,7 +1,16 @@
-"""DRY formatter with optional CopilotKit integration."""
+"""DRY formatter with optional CopilotKit integration.
+
+The formatter provides a small set of helpers for building responses with a
+consistent structure.  It intentionally keeps the logic lightweight and free of
+heavy dependencies so that it can be reused across the code base.  If the
+optional :mod:`copilotkit` package is available the final formatted text can be
+"enhanced" before being returned.  When the dependency is missing the formatter
+degrades gracefully and simply returns the unmodified result.
+"""
+
 from __future__ import annotations
 
-from typing import Any
+from typing import Iterable, Optional
 
 try:  # pragma: no cover - optional dependency
     from copilotkit import enhance_text
@@ -13,15 +22,68 @@ class DRYFormatter:
     """Format responses consistently with optional CopilotKit hooks."""
 
     def __init__(self, enable_copilotkit: bool = True) -> None:
-        self.enable_copilotkit = enable_copilotkit and enhance_text is not None
+        self.enable_copilotkit = bool(enable_copilotkit and enhance_text is not None)
 
-    def format(self, text: str, **_: Any) -> str:
-        """Return formatted text with graceful degradation."""
+    # -- basic building blocks -------------------------------------------------
+    @staticmethod
+    def heading(text: str, level: int = 2) -> str:
+        """Return a Markdown heading."""
 
-        result = f"## Response\n\n{text.strip()}"
+        return f"{'#' * level} {text.strip()}"
+
+    @staticmethod
+    def bullet_list(items: Iterable[str]) -> str:
+        """Return a Markdown bullet list."""
+
+        return "\n".join(f"- {item.strip()}" for item in items)
+
+    @staticmethod
+    def code_block(code: str, language: str = "") -> str:
+        """Return a fenced code block."""
+
+        lang = f"{language}\n" if language else ""
+        return f"```{lang}{code.strip()}\n```"
+
+    # -- public API ------------------------------------------------------------
+    def format(
+        self,
+        heading: str,
+        body: str,
+        bullets: Optional[Iterable[str]] = None,
+        code: Optional[str] = None,
+        language: str = "",
+    ) -> str:
+        """Build a response with optional bullets and code block.
+
+        Parameters
+        ----------
+        heading:
+            Heading text for the response.
+        body:
+            Main body text.
+        bullets:
+            Optional iterable of bullet point strings.
+        code:
+            Optional code snippet to include.
+        language:
+            Optional language indicator for the code block.
+        """
+
+        parts = [self.heading(heading), "", body.strip()]
+
+        if bullets:
+            parts.extend(["", self.bullet_list(bullets)])
+
+        if code:
+            parts.extend(["", self.code_block(code, language)])
+
+        result = "\n".join(parts).strip()
+
         if self.enable_copilotkit and enhance_text is not None:
-            try:
+            try:  # pragma: no cover - defensive
                 result = enhance_text(result)
-            except Exception:
+            except Exception:  # pragma: no cover - degrade gracefully
                 pass
+
         return result
+

--- a/src/core/response/tests/test_formatter.py
+++ b/src/core/response/tests/test_formatter.py
@@ -1,0 +1,43 @@
+import importlib
+import pytest
+
+formatter_mod = importlib.import_module("core.response.formatter")
+DRYFormatter = formatter_mod.DRYFormatter
+
+
+def test_basic_formatting():
+    formatter = DRYFormatter(enable_copilotkit=False)
+    result = formatter.format(
+        "Title",
+        "Body text",
+        bullets=["one", "two"],
+        code="print('hi')",
+        language="python",
+    )
+    assert result == (
+        "## Title\n\n"
+        "Body text\n\n"
+        "- one\n- two\n\n"
+        "```python\nprint('hi')\n```"
+    )
+
+
+def test_copilotkit_enhancement(monkeypatch):
+    calls = []
+
+    def fake_enhance(text: str) -> str:
+        calls.append(text)
+        return text + " [enhanced]"
+
+    monkeypatch.setattr(formatter_mod, "enhance_text", fake_enhance)
+    formatter = DRYFormatter()
+    result = formatter.format("Heading", "Text")
+    assert result.endswith("[enhanced]")
+    assert calls and calls[0].startswith("## Heading")
+
+
+def test_copilotkit_unavailable(monkeypatch):
+    monkeypatch.setattr(formatter_mod, "enhance_text", None)
+    formatter = DRYFormatter()
+    result = formatter.format("Heading", "Text")
+    assert result == "## Heading\n\nText"


### PR DESCRIPTION
## Summary
- add DRYFormatter with reusable helpers for headings, bullet lists, and code blocks
- integrate optional CopilotKit `enhance_text` hook with graceful degradation
- test formatter output and CopilotKit enhancement

## Testing
- `pytest src/core/response/tests/test_formatter.py`

------
https://chatgpt.com/codex/tasks/task_e_68ab9d565a848324a6e20b09d9782753