### PR TITLE
feat: add health monitoring with metrics

### DIFF
--- a/main.py
+++ b/main.py
@@ -75,6 +75,7 @@ from ai_karen_engine.api_routes.profile_routes import router as profile_router
 from ai_karen_engine.api_routes.settings_routes import router as settings_router
 from ai_karen_engine.api_routes.error_response_routes import router as error_response_router
 from ai_karen_engine.api_routes.analytics_routes import router as analytics_router
+from ai_karen_engine.api_routes.health import router as health_router
 from ai_karen_engine.server.middleware import configure_middleware
 from ai_karen_engine.server.plugin_loader import ENABLED_PLUGINS, PLUGIN_MAP
 from ai_karen_engine.server.startup import create_lifespan
@@ -327,6 +328,7 @@ def create_app() -> FastAPI:
     app.include_router(provider_router, prefix="/api/providers", tags=["providers"])
     app.include_router(profile_router, prefix="/api/profiles", tags=["profiles"])
     app.include_router(error_response_router, prefix="/api", tags=["error-response"])
+    app.include_router(health_router, prefix="/api/health", tags=["health"])
     app.include_router(settings_router)
 
     # Setup developer API with enhanced debugging capabilities

--- a/src/ai_karen_engine/api_routes/health.py
+++ b/src/ai_karen_engine/api_routes/health.py
@@ -1,11 +1,159 @@
-from ai_karen_engine.utils.dependency_checks import import_fastapi
+from __future__ import annotations
 
-APIRouter = import_fastapi("APIRouter")
+"""Health monitoring API routes.
+
+Expose structured service health information with Prometheus metrics,
+correlation-aware logging, and circuit breaker support.
+"""
+
+import time
+from typing import Any, Dict
+
+from ai_karen_engine.utils.dependency_checks import import_fastapi
+from ai_karen_engine.services.connection_health_manager import (
+    ConnectionHealthManager,
+    get_connection_health_manager,
+)
+from ai_karen_engine.services.correlation_service import get_request_id
+from ai_karen_engine.services.structured_logging import (
+    get_structured_logging_service,
+)
+
+APIRouter, Request = import_fastapi("APIRouter", "Request")
+
+# ---------------------------------------------------------------------------
+# Prometheus metrics with safe fallbacks
+# ---------------------------------------------------------------------------
+try:  # pragma: no cover - optional dependency
+    from prometheus_client import Counter, Histogram
+
+    _REQ_COUNTER = Counter(
+        "health_endpoint_requests_total",
+        "Total health endpoint requests",
+        ["endpoint"],
+    )
+    _LATENCY_HIST = Histogram(
+        "health_endpoint_latency_seconds",
+        "Latency for health endpoint requests",
+        ["endpoint"],
+    )
+except Exception:  # pragma: no cover - prometheus optional
+
+    class _DummyMetric:
+        def labels(self, **_kwargs):  # type: ignore[override]
+            return self
+
+        def inc(self, *_args, **_kwargs):  # type: ignore[override]
+            pass
+
+        def observe(self, *_args, **_kwargs):  # type: ignore[override]
+            pass
+
+    _REQ_COUNTER = _DummyMetric()
+    _LATENCY_HIST = _DummyMetric()
+
 
 router = APIRouter()
 
 
-@router.get("/health")
-async def health() -> dict:
-    """Basic health check for UIs."""
-    return {"status": "ok"}
+def _record_metrics(endpoint: str, duration_ms: float) -> None:
+    """Record Prometheus metrics if available."""
+    _REQ_COUNTER.labels(endpoint=endpoint).inc()
+    _LATENCY_HIST.labels(endpoint=endpoint).observe(duration_ms / 1000)
+
+
+def _collect_health(manager: ConnectionHealthManager) -> Dict[str, Any]:
+    """Collect health status for all registered services."""
+    services: Dict[str, Any] = {}
+    for name in list(manager.health_status.keys()):
+        try:
+            result = manager.health_status[name]
+            services[name] = {
+                "status": result.status.value,
+                "last_check": result.last_check.isoformat(),
+                "response_time_ms": result.response_time_ms,
+                "degraded_features": result.degraded_features,
+            }
+        except Exception as exc:  # pragma: no cover - defensive
+            services[name] = {"status": "unknown", "error": str(exc)}
+    return services
+
+
+@router.get("")
+async def overall_health(request: Request) -> Dict[str, Any]:
+    """Return overall health status for registered services."""
+    start = time.time()
+    correlation_id = request.headers.get("X-Correlation-Id") or get_request_id()
+    manager = get_connection_health_manager()
+
+    # Perform health checks with circuit breaker protection
+    for name in list(manager.health_status.keys()):
+        try:
+            await manager.check_service_health(name)
+        except Exception:
+            # check_service_health already handles circuit breaker and
+            # degraded mode. Failures are reflected in status.
+            pass
+
+    services = _collect_health(manager)
+    overall = (
+        "healthy"
+        if all(s["status"] == "healthy" for s in services.values())
+        else "degraded"
+    )
+
+    duration_ms = (time.time() - start) * 1000
+    _record_metrics("overall", duration_ms)
+
+    get_structured_logging_service().log_api_request(
+        method="GET",
+        endpoint="/api/health",
+        status_code=200,
+        duration_ms=duration_ms,
+        correlation_id=correlation_id,
+    )
+
+    return {
+        "status": overall,
+        "services": services,
+        "timestamp": time.time(),
+        "correlation_id": correlation_id,
+    }
+
+
+@router.get("/{service_name}")
+async def service_health(service_name: str, request: Request) -> Dict[str, Any]:
+    """Return health status for a specific service."""
+    start = time.time()
+    correlation_id = request.headers.get("X-Correlation-Id") or get_request_id()
+    manager = get_connection_health_manager()
+
+    try:
+        result = await manager.check_service_health(service_name)
+        status = {
+            "status": result.status.value,
+            "last_check": result.last_check.isoformat(),
+            "response_time_ms": result.response_time_ms,
+            "degraded_features": result.degraded_features,
+        }
+        code = 200
+    except Exception as exc:
+        status = {"status": "unknown", "error": str(exc)}
+        code = 404
+
+    duration_ms = (time.time() - start) * 1000
+    _record_metrics(service_name, duration_ms)
+
+    get_structured_logging_service().log_api_request(
+        method="GET",
+        endpoint=f"/api/health/{service_name}",
+        status_code=code,
+        duration_ms=duration_ms,
+        correlation_id=correlation_id,
+    )
+
+    return {"service": service_name, "result": status, "correlation_id": correlation_id}
+
+
+__all__ = ["router"]
+

--- a/tests/test_health_api_routes.py
+++ b/tests/test_health_api_routes.py
@@ -1,0 +1,40 @@
+import pytest
+
+try:
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+    FASTAPI_AVAILABLE = True
+except Exception:  # pragma: no cover - fastapi optional
+    FASTAPI_AVAILABLE = False
+    FastAPI = TestClient = None
+
+from ai_karen_engine.api_routes.health import router
+from ai_karen_engine.services.connection_health_manager import (
+    ConnectionType,
+    initialize_connection_health_manager,
+    shutdown_connection_health_manager,
+)
+
+
+@pytest.mark.skipif(not FASTAPI_AVAILABLE, reason="FastAPI not available")
+@pytest.mark.asyncio
+async def test_health_endpoints_return_service_status() -> None:
+    manager = await initialize_connection_health_manager(start_monitoring=False)
+    manager.register_service("dummy", ConnectionType.DATABASE, lambda: True)
+
+    app = FastAPI()
+    app.include_router(router, prefix="/api/health")
+    client = TestClient(app)
+
+    response = client.get("/api/health", headers={"X-Correlation-Id": "test"})
+    assert response.status_code == 200
+    data = response.json()
+    assert data["services"]["dummy"]["status"] == "healthy"
+    assert data["correlation_id"] == "test"
+
+    response = client.get("/api/health/dummy")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["result"]["status"] == "healthy"
+
+    await shutdown_connection_health_manager()


### PR DESCRIPTION
## Summary
- expose health monitoring API with Prometheus metrics and correlation-aware logging
- register health router in main server
- add tests for health endpoint

## Testing
- `pytest tests/test_health_api_routes.py tests/test_web_ui_api_integration.py::TestWebUIAPIIntegration::test_health_check_endpoint -q` *(fails: ModuleNotFoundError: No module named 'bcrypt')*

------
https://chatgpt.com/codex/tasks/task_e_68aba00f6724832497305630e5cdf71c