### PR TITLE
Reduce degraded mode startup dependencies

### DIFF
--- a/src/ai_karen_engine/services/ai_orchestrator/ai_orchestrator.py
+++ b/src/ai_karen_engine/services/ai_orchestrator/ai_orchestrator.py
@@ -34,6 +34,12 @@ class AIOrchestrator(BaseService):
         self._memory_service = None
         self._initialized = False
 
+        # Ensure a router instance exists for compatibility with legacy tests
+        # and call sites that patch ``llm_router`` directly.  The router itself
+        # still performs lazy provider resolution, and heavy degraded-mode
+        # helpers remain disabled unless explicitly requested.
+        self._get_llm_router()
+
     def _get_llm_router(self):
         """Lazily initialize LLM router to avoid circular imports."""
         if self.llm_router is None:

--- a/src/ai_karen_engine/services/nlp_service_manager.py
+++ b/src/ai_karen_engine/services/nlp_service_manager.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 from typing import Dict, Any, Optional, List, Union
 
 from ai_karen_engine.services.spacy_service import SpacyService, ParsedMessage
@@ -33,6 +34,19 @@ class NLPServiceManager:
             return
         
         self.config = self._load_config()
+
+        enable_heavy_helpers = (
+            os.getenv("KARI_ENABLE_DEGRADED_HELPERS", "").lower()
+            in {"1", "true", "yes"}
+        )
+        if not enable_heavy_helpers:
+            os.environ.setdefault("TRANSFORMERS_OFFLINE", "1")
+            os.environ.setdefault("HF_HUB_OFFLINE", "1")
+            logger.info(
+                "DistilBERT will run in offline fallback mode. Set "
+                "KARI_ENABLE_DEGRADED_HELPERS=1 to allow full model loading."
+            )
+
         self.spacy_service = SpacyService(self.config.spacy)
         self.distilbert_service = DistilBertService(self.config.distilbert)
         self.health_monitor = NLPHealthMonitor(


### PR DESCRIPTION
## Summary
- default degraded-mode helpers to a lightweight configuration and gate heavy model loading behind the `KARI_ENABLE_DEGRADED_HELPERS` flag so offline environments respond immediately
- have the NLP service manager honor the same flag and force transformer libraries into offline mode when heavy helpers are disabled
- pre-initialize the LLM router during orchestrator construction to preserve legacy injection points after tightening lazy-loading

## Testing
- `KARI_DUCKDB_PASSWORD=test KARI_JOB_ENC_KEY=MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDA= KARI_JOB_SIGNING_KEY=dummy pytest tests/unit/core/test_persona_fallback.py -k persona --maxfail=1`


------
https://chatgpt.com/codex/tasks/task_e_68d54002f148832491853c6632f181db