### PR TITLE
feat: add memory metrics and health

### DIFF
--- a/src/core/response/tests/test_chat_memory.py
+++ b/src/core/response/tests/test_chat_memory.py
@@ -34,3 +34,13 @@ def test_recall_promotes_frequent_items(tmp_path):
     # after repeated access, second record should have higher access_count
     records = memory._store[conv]
     assert records[0].access_count <= records[1].access_count
+
+
+def test_health_status(tmp_path):
+    meta_file = tmp_path / "meta.json"
+    memory = ChatMemory(metadata_path=meta_file)
+    conv = "c3"
+    memory.store(conv, "hello", "hi")
+    status = memory.health_status()
+    assert status["conversations"] == 1
+    assert status["records"] == 1


### PR DESCRIPTION
## Summary
- add optional Prometheus counters and correlation-aware logging to ChatMemory
- expose basic health status metrics
- test memory health behavior

## Testing
- `pytest src/core/response/tests/test_chat_memory.py::test_store_and_fetch_context src/core/response/tests/test_chat_memory.py::test_recall_promotes_frequent_items src/core/response/tests/test_chat_memory.py::test_health_status -q`

------
https://chatgpt.com/codex/tasks/task_e_68ac4cce7180832492485199c34e2818