### PR TITLE
Fix missing import for LLaMA provider default model lookup

### DIFF
--- a/src/ai_karen_engine/integrations/providers/llamacpp_provider.py
+++ b/src/ai_karen_engine/integrations/providers/llamacpp_provider.py
@@ -6,9 +6,10 @@ for local GGUF model execution using llama-cpp-python.
 """
 
 import logging
+import os
 import time
-from typing import Any, Dict, List, Optional, Union, Iterator
 from pathlib import Path
+from typing import Any, Dict, Iterator, List, Optional, Union
 
 from ai_karen_engine.integrations.llm_utils import LLMProviderBase, GenerationFailed, EmbeddingFailed, record_llm_metric
 from ai_karen_engine.inference.llamacpp_runtime import LlamaCppRuntime


### PR DESCRIPTION
## Summary
- import the os module in the LlamaCpp provider so environment checks used during default model discovery work
- ensure the typing import ordering stays consistent after the new dependency is added

## Testing
- python -m compileall src/ai_karen_engine/integrations/providers/llamacpp_provider.py

------
https://chatgpt.com/codex/tasks/task_e_68d54002f148832491853c6632f181db