### PR TITLE
Fix circular imports and ensure fallback LLM responses

### DIFF
--- a/src/ai_karen_engine/integrations/llm_utils.py
+++ b/src/ai_karen_engine/integrations/llm_utils.py
@@ -410,9 +410,7 @@ class LLMUtils:
         finally:
             duration = time.time() - t0
             try:
-                from ai_karen_engine.services.metrics_service import get_metrics_service
-
-                get_metrics_service().record_llm_latency(
+                metrics_service.record_llm_latency(
                     duration,
                     provider=provider_name,
                     model=model_name or "",
@@ -469,9 +467,8 @@ class LLMUtils:
         finally:
             duration = time.time() - t0
             try:
-                from ai_karen_engine.services.metrics_service import get_metrics_service
-
-                get_metrics_service().record_llm_latency(
+                metrics_service = get_metrics_service()
+                metrics_service.record_llm_latency(
                     duration,
                     provider=provider_name,
                     model=model_name or "",


### PR DESCRIPTION
## Summary
- defer loading heavy core helpers via lazy imports to prevent circular imports during low-level initialization
- reuse metrics service instances in LLM utilities so fallback providers can respond without UnboundLocal errors

## Testing
- pytest -q tests/unit/ai/test_fallback_provider.py -o addopts=


------
https://chatgpt.com/codex/tasks/task_e_68d5deeeaf408324bbe3c1f38ac859d2