### PR TITLE
Improve fallback LLM robustness

### DIFF
--- a/models/llm_registry.json
+++ b/models/llm_registry.json
@@ -82,5 +82,17 @@
     "health_status": "unknown",
     "last_health_check": null,
     "error_message": null
+  },
+  {
+    "name": "fallback",
+    "provider_class": "FallbackProvider",
+    "description": "Deterministic offline fallback provider",
+    "supports_streaming": true,
+    "supports_embeddings": true,
+    "requires_api_key": false,
+    "default_model": "kari-fallback-v1",
+    "health_status": "healthy",
+    "last_health_check": null,
+    "error_message": null
   }
 ]

--- a/src/ai_karen_engine/integrations/__init__.py
+++ b/src/ai_karen_engine/integrations/__init__.py
@@ -1,26 +1,5 @@
 """Integration helpers for Kari AI (compatibility wrappers)."""
 
-from ai_karen_engine.integrations.automation_manager import AutomationManager
-from ai_karen_engine.integrations.local_rpa_client import LocalRPAClient
-from ai_karen_engine.integrations.llm_router import LLMProfileRouter
-from ai_karen_engine.integrations.voice_registry import (
-    VoiceRegistry,
-    get_voice_registry,
-    VoiceProviderBase,
-    DummyVoiceProvider,
-)
-from ai_karen_engine.integrations.video_registry import (
-    VideoRegistry,
-    get_video_registry,
-    VideoProviderBase,
-    DummyVideoProvider,
-)
-from ai_karen_engine.integrations.provider_registry import (
-    ProviderRegistry,
-    ModelInfo,
-    get_provider_registry,
-)
-
 __all__ = [
     "AutomationManager",
     "LocalRPAClient",
@@ -37,3 +16,69 @@ __all__ = [
     "DummyVideoProvider",
     "get_video_registry",
 ]
+
+
+def __getattr__(name):
+    if name == "AutomationManager":
+        from ai_karen_engine.integrations.automation_manager import AutomationManager as _AutomationManager
+
+        return _AutomationManager
+    if name == "LocalRPAClient":
+        from ai_karen_engine.integrations.local_rpa_client import LocalRPAClient as _LocalRPAClient
+
+        return _LocalRPAClient
+    if name == "LLMProfileRouter":
+        from ai_karen_engine.integrations.llm_router import LLMProfileRouter as _LLMProfileRouter
+
+        return _LLMProfileRouter
+    if name in {"ProviderRegistry", "ModelInfo", "get_provider_registry"}:
+        from ai_karen_engine.integrations.provider_registry import (
+            ProviderRegistry as _ProviderRegistry,
+            ModelInfo as _ModelInfo,
+            get_provider_registry as _get_provider_registry,
+        )
+
+        return {
+            "ProviderRegistry": _ProviderRegistry,
+            "ModelInfo": _ModelInfo,
+            "get_provider_registry": _get_provider_registry,
+        }[name]
+    if name in {
+        "VoiceRegistry",
+        "VoiceProviderBase",
+        "DummyVoiceProvider",
+        "get_voice_registry",
+    }:
+        from ai_karen_engine.integrations.voice_registry import (
+            VoiceRegistry as _VoiceRegistry,
+            VoiceProviderBase as _VoiceProviderBase,
+            DummyVoiceProvider as _DummyVoiceProvider,
+            get_voice_registry as _get_voice_registry,
+        )
+
+        return {
+            "VoiceRegistry": _VoiceRegistry,
+            "VoiceProviderBase": _VoiceProviderBase,
+            "DummyVoiceProvider": _DummyVoiceProvider,
+            "get_voice_registry": _get_voice_registry,
+        }[name]
+    if name in {
+        "VideoRegistry",
+        "VideoProviderBase",
+        "DummyVideoProvider",
+        "get_video_registry",
+    }:
+        from ai_karen_engine.integrations.video_registry import (
+            VideoRegistry as _VideoRegistry,
+            VideoProviderBase as _VideoProviderBase,
+            DummyVideoProvider as _DummyVideoProvider,
+            get_video_registry as _get_video_registry,
+        )
+
+        return {
+            "VideoRegistry": _VideoRegistry,
+            "VideoProviderBase": _VideoProviderBase,
+            "DummyVideoProvider": _DummyVideoProvider,
+            "get_video_registry": _get_video_registry,
+        }[name]
+    raise AttributeError(name)

--- a/src/ai_karen_engine/integrations/providers/__init__.py
+++ b/src/ai_karen_engine/integrations/providers/__init__.py
@@ -1,19 +1,33 @@
-"""
-LLM Provider implementations for Kari AI.
-"""
+"""LLM Provider implementations for Kari AI (lazy import facade)."""
 
-from ai_karen_engine.integrations.providers.huggingface_provider import HuggingFaceProvider
-from ai_karen_engine.integrations.providers.llamacpp_provider import LlamaCppProvider
-from ai_karen_engine.integrations.providers.openai_provider import OpenAIProvider
-from ai_karen_engine.integrations.providers.gemini_provider import GeminiProvider
-from ai_karen_engine.integrations.providers.deepseek_provider import DeepseekProvider
-from ai_karen_engine.integrations.providers.copilotkit_provider import CopilotKitProvider
+from __future__ import annotations
+
+from importlib import import_module
 
 __all__ = [
     "HuggingFaceProvider",
-    "LlamaCppProvider", 
+    "LlamaCppProvider",
     "OpenAIProvider",
     "GeminiProvider",
     "DeepseekProvider",
-    "CopilotKitProvider"
+    "CopilotKitProvider",
+    "FallbackProvider",
 ]
+
+
+def __getattr__(name: str):
+    module_map = {
+        "HuggingFaceProvider": "ai_karen_engine.integrations.providers.huggingface_provider",
+        "LlamaCppProvider": "ai_karen_engine.integrations.providers.llamacpp_provider",
+        "OpenAIProvider": "ai_karen_engine.integrations.providers.openai_provider",
+        "GeminiProvider": "ai_karen_engine.integrations.providers.gemini_provider",
+        "DeepseekProvider": "ai_karen_engine.integrations.providers.deepseek_provider",
+        "CopilotKitProvider": "ai_karen_engine.integrations.providers.copilotkit_provider",
+        "FallbackProvider": "ai_karen_engine.integrations.providers.fallback_provider",
+    }
+
+    if name not in module_map:
+        raise AttributeError(name)
+
+    module = import_module(module_map[name])
+    return getattr(module, name)

--- a/src/ai_karen_engine/integrations/providers/fallback_provider.py
+++ b/src/ai_karen_engine/integrations/providers/fallback_provider.py
@@ -1,0 +1,175 @@
+"""Simple deterministic fallback provider for offline environments.
+
+This provider acts as a safety net when no networked or heavy-weight LLM
+backends are available.  It produces lightweight, helpful responses without
+external dependencies so that the rest of the Kari stack can continue to
+operate (for smoke tests, demos, or degraded modes).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import textwrap
+from datetime import datetime
+from typing import Any, Dict, Iterable, Iterator, List
+
+from ai_karen_engine.integrations.llm_utils import (
+    EmbeddingFailed,
+    GenerationFailed,
+    LLMProviderBase,
+    record_llm_metric,
+)
+
+logger = logging.getLogger("kari.fallback_provider")
+
+
+class FallbackProvider(LLMProviderBase):
+    """Deterministic provider that keeps Kari responsive without real LLMs.
+
+    The goal is graceful degradation: when "real" providers are unavailable the
+    fallback still returns a contextual acknowledgement so that the UI and
+    downstream services can verify the full request/response loop.
+    """
+
+    def __init__(
+        self,
+        model: str = "kari-fallback-v1",
+        max_history: int = 5,
+        **_: Any,
+    ) -> None:
+        self.model = model
+        self.max_history = max_history
+        self._history: List[str] = []
+        self.last_usage: Dict[str, Any] = {}
+        self.provider_name = "fallback"
+
+    # ------------------------------------------------------------------
+    # Core helpers
+    def _summarize_prompt(self, prompt: str) -> str:
+        """Create a compact summary snippet for the prompt."""
+
+        cleaned = " ".join(prompt.strip().split())
+        if not cleaned:
+            return "an empty prompt"
+
+        words = cleaned.split(" ")
+        if len(words) <= 16:
+            return cleaned
+
+        # Generate a deterministic checksum fragment so responses are stable
+        digest = hashlib.sha1(cleaned.encode("utf-8")).hexdigest()[:6]
+        preview = " ".join(words[:16])
+        return f"{preview}… (ref:{digest})"
+
+    def _build_suggestions(self, prompt: str) -> List[str]:
+        """Generate a couple of lightweight follow-up suggestions."""
+
+        topics = [
+            "analysis",
+            "planning",
+            "next steps",
+            "limitations",
+            "validation",
+        ]
+        # Deterministic shuffle based on prompt hash for variety without RNG drift
+        digest = hashlib.md5(prompt.encode("utf-8")).hexdigest()
+        start = int(digest[:8], 16)
+        ordered = topics[start % len(topics) :] + topics[: start % len(topics)]
+        return [f"Explore {topic}." for topic in ordered[:2]]
+
+    # ------------------------------------------------------------------
+    # LLMProviderBase interface
+    def generate_text(self, prompt: str, **kwargs: Any) -> str:  # type: ignore[override]
+        """Return a friendly deterministic message acknowledging the prompt."""
+
+        start = datetime.utcnow()
+        prompt_summary = self._summarize_prompt(prompt)
+
+        self._history.append(prompt_summary)
+        if len(self._history) > self.max_history:
+            self._history = self._history[-self.max_history :]
+
+        suggestions = self._build_suggestions(prompt)
+        response = textwrap.dedent(
+            f"""
+            Hello! I'm Kari's fallback assistant ({self.model}).
+            I received your message about: {prompt_summary}.
+
+            Here's a concise next step you can take right now:
+            - {suggestions[0]}
+
+            Another idea to continue the work:
+            - {suggestions[1]}
+
+            Let me know if you'd like me to expand on any part of this topic.
+            """
+        ).strip()
+
+        duration = (datetime.utcnow() - start).total_seconds()
+        token_estimate = max(1, len(prompt.split()))
+        self.last_usage = {
+            "prompt_tokens": token_estimate,
+            "completion_tokens": max(1, len(response.split()) // 2),
+            "total_tokens": token_estimate + max(1, len(response.split()) // 2),
+            "cost": 0.0,
+        }
+
+        record_llm_metric("generate_text", duration, True, "fallback")
+        logger.debug("FallbackProvider returning deterministic response")
+        return response
+
+    def stream_generate(self, prompt: str, **kwargs: Any) -> Iterator[str]:
+        """Provide a very small streaming-compatible generator."""
+
+        try:
+            result = self.generate_text(prompt, **kwargs)
+        except GenerationFailed as exc:  # pragma: no cover - defensive
+            raise exc
+
+        for chunk in textwrap.wrap(result, 80):
+            yield chunk
+
+    def embed(self, text: Any, **kwargs: Any) -> List[float]:  # type: ignore[override]
+        """Produce a deterministic pseudo-embedding vector."""
+
+        if isinstance(text, str):
+            values = text
+        elif isinstance(text, Iterable):
+            values = " ".join(str(item) for item in text)
+        else:
+            raise EmbeddingFailed("Unsupported input type for fallback embeddings")
+
+        digest = hashlib.sha1(values.encode("utf-8")).digest()
+        # Create a small deterministic vector in range [-1, 1]
+        vector = [((b / 255.0) * 2) - 1 for b in digest[:32]]
+        if not vector:
+            raise EmbeddingFailed("Unable to generate embedding")
+        return vector
+
+    def warm_cache(self) -> None:  # type: ignore[override]
+        """Nothing to warm, but keep interface parity."""
+
+        logger.debug("FallbackProvider warm_cache invoked - no action needed")
+
+    # ------------------------------------------------------------------
+    # Metadata helpers
+    def get_provider_info(self) -> Dict[str, Any]:
+        return {
+            "name": "fallback",
+            "model": self.model,
+            "supports_streaming": True,
+            "supports_embeddings": True,
+            "description": "Deterministic offline fallback provider",
+        }
+
+    def health_check(self) -> Dict[str, Any]:
+        return {
+            "status": "healthy",
+            "message": "Fallback provider operational",
+            "checked_at": datetime.utcnow().isoformat(),
+        }
+
+
+__all__ = ["FallbackProvider"]
+

--- a/tests/unit/ai/test_fallback_provider.py
+++ b/tests/unit/ai/test_fallback_provider.py
@@ -1,0 +1,200 @@
+"""Tests for the deterministic fallback LLM provider."""
+
+import importlib.util
+import os
+import sys
+import types
+from contextlib import contextmanager
+from pathlib import Path
+
+os.environ.setdefault("KARI_DUCKDB_PASSWORD", "test-password")
+
+
+def _install_database_stubs() -> None:
+    if "ai_karen_engine.database.client" not in sys.modules:
+        client_module = types.ModuleType("ai_karen_engine.database.client")
+
+        @contextmanager
+        def _ctx_manager():
+            class _DummySession:
+                def query(self, *args, **kwargs):
+                    return self
+
+                def filter_by(self, **kwargs):
+                    return self
+
+                def first(self):
+                    return None
+
+                def add(self, obj):
+                    return None
+
+                def commit(self):
+                    return None
+
+            yield _DummySession()
+
+        client_module.get_db_session_context = _ctx_manager  # type: ignore[attr-defined]
+        sys.modules["ai_karen_engine.database.client"] = client_module
+
+    if "ai_karen_engine.database.models" not in sys.modules:
+        models_module = types.ModuleType("ai_karen_engine.database.models")
+
+        class _LLMProvider:
+            id = None
+
+        class _LLMRequest:
+            def __init__(self, **kwargs):
+                self.__dict__.update(kwargs)
+
+        class _GenericModel:
+            def __init__(self, **kwargs):
+                self.__dict__.update(kwargs)
+
+        def _module_getattr(name: str):
+            return _GenericModel
+
+        models_module.LLMProvider = _LLMProvider  # type: ignore[attr-defined]
+        models_module.LLMRequest = _LLMRequest  # type: ignore[attr-defined]
+        models_module.__getattr__ = _module_getattr  # type: ignore[attr-defined]
+        sys.modules["ai_karen_engine.database.models"] = models_module
+
+    if "ai_karen_engine.services.metrics_service" not in sys.modules:
+        metrics_module = types.ModuleType("ai_karen_engine.services.metrics_service")
+
+        class _Metrics:
+            def record_llm_latency(self, *args, **kwargs):
+                return None
+
+        metrics_module.get_metrics_service = lambda: _Metrics()  # type: ignore[attr-defined]
+        sys.modules["ai_karen_engine.services.metrics_service"] = metrics_module
+
+
+def _load_fallback_provider():
+    _install_database_stubs()
+
+    module_name = "ai_karen_engine.integrations.providers.fallback_provider"
+    module_path = (
+        Path(__file__).resolve().parents[3]
+        / "src"
+        / "ai_karen_engine"
+        / "integrations"
+        / "providers"
+        / "fallback_provider.py"
+    )
+
+    if module_name not in sys.modules:
+        spec = importlib.util.spec_from_file_location(module_name, module_path)
+        fallback_module = importlib.util.module_from_spec(spec)
+        assert spec.loader is not None
+        spec.loader.exec_module(fallback_module)
+        sys.modules[module_name] = fallback_module
+    else:
+        fallback_module = sys.modules[module_name]
+
+    providers_name = "ai_karen_engine.integrations.providers"
+    if providers_name not in sys.modules:
+        providers_module = types.ModuleType(providers_name)
+        fallback_cls = fallback_module.FallbackProvider
+
+        class _DummyProvider:  # pragma: no cover - placeholder
+            def __init__(self, *args, **kwargs):
+                return None
+
+        providers_module.HuggingFaceProvider = _DummyProvider  # type: ignore[attr-defined]
+        providers_module.LlamaCppProvider = _DummyProvider  # type: ignore[attr-defined]
+        providers_module.OpenAIProvider = _DummyProvider  # type: ignore[attr-defined]
+        providers_module.GeminiProvider = _DummyProvider  # type: ignore[attr-defined]
+        providers_module.DeepseekProvider = _DummyProvider  # type: ignore[attr-defined]
+        providers_module.CopilotKitProvider = _DummyProvider  # type: ignore[attr-defined]
+        providers_module.FallbackProvider = fallback_cls  # type: ignore[attr-defined]
+        providers_module.__all__ = [
+            "HuggingFaceProvider",
+            "LlamaCppProvider",
+            "OpenAIProvider",
+            "GeminiProvider",
+            "DeepseekProvider",
+            "CopilotKitProvider",
+            "FallbackProvider",
+        ]
+        sys.modules[providers_name] = providers_module
+
+    return fallback_module.FallbackProvider
+
+
+class TestFallbackProvider:
+    """Ensure the fallback provider keeps the prompt/response loop alive."""
+
+    def test_generate_text_acknowledges_prompt(self):
+        provider_cls = _load_fallback_provider()
+        provider = provider_cls()
+        prompt = "Summarise offline readiness steps"
+
+        response = provider.generate_text(prompt)
+
+        assert "fallback assistant" in response.lower()
+        assert "summarise" in response.lower()
+
+    def test_embeddings_are_deterministic(self):
+        provider_cls = _load_fallback_provider()
+        provider = provider_cls()
+        text = "deterministic embedding"
+
+        first = provider.embed(text)
+        second = provider.embed(text)
+
+        assert first == second
+        assert all(-1.0 <= value <= 1.0 for value in first)
+
+    def test_llm_utils_uses_fallback_when_primary_missing(self):
+        provider_cls = _load_fallback_provider()
+        _install_database_stubs()
+
+        class _DummyRegistry:
+            def __init__(self):
+                self.calls = []
+
+            def get_available_providers(self):
+                return ["fallback"]
+
+            def list_providers(self):
+                return ["fallback", "openai"]
+
+            def auto_select_provider(self, _requirements):
+                return "fallback"
+
+            def get_provider(self, name, **_kwargs):
+                self.calls.append(name)
+                if name == "fallback":
+                    return provider_cls()
+                return None
+
+        registry_module = types.ModuleType(
+            "ai_karen_engine.integrations.llm_registry"
+        )
+        dummy_registry = _DummyRegistry()
+        registry_module.get_registry = lambda: dummy_registry  # type: ignore[attr-defined]
+        registry_module.list_providers = dummy_registry.list_providers  # type: ignore[attr-defined]
+        original_module = sys.modules.get(
+            "ai_karen_engine.integrations.llm_registry"
+        )
+        sys.modules["ai_karen_engine.integrations.llm_registry"] = registry_module
+
+        try:
+            from ai_karen_engine.integrations.llm_utils import LLMUtils
+
+            utils = LLMUtils(use_registry=True)
+            response = utils.generate_text(
+                "Verify fallback readiness", provider="openai"
+            )
+
+            assert "fallback assistant" in response.lower()
+            assert dummy_registry.calls == ["openai", "fallback"]
+        finally:
+            if original_module is not None:
+                sys.modules["ai_karen_engine.integrations.llm_registry"] = (
+                    original_module
+                )
+            else:
+                del sys.modules["ai_karen_engine.integrations.llm_registry"]
+


### PR DESCRIPTION
## Summary
- lazily import provider implementations in the registry facade so initializing the registry no longer triggers heavyweight dependencies
- harden `LLMUtils` to tolerate missing database/metrics stacks and ensure fallback selection works even when the requested provider is unavailable
- mark the deterministic fallback provider as streaming-capable in both code and metadata and cover the behaviour with a regression test

## Testing
- pytest --override-ini addopts="" tests/unit/ai/test_fallback_provider.py

------
https://chatgpt.com/codex/tasks/task_e_68d54002f148832491853c6632f181db