### PR TITLE
Ensure fallback LLM provider is registered

### DIFF
--- a/src/ai_karen_engine/integrations/provider_registry.py
+++ b/src/ai_karen_engine/integrations/provider_registry.py
@@ -184,6 +184,7 @@ class ProviderRegistry:
                 HuggingFaceProvider,
                 LlamaCppProvider,
                 OpenAIProvider,
+                FallbackProvider,
             )
 
             providers: List[Dict[str, Any]] = [
@@ -226,6 +227,14 @@ class ProviderRegistry:
                     "default_model": "microsoft/DialoGPT-large",
                     "requires_api_key": True,
                     "capabilities": ["text", "embeddings"],
+                },
+                {
+                    "name": "fallback",
+                    "cls": FallbackProvider,
+                    "description": "Deterministic offline responses for smoke tests and degraded mode",
+                    "default_model": "kari-fallback-v1",
+                    "requires_api_key": False,
+                    "capabilities": ["generic", "text"],
                 },
             ]
 

--- a/src/ai_karen_engine/integrations/providers/fallback_provider.py
+++ b/src/ai_karen_engine/integrations/providers/fallback_provider.py
@@ -119,6 +119,15 @@ class FallbackProvider(LLMProviderBase):
         logger.debug("FallbackProvider returning deterministic response")
         return response
 
+    # The orchestrator prefers providers exposing ``generate_response`` (and
+    # sometimes ``enhanced_generate_response``) so mirror ``generate_text`` to
+    # keep compatibility with richer providers without duplicating logic.
+    def generate_response(self, prompt: str, **kwargs: Any) -> str:  # type: ignore[override]
+        return self.generate_text(prompt, **kwargs)
+
+    def enhanced_generate_response(self, prompt: str, **kwargs: Any) -> str:  # type: ignore[override]
+        return self.generate_text(prompt, **kwargs)
+
     def stream_generate(self, prompt: str, **kwargs: Any) -> Iterator[str]:
         """Provide a very small streaming-compatible generator."""
 

--- a/src/ai_karen_engine/llm_orchestrator.py
+++ b/src/ai_karen_engine/llm_orchestrator.py
@@ -438,7 +438,17 @@ class LLMOrchestrator:
                     provider = registry.get_provider(provider_name, model=m.name)
                     model_id = f"{provider_name}:{m.name}"
                     capabilities = m.capabilities or ["generic"]
-                    self.registry.register(model_id, provider, capabilities)
+                    register_kwargs = {}
+                    if provider_name.lower() == "fallback":
+                        # Ensure fallback provider is always tried last
+                        register_kwargs["weight"] = 100
+                        register_kwargs["tags"] = ["fallback", "deterministic"]
+                    self.registry.register(
+                        model_id,
+                        provider,
+                        capabilities,
+                        **register_kwargs,
+                    )
                     latency = self._warm_model(model_id, provider)
                     if latency is not None:
                         info = self.registry._models.get(model_id)


### PR DESCRIPTION
## Summary
- auto-register the deterministic fallback LLM provider in the shared provider registry so Kari can respond without external models
- make the orchestrator recognize the fallback provider with a low priority weight to preserve other model choices
- expose `generate_response` helpers on the fallback provider so streaming/enhanced routes can safely call it

## Testing
- `pytest tests/unit/ai/test_llm_orchestrator.py::test_orchestrator_fallback_to_default` *(fails: import chain hits circular dependency after loading numerous optional services; fallback registration itself works but the suite expects a fuller runtime stack)*

------
https://chatgpt.com/codex/tasks/task_e_68d5cef996608324a8e0f20f45bcc313