### PR TITLE
feat: add web client circuit breaker and request correlation IDs

### DIFF
--- a/ui_launchers/web_ui/src/__tests__/karen-backend.test.ts
+++ b/ui_launchers/web_ui/src/__tests__/karen-backend.test.ts
@@ -44,6 +44,8 @@ describe('KarenBackendService session handling', () => {
     expect(fetchMock).toHaveBeenCalled();
     const body = JSON.parse(fetchMock.mock.calls[0][1]!.body as string);
     expect(body.session_id).toBe('session-xyz');
+    const headers = fetchMock.mock.calls[0][1]!.headers as Record<string, string>;
+    expect(headers['X-Correlation-ID']).toBeTruthy();
   });
 
   it('retries auth on 401 and redirects when unauthorized', async () => {
@@ -94,6 +96,6 @@ describe('KarenBackendService session handling', () => {
     const second = await service.getAvailablePlugins();
     expect(second).toEqual([{ name: 'p1' }]);
 
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary
- add circuit breaker settings to web UI config
- implement client-side circuit breaker and correlation ID logging in KarenBackendService
- test request header includes X-Correlation-ID and cached plugin logic

## Testing
- `pre-commit run --files ui_launchers/web_ui/src/lib/config.ts ui_launchers/web_ui/src/lib/karen-backend.ts ui_launchers/web_ui/src/__tests__/karen-backend.test.ts`
- `cd ui_launchers/web_ui && npm test src/__tests__/karen-backend.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68ac4cce7180832492485199c34e2818