### PR TITLE
Fix fallback LLM routing without database

### DIFF
--- a/src/ai_karen_engine/integrations/provider_registry.py
+++ b/src/ai_karen_engine/integrations/provider_registry.py
@@ -178,12 +178,22 @@ class ProviderRegistry:
         """Best-effort auto-registration of core system providers."""
 
         try:
-            from ai_karen_engine.integrations.providers import (
+            from ai_karen_engine.integrations.providers.deepseek_provider import (
                 DeepseekProvider,
+            )
+            from ai_karen_engine.integrations.providers.gemini_provider import (
                 GeminiProvider,
+            )
+            from ai_karen_engine.integrations.providers.huggingface_provider import (
                 HuggingFaceProvider,
+            )
+            from ai_karen_engine.integrations.providers.llamacpp_provider import (
                 LlamaCppProvider,
+            )
+            from ai_karen_engine.integrations.providers.openai_provider import (
                 OpenAIProvider,
+            )
+            from ai_karen_engine.integrations.providers.fallback_provider import (
                 FallbackProvider,
             )
 

--- a/src/ai_karen_engine/integrations/providers/__init__.py
+++ b/src/ai_karen_engine/integrations/providers/__init__.py
@@ -1,21 +1,34 @@
-"""
-LLM Provider implementations for Kari AI.
-"""
+"""Lazy loading interface for Kari AI provider implementations."""
 
-from ai_karen_engine.integrations.providers.huggingface_provider import HuggingFaceProvider
-from ai_karen_engine.integrations.providers.llamacpp_provider import LlamaCppProvider
-from ai_karen_engine.integrations.providers.openai_provider import OpenAIProvider
-from ai_karen_engine.integrations.providers.gemini_provider import GeminiProvider
-from ai_karen_engine.integrations.providers.deepseek_provider import DeepseekProvider
-from ai_karen_engine.integrations.providers.copilotkit_provider import CopilotKitProvider
-from ai_karen_engine.integrations.providers.fallback_provider import FallbackProvider
+from importlib import import_module
+from typing import Any
 
 __all__ = [
     "HuggingFaceProvider",
-    "LlamaCppProvider", 
+    "LlamaCppProvider",
     "OpenAIProvider",
     "GeminiProvider",
     "DeepseekProvider",
     "CopilotKitProvider",
     "FallbackProvider",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    """Dynamically import provider implementations on first access."""
+
+    if name not in __all__:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    module_name = {
+        "HuggingFaceProvider": "ai_karen_engine.integrations.providers.huggingface_provider",
+        "LlamaCppProvider": "ai_karen_engine.integrations.providers.llamacpp_provider",
+        "OpenAIProvider": "ai_karen_engine.integrations.providers.openai_provider",
+        "GeminiProvider": "ai_karen_engine.integrations.providers.gemini_provider",
+        "DeepseekProvider": "ai_karen_engine.integrations.providers.deepseek_provider",
+        "CopilotKitProvider": "ai_karen_engine.integrations.providers.copilotkit_provider",
+        "FallbackProvider": "ai_karen_engine.integrations.providers.fallback_provider",
+    }[name]
+
+    module = import_module(module_name)
+    return getattr(module, name)


### PR DESCRIPTION
## Summary
- make llm utils resilient to missing database/metrics dependencies and skip persistence when offline
- lazily import metrics and provider modules to avoid circular imports during orchestrator bootstrap
- adjust provider registry to load core providers without pulling in heavy optional dependencies

## Testing
- `pytest -o addopts='' tests/unit/ai/test_fallback_provider.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68d5deeeaf408324bbe3c1f38ac859d2