### PR TITLE
Optimize copilot routes for lightweight initialization

### DIFF
--- a/src/ai_karen_engine/server/__init__.py
+++ b/src/ai_karen_engine/server/__init__.py
@@ -1,39 +1,69 @@
+"""Lightweight server package exports with lazy loading.
+
+Historically this module eagerly imported a large collection of server
+utilities so that downstream modules could access them via
+``ai_karen_engine.server``. Those imports pulled in heavy dependencies
+including NLP pipelines and database clients during application start-up,
+which made simple tasks—like instantiating a FastAPI test client—very
+slow or even caused timeouts when optional models (spaCy, transformers)
+were missing.
+
+To keep import-time side effects minimal we now expose the same public
+symbols via on-demand imports. This keeps compatibility with existing
+``from ai_karen_engine.server import <Symbol>`` statements while avoiding
+the expensive initialization until a symbol is actually used.
 """
-AI Karen Engine Server Module
 
-This module contains server-related components including middleware,
-HTTP request validation, and server configuration.
-"""
-
-from ai_karen_engine.server.http_validator import (
-    HTTPRequestValidator,
-    ValidationConfig,
-    ValidationResult,
-)
-
-from ai_karen_engine.server.enhanced_logger import (
-    EnhancedLogger,
-    LoggingConfig,
-    SecurityEvent,
-    SecurityEventType,
-    ThreatLevel,
-    DataSanitizer,
-    SecurityAlertManager,
-    get_enhanced_logger,
-    init_enhanced_logging
-)
+from importlib import import_module
+from typing import Any, Dict
 
 __all__ = [
-    "HTTPRequestValidator", 
-    "ValidationConfig", 
+    "HTTPRequestValidator",
+    "ValidationConfig",
     "ValidationResult",
     "EnhancedLogger",
     "LoggingConfig",
     "SecurityEvent",
-    "SecurityEventType", 
+    "SecurityEventType",
     "ThreatLevel",
     "DataSanitizer",
     "SecurityAlertManager",
     "get_enhanced_logger",
-    "init_enhanced_logging"
+    "init_enhanced_logging",
 ]
+
+_LAZY_IMPORTS: Dict[str, str] = {
+    "HTTPRequestValidator": "ai_karen_engine.server.http_validator",
+    "ValidationConfig": "ai_karen_engine.server.http_validator",
+    "ValidationResult": "ai_karen_engine.server.http_validator",
+    "EnhancedLogger": "ai_karen_engine.server.enhanced_logger",
+    "LoggingConfig": "ai_karen_engine.server.enhanced_logger",
+    "SecurityEvent": "ai_karen_engine.server.enhanced_logger",
+    "SecurityEventType": "ai_karen_engine.server.enhanced_logger",
+    "ThreatLevel": "ai_karen_engine.server.enhanced_logger",
+    "DataSanitizer": "ai_karen_engine.server.enhanced_logger",
+    "SecurityAlertManager": "ai_karen_engine.server.enhanced_logger",
+    "get_enhanced_logger": "ai_karen_engine.server.enhanced_logger",
+    "init_enhanced_logging": "ai_karen_engine.server.enhanced_logger",
+}
+
+
+def __getattr__(name: str) -> Any:
+    """Load server utilities lazily on first access.
+
+    This prevents heavyweight optional dependencies from being imported
+    unless the caller explicitly uses the associated functionality.
+    """
+
+    module_path = _LAZY_IMPORTS.get(name)
+    if not module_path:
+        raise AttributeError(name)
+
+    module = import_module(module_path)
+    value = getattr(module, name)
+    globals()[name] = value
+    return value
+
+
+def __dir__() -> Any:  # pragma: no cover - trivial helper
+    return sorted(set(__all__ + list(globals().keys())))


### PR DESCRIPTION
## Summary
- lazily load server utilities so importing `ai_karen_engine.server` no longer drags heavy dependencies during startup
- defer copilot route dependencies (predictor registry, audit logger, health manager) until request time with resilient fallbacks
- keep the copilot assist health gate functional even when the connection manager cannot be imported and provide graceful degraded responses

## Testing
- `SPACY_DOWNLOAD_MISSING=false TRANSFORMERS_OFFLINE=1 HF_HUB_OFFLINE=1 PYTHONPATH=src python - <<'PY'\nfrom fastapi import FastAPI\nfrom fastapi.testclient import TestClient\n\nfrom ai_karen_engine.api_routes import copilot_routes\n\napp = FastAPI()\napp.include_router(copilot_routes.router, prefix="/api/copilot")\n\nclass DummyResp:\n    def __init__(self, response="Hello!", context_data=None):\n        self.response = response\n        self.context_data = context_data or []\n\ndef dummy_orchestrator():\n    class Orchestrator:\n        async def process_message(self, chat_request):\n            return DummyResp(response=f"Echo: {chat_request.message}")\n    return Orchestrator()\n\napp.dependency_overrides[copilot_routes.get_chat_orchestrator] = dummy_orchestrator\n\nclient = TestClient(app)\nresp = client.post("/api/copilot/assist", json={"user_id": "u", "message": "Test message"})\nprint(resp.status_code)\nprint(resp.json())\nPY`


------
https://chatgpt.com/codex/tasks/task_e_68d5deeeaf408324bbe3c1f38ac859d2