### PR TITLE
Add response observability and memory integration

### DIFF
--- a/src/core/response/__init__.py
+++ b/src/core/response/__init__.py
@@ -1,6 +1,8 @@
 """Core response pipeline components."""
 
 from .config import PipelineConfig
+from .circuit_breaker import CircuitBreaker
+from .chat_memory import ChatMemory
 from .formatter import DRYFormatter
 from .orchestrator import ResponseOrchestrator
 from .prompt_builder import PromptBuilder
@@ -13,8 +15,10 @@ __all__ = [
     "LLMClient",
     "Memory",
     "PipelineConfig",
+    "ChatMemory",
     "PromptBuilder",
     "DRYFormatter",
+    "CircuitBreaker",
     "SpaCyAnalyzer",
     "UnifiedLLMClient",
     "ResponseOrchestrator",

--- a/src/core/response/chat_memory.py
+++ b/src/core/response/chat_memory.py
@@ -11,6 +11,7 @@ audit trail and to enable basic data-retention policies.
 """
 
 import json
+import logging
 import math
 import time
 import hashlib
@@ -19,7 +20,36 @@ from pathlib import Path
 from typing import Any, Dict, List, DefaultDict
 from collections import defaultdict
 
+try:  # pragma: no cover - optional dependency
+    from ai_karen_engine.services.correlation_service import get_request_id
+except Exception:  # pragma: no cover - fallback when service unavailable
+    import uuid
+
+    def get_request_id() -> str:
+        return str(uuid.uuid4())
 from .protocols import Memory
+
+logger = logging.getLogger(__name__)
+
+try:  # pragma: no cover - optional dependency
+    from prometheus_client import Counter
+
+    _FETCH_COUNTER = Counter(
+        "chat_memory_fetch_total", "Total chat memory fetches", ["status"]
+    )
+    _STORE_COUNTER = Counter(
+        "chat_memory_store_total", "Total chat memory stores", ["status"]
+    )
+except Exception:  # pragma: no cover - metrics optional
+    class _DummyMetric:
+        def labels(self, **_kwargs):  # type: ignore[override]
+            return self
+
+        def inc(self, *_args, **_kwargs):  # type: ignore[override]
+            pass
+
+    _FETCH_COUNTER = _DummyMetric()
+    _STORE_COUNTER = _DummyMetric()
 
 
 @dataclass
@@ -51,45 +81,75 @@ class ChatMemory(Memory):
     # ------------------------------------------------------------------
     # Public protocol methods
     # ------------------------------------------------------------------
-    def fetch_context(self, conversation_id: str) -> List[str]:
+    def fetch_context(self, conversation_id: str, correlation_id: str | None = None) -> List[str]:
         """Return relevant context strings for *conversation_id*."""
-        if conversation_id in self._cache:
-            return self._cache[conversation_id]
+        correlation_id = correlation_id or get_request_id()
+        try:
+            if conversation_id in self._cache:
+                _FETCH_COUNTER.labels(status="cache").inc()
+                return self._cache[conversation_id]
 
-        self._purge_expired(conversation_id)
-        records = self._store.get(conversation_id, [])
-        if not records:
-            self._cache[conversation_id] = []
+            self._purge_expired(conversation_id)
+            records = self._store.get(conversation_id, [])
+            if not records:
+                self._cache[conversation_id] = []
+                _FETCH_COUNTER.labels(status="miss").inc()
+                return []
+
+            now = time.time()
+            scored: List[tuple[float, MemoryRecord]] = []
+            for rec in records:
+                recency = 1 / (1 + (now - rec.timestamp))
+                score = recency + math.log1p(rec.access_count)
+                scored.append((score, rec))
+
+            scored.sort(key=lambda x: x[0], reverse=True)
+            top_records = [f"{r.user_input}\n{r.response}" for _, r in scored[:5]]
+            for _, rec in scored[:5]:
+                rec.access_count += 1
+            self._cache[conversation_id] = top_records
+            self._save_metadata()
+            _FETCH_COUNTER.labels(status="hit").inc()
+            logger.info("Memory fetch", extra={"correlation_id": correlation_id})
+            return top_records
+        except Exception as exc:
+            _FETCH_COUNTER.labels(status="error").inc()
+            logger.exception("Memory fetch failed", extra={"correlation_id": correlation_id})
             return []
 
-        now = time.time()
-        scored: List[tuple[float, MemoryRecord]] = []
-        for rec in records:
-            recency = 1 / (1 + (now - rec.timestamp))
-            score = recency + math.log1p(rec.access_count)
-            scored.append((score, rec))
-
-        scored.sort(key=lambda x: x[0], reverse=True)
-        top_records = [f"{r.user_input}\n{r.response}" for _, r in scored[:5]]
-        for _, rec in scored[:5]:
-            rec.access_count += 1
-        self._cache[conversation_id] = top_records
-        self._save_metadata()
-        return top_records
-
-    def store(self, conversation_id: str, user_input: str, response: str) -> None:
+    def store(
+        self,
+        conversation_id: str,
+        user_input: str,
+        response: str,
+        correlation_id: str | None = None,
+    ) -> None:
         """Persist the exchange for future retrieval."""
-        embedding = self._embed(user_input)
-        record = MemoryRecord(
-            user_input=user_input,
-            response=response,
-            embedding=embedding,
-            timestamp=time.time(),
-            metadata={"length": len(user_input)},
-        )
-        self._store[conversation_id].append(record)
-        self._cache.pop(conversation_id, None)
-        self._save_metadata()
+        correlation_id = correlation_id or get_request_id()
+        try:
+            embedding = self._embed(user_input)
+            record = MemoryRecord(
+                user_input=user_input,
+                response=response,
+                embedding=embedding,
+                timestamp=time.time(),
+                metadata={"length": len(user_input)},
+            )
+            self._store[conversation_id].append(record)
+            self._cache.pop(conversation_id, None)
+            self._save_metadata()
+            _STORE_COUNTER.labels(status="ok").inc()
+            logger.info("Memory store", extra={"correlation_id": correlation_id})
+        except Exception:
+            _STORE_COUNTER.labels(status="error").inc()
+            logger.exception("Memory store failed", extra={"correlation_id": correlation_id})
+
+    def diagnostics(self) -> Dict[str, int]:
+        """Return basic diagnostic information."""
+        return {
+            "conversations": len(self._store),
+            "cache_entries": len(self._cache),
+        }
 
     # ------------------------------------------------------------------
     # Internal helpers

--- a/src/core/response/circuit_breaker.py
+++ b/src/core/response/circuit_breaker.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+"""Simple circuit breaker implementation for graceful degradation."""
+
+import time
+from dataclasses import dataclass
+
+
+@dataclass
+class CircuitBreaker:
+    """Track failures and temporarily block calls when threshold exceeded."""
+
+    failure_threshold: int = 3
+    recovery_time: float = 30.0  # seconds
+
+    _failures: int = 0
+    _opened_until: float = 0.0
+
+    def allow(self) -> bool:
+        """Return True if calls are allowed."""
+        if time.time() < self._opened_until:
+            return False
+        return True
+
+    def record_success(self) -> None:
+        self._failures = 0
+        self._opened_until = 0.0
+
+    def record_failure(self) -> None:
+        self._failures += 1
+        if self._failures >= self.failure_threshold:
+            self._opened_until = time.time() + self.recovery_time
+
+    @property
+    def state(self) -> str:
+        return "open" if not self.allow() else "closed"

--- a/src/core/response/config.py
+++ b/src/core/response/config.py
@@ -18,3 +18,5 @@ class PipelineConfig:
     template_dir: Path = field(
         default_factory=lambda: Path(__file__).parent / "templates"
     )
+    # Default message returned when the system is in a degraded state
+    safe_default: str = "I'm having trouble responding right now. Please try again later."

--- a/src/core/response/orchestrator.py
+++ b/src/core/response/orchestrator.py
@@ -2,12 +2,49 @@
 
 from __future__ import annotations
 
+import logging
+import time
+import uuid
 from typing import Any, Dict, List
 
+try:  # pragma: no cover - optional dependency
+    from ai_karen_engine.services.correlation_service import get_request_id
+except Exception:  # pragma: no cover - fallback when service unavailable
+    import uuid
+
+    def get_request_id() -> str:  # type: ignore[override]
+        return str(uuid.uuid4())
+
+from .circuit_breaker import CircuitBreaker
 from .config import PipelineConfig
 from .formatter import DRYFormatter
 from .prompt_builder import PromptBuilder
 from .protocols import Analyzer, LLMClient, Memory
+
+try:  # pragma: no cover - optional dependency
+    from prometheus_client import Counter, Histogram
+
+    _RESP_COUNTER = Counter(
+        "response_requests_total", "Total response orchestrations", ["status"]
+    )
+    _LATENCY_HIST = Histogram(
+        "response_latency_seconds", "Latency of response orchestration"
+    )
+except Exception:  # pragma: no cover
+    class _DummyMetric:
+        def labels(self, **_kwargs):  # type: ignore[override]
+            return self
+
+        def inc(self, *_args, **_kwargs):  # type: ignore[override]
+            pass
+
+        def observe(self, *_args, **_kwargs):  # type: ignore[override]
+            pass
+
+    _RESP_COUNTER = _DummyMetric()
+    _LATENCY_HIST = _DummyMetric()
+
+logger = logging.getLogger(__name__)
 
 
 class ResponseOrchestrator:
@@ -21,6 +58,7 @@ class ResponseOrchestrator:
         llm_client: LLMClient,
         prompt_builder: PromptBuilder | None = None,
         formatter: DRYFormatter | None = None,
+        breaker: CircuitBreaker | None = None,
     ) -> None:
         self.config = config
         self.analyzer = analyzer
@@ -28,6 +66,7 @@ class ResponseOrchestrator:
         self.llm_client = llm_client
         self.prompt_builder = prompt_builder or PromptBuilder(config.template_dir)
         self.formatter = formatter or DRYFormatter()
+        self.breaker = breaker or CircuitBreaker()
 
     def build_prompt(
         self, user_input: str, context: List[str], analysis: Dict[str, Any]
@@ -45,16 +84,60 @@ class ResponseOrchestrator:
             max_history=self.config.max_history,
         )
 
-    def respond(self, conversation_id: str, user_input: str, **llm_kwargs: Any) -> str:
+    def respond(
+        self,
+        conversation_id: str,
+        user_input: str,
+        correlation_id: str | None = None,
+        **llm_kwargs: Any,
+    ) -> str:
         """Generate a model response for *user_input* in *conversation_id*."""
 
-        analysis = self.analyzer.analyze(user_input)
-        context = self.memory.fetch_context(conversation_id)
-        prompt = self.build_prompt(user_input, context, analysis)
-        llm_kwargs.setdefault("model", self.config.model)
-        if self.config.fallback_model is not None:
-            llm_kwargs.setdefault("fallback_model", self.config.fallback_model)
-        response = self.llm_client.generate(prompt, **llm_kwargs)
-        formatted = self.formatter.format("Response", response)
-        self.memory.store(conversation_id, user_input, formatted)
-        return formatted
+        start = time.time()
+        correlation_id = correlation_id or get_request_id()
+        if not self.breaker.allow():
+            logger.warning(
+                "Circuit breaker open", extra={"correlation_id": correlation_id}
+            )
+            _RESP_COUNTER.labels(status="open").inc()
+            _LATENCY_HIST.observe(time.time() - start)
+            return self.config.safe_default
+
+        try:
+            analysis = self.analyzer.analyze(user_input)
+            context = self.memory.fetch_context(conversation_id, correlation_id)
+            prompt = self.build_prompt(user_input, context, analysis)
+            llm_kwargs.setdefault("model", self.config.model)
+            if self.config.fallback_model is not None:
+                llm_kwargs.setdefault("fallback_model", self.config.fallback_model)
+            response = self.llm_client.generate(prompt, **llm_kwargs)
+            formatted = self.formatter.format("Response", response)
+            self.memory.store(
+                conversation_id, user_input, formatted, correlation_id=correlation_id
+            )
+            self.breaker.record_success()
+            duration = time.time() - start
+            _RESP_COUNTER.labels(status="success").inc()
+            _LATENCY_HIST.observe(duration)
+            logger.info(
+                "Generated response",
+                extra={"correlation_id": correlation_id, "duration_ms": duration * 1000},
+            )
+            return formatted
+        except Exception as exc:
+            self.breaker.record_failure()
+            duration = time.time() - start
+            _RESP_COUNTER.labels(status="error").inc()
+            _LATENCY_HIST.observe(duration)
+            logger.exception(
+                "Response generation failed",
+                extra={"correlation_id": correlation_id},
+            )
+            return self.config.safe_default
+
+    def diagnostics(self) -> Dict[str, Any]:
+        """Return diagnostic information for health checks."""
+        info: Dict[str, Any] = {"circuit_breaker": self.breaker.state}
+        if hasattr(self.memory, "diagnostics"):
+            info["memory"] = self.memory.diagnostics()
+        return info

--- a/src/core/response/protocols.py
+++ b/src/core/response/protocols.py
@@ -15,10 +15,18 @@ class Analyzer(Protocol):
 class Memory(Protocol):
     """Stores and retrieves conversational context."""
 
-    def fetch_context(self, conversation_id: str) -> List[str]:
+    def fetch_context(
+        self, conversation_id: str, correlation_id: str | None = None
+    ) -> List[str]:
         """Return a list of relevant context strings."""
 
-    def store(self, conversation_id: str, user_input: str, response: str) -> None:
+    def store(
+        self,
+        conversation_id: str,
+        user_input: str,
+        response: str,
+        correlation_id: str | None = None,
+    ) -> None:
         """Persist the exchange for future retrieval."""
 
 


### PR DESCRIPTION
## Summary
- add circuit breaker with safe defaults to chat response orchestrator
- instrument chat memory and orchestration with Prometheus metrics and correlation-aware logging
- expose diagnostics helpers and extend memory protocol for correlation IDs

## Testing
- `pytest src/core/response/tests/test_chat_memory.py src/core/response/tests/test_response_pipeline.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac4e81aea08324b3bd77a1d3d127c1