### PR TITLE
Implement basic model and profile management components

### DIFF
--- a/ui_launchers/web_ui/src/components/settings/ModelBrowser.tsx
+++ b/ui_launchers/web_ui/src/components/settings/ModelBrowser.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { useState, useMemo } from "react";
+
+interface ModelInfo {
+  id: string;
+  name: string;
+  provider: string;
+  description?: string;
+}
+
+interface LLMProvider {
+  name: string;
+  description: string;
+}
+
+interface ModelBrowserProps {
+  models: ModelInfo[];
+  setModels: (models: ModelInfo[]) => void;
+  providers: LLMProvider[];
+}
+
+/**
+ * Lightweight model browser used when the backend is unavailable.
+ * Provides basic listing and client-side filtering of models loaded
+ * from the parent component.  This prevents React from attempting to
+ * render an undefined component which previously caused a crash.
+ */
+export default function ModelBrowser({ models, setModels, providers }: ModelBrowserProps) {
+  const [filter, setFilter] = useState("");
+
+  const filtered = useMemo(() => {
+    const lower = filter.toLowerCase();
+    return models.filter(m =>
+      m.name.toLowerCase().includes(lower) ||
+      m.provider.toLowerCase().includes(lower)
+    );
+  }, [models, filter]);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Available Models</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <Input
+          placeholder="Filter by name or provider"
+          value={filter}
+          onChange={e => setFilter(e.target.value)}
+        />
+        {filtered.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No models found.</p>
+        ) : (
+          <ul className="text-sm space-y-1">
+            {filtered.map(model => (
+              <li key={model.id} className="flex justify-between">
+                <span>{model.name}</span>
+                <span className="text-muted-foreground">{model.provider}</span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/ui_launchers/web_ui/src/components/settings/ProfileManager.tsx
+++ b/ui_launchers/web_ui/src/components/settings/ProfileManager.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { useState } from "react";
+
+interface LLMProvider {
+  name: string;
+  description: string;
+}
+
+interface LLMProfile {
+  id: string;
+  name: string;
+  description: string;
+}
+
+interface ProfileManagerProps {
+  profiles: LLMProfile[];
+  setProfiles: (profiles: LLMProfile[]) => void;
+  activeProfile: LLMProfile | null;
+  setActiveProfile: (profile: LLMProfile | null) => void;
+  providers: LLMProvider[];
+}
+
+/**
+ * Minimal profile manager that lets a user pick the active profile.
+ * This replaces an empty placeholder file that previously caused the
+ * settings dialog to crash during rendering.
+ */
+export default function ProfileManager({
+  profiles,
+  setProfiles,
+  activeProfile,
+  setActiveProfile,
+  providers,
+}: ProfileManagerProps) {
+  const [creating, setCreating] = useState(false);
+
+  const handleCreate = () => {
+    const newProfile: LLMProfile = {
+      id: `profile-${Date.now()}`,
+      name: `Profile ${profiles.length + 1}`,
+      description: "User created profile",
+    };
+    setProfiles([...profiles, newProfile]);
+    setActiveProfile(newProfile);
+    setCreating(false);
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Profiles</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {profiles.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No profiles defined.</p>
+        ) : (
+          <ul className="space-y-2">
+            {profiles.map(p => (
+              <li key={p.id} className="flex items-center justify-between">
+                <span>{p.name}</span>
+                {activeProfile?.id === p.id ? (
+                  <span className="text-sm text-muted-foreground">Active</span>
+                ) : (
+                  <Button size="sm" variant="secondary" onClick={() => setActiveProfile(p)}>
+                    Activate
+                  </Button>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+        <Button size="sm" onClick={handleCreate} disabled={creating}>
+          Add Profile
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}


### PR DESCRIPTION
## Summary
- add lightweight ModelBrowser and ProfileManager components
- guard provider health check against missing backend responses

## Testing
- `pre-commit run --files ui_launchers/web_ui/src/components/settings/ModelBrowser.tsx ui_launchers/web_ui/src/components/settings/ProfileManager.tsx ui_launchers/web_ui/src/components/settings/ProviderManagement.tsx`
- `pytest` *(fails: ImportError: cannot import name 'field_serializer' from 'ai_karen_engine.pydantic_stub')*

------
https://chatgpt.com/codex/tasks/task_e_68acffb2dbf48324bcb9040c711b3cd4