### PR TITLE
Ensure routers load synchronously so chat API works immediately

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -80,7 +80,9 @@ def create_app() -> FastAPI:
     configure_middleware(app, settings, REQUEST_COUNT, REQUEST_LATENCY, ERROR_COUNT)
     
     # Optionally defer router wiring to speed up initial readiness in dev
-    _defer_wiring = os.getenv("KARI_DEFER_ROUTER_WIRING", "true").lower() in ("1", "true", "yes")
+    # Default to immediate wiring so critical routes (e.g. auth) are available
+    # before the first request without requiring special environment flags.
+    _defer_wiring = os.getenv("KARI_DEFER_ROUTER_WIRING", "false").lower() in ("1", "true", "yes")
     if _defer_wiring and settings.environment != "production":
         logger.info("⚡ Deferring router wiring to background for faster readiness")
     else:


### PR DESCRIPTION
## Summary
- default router wiring to happen immediately unless KARI_DEFER_ROUTER_WIRING explicitly enables deferral
- document why immediate wiring is the safe default so auth and chat routes are always available at startup

## Testing
- python - <<'PY'
from fastapi.testclient import TestClient
from server.app import create_app

app = create_app()
client = TestClient(app)

resp = client.post('/api/auth/login', json={'email':'admin@example.com','password':'admin'})
print('login status', resp.status_code)
print(resp.json())

token = resp.json()['access_token']
headers={'Authorization': f'Bearer {token}'}

resp = client.post('/api/chat/runtime', json={'message':'Hello there!','stream': False}, headers=headers)
print('chat status', resp.status_code)
print(resp.json())
PY

------
https://chatgpt.com/codex/tasks/task_e_68d5e6b049088324a754095837785029