### PR TITLE
Improve layout styling and accessibility

### DIFF
--- a/ui_launchers/web_ui/src/app/chat/page.tsx
+++ b/ui_launchers/web_ui/src/app/chat/page.tsx
@@ -152,24 +152,26 @@ function ChatView() {
             </Sidebar>
           )}
 
-          <SidebarInset className="flex flex-col min-h-0">
+          <SidebarInset className="chat-surface min-h-0">
             <MetaBar />
             <div className="chat-messages">
               <div className="container max-w-screen-xl">
-                <ChatInterface
-                  className="h-full smooth-transition"
-                  useCopilotKit={true}
-                  enableCodeAssistance={true}
-                  enableContextualHelp={true}
-                  enableDocGeneration={true}
-                  showTabs={true}
-                  showSettings={true}
-                  enableVoiceInput={false}
-                  enableFileUpload={true}
-                  enableAnalytics={true}
-                  enableExport={true}
-                  enableSharing={false}
-                />
+                <div className="chat-panel">
+                  <ChatInterface
+                    className="h-full smooth-transition"
+                    useCopilotKit={true}
+                    enableCodeAssistance={true}
+                    enableContextualHelp={true}
+                    enableDocGeneration={true}
+                    showTabs={true}
+                    showSettings={true}
+                    enableVoiceInput={false}
+                    enableFileUpload={true}
+                    enableAnalytics={true}
+                    enableExport={true}
+                    enableSharing={false}
+                  />
+                </div>
               </div>
             </div>
           </SidebarInset>

--- a/ui_launchers/web_ui/src/app/layout.tsx
+++ b/ui_launchers/web_ui/src/app/layout.tsx
@@ -64,14 +64,6 @@ export default function RootLayout({
         <meta name="color-scheme" content="light dark" />
       </head>
       <body className={`${inter.variable} ${robotoMono.variable} font-sans antialiased scroll-smooth`}>
-        {/* Skip to main content link for accessibility */}
-        <a 
-          href="#main-content" 
-          className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 bg-primary text-primary-foreground px-4 py-2 rounded-md z-50 interactive"
-          aria-label="Skip to main content"
-        >
-          Skip to main content
-        </a>
         {/* Console error fix script - load early to prevent interceptor issues */}
         <Script
           id="console-error-fix"
@@ -125,11 +117,13 @@ export default function RootLayout({
         />
         
         {/* Accessible skip link for keyboard users */}
-        <a href="#content" className="skip-link">Skip to content</a>
+        <a href="#main-content" className="skip-link" aria-label="Skip to main content">
+          Skip to main content
+        </a>
         <ThemeBridge>
           <Providers>
             <HealthStatusBadge />
-            <main id="content" role="main" className="min-h-dvh focus:outline-none smooth-transition content-area">
+            <main id="main-content" role="main" className="min-h-dvh focus:outline-none smooth-transition content-area">
               <div className="container-fluid modern-layout-root">
                 {children}
               </div>

--- a/ui_launchers/web_ui/src/components/chat/MetaBar.tsx
+++ b/ui_launchers/web_ui/src/components/chat/MetaBar.tsx
@@ -126,8 +126,10 @@ export const MetaBar: React.FC<MetaBarProps> = ({
   }
 
   return (
-    <div className="flex items-center gap-2 border-b border-border px-4 py-2">
-      {items}
+    <div className="chat-meta-bar">
+      <div className="container max-w-screen-xl flex flex-wrap items-center gap-2 py-2">
+        {items}
+      </div>
     </div>
   );
 };

--- a/ui_launchers/web_ui/src/components/ui/sidebar.tsx
+++ b/ui_launchers/web_ui/src/components/ui/sidebar.tsx
@@ -179,6 +179,8 @@ const Sidebar = React.forwardRef<
             "flex h-full w-[--sidebar-width] flex-col bg-sidebar text-sidebar-foreground",
             className
           )}
+          role="navigation"
+          aria-label="Sidebar"
           ref={ref}
           {...props}
         >

--- a/ui_launchers/web_ui/src/styles/globals.css
+++ b/ui_launchers/web_ui/src/styles/globals.css
@@ -215,6 +215,7 @@
     grid-template-rows: auto 1fr auto;
     height: 100vh;
     width: 100%;
+    background: hsl(var(--background));
   }
   
   .chat-header {
@@ -229,12 +230,49 @@
     overflow-y: auto;
     padding: 1rem;
     flex: 1;
+    background: hsl(var(--background));
   }
   
   .chat-input {
     padding: 1rem 1.5rem;
     border-top: 1px solid hsl(var(--border));
     background: hsl(var(--background));
+  }
+
+  .chat-surface {
+    gap: clamp(1rem, 2vw, 1.5rem);
+    padding: clamp(1rem, 2vw, 1.5rem);
+    background: linear-gradient(
+      180deg,
+      hsl(var(--background)) 0%,
+      hsl(var(--background) / 0.96) 100%
+    );
+    color: hsl(var(--foreground));
+  }
+
+  .chat-panel {
+    background: hsl(var(--card));
+    border: 1px solid hsl(var(--border));
+    border-radius: calc(var(--radius) + 2px);
+    box-shadow:
+      0 15px 50px -25px rgb(17 24 39 / 0.45),
+      0 8px 18px -12px rgb(17 24 39 / 0.35);
+    overflow: hidden;
+  }
+
+  .chat-panel > * {
+    background: transparent;
+  }
+
+  .chat-meta-bar {
+    position: sticky;
+    top: 0;
+    z-index: 10;
+    background: hsl(var(--background) / 0.94);
+    border-bottom: 1px solid hsl(var(--border));
+    box-shadow: 0 6px 20px -15px rgb(0 0 0 / 0.45);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
   }
   
   /* Dashboard Grid System */
@@ -296,6 +334,27 @@
     box-shadow: 0 2px 4px 0 rgb(0 0 0 / 0.05); /* Subtle hover effect */
     transform: translateY(-0.5px);
   }
+
+  .modern-card-elevated {
+    background: hsl(var(--card));
+    border: 1px solid hsl(var(--border) / 0.7);
+    box-shadow:
+      0 10px 30px -15px rgb(0 0 0 / 0.35),
+      0 10px 12px -12px rgb(0 0 0 / 0.2);
+  }
+
+  .modern-card-outlined {
+    background: hsl(var(--background));
+    border: 1px dashed hsl(var(--border));
+  }
+
+  .modern-card-glass {
+    background: hsl(var(--background) / 0.82);
+    border: 1px solid hsl(var(--border) / 0.6);
+    backdrop-filter: blur(18px);
+    -webkit-backdrop-filter: blur(18px);
+    box-shadow: 0 12px 32px -20px rgb(0 0 0 / 0.45);
+  }
   
   .modern-card-header {
     padding: 1.5rem 1.5rem 0;
@@ -337,6 +396,34 @@
     padding-right: 1rem;
     margin-left: auto;
     margin-right: auto;
+  }
+
+  .modern-layout-root {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    gap: clamp(1.5rem, 3vw, 3rem);
+    padding-block: clamp(1.5rem, 4vw, 3.5rem);
+  }
+
+  .modern-layout-root::before,
+  .modern-layout-root::after {
+    content: "";
+    position: fixed;
+    inset: 0;
+    pointer-events: none;
+  }
+
+  .modern-layout-root::before {
+    background:
+      radial-gradient(circle at 20% 20%, hsl(var(--primary) / 0.08), transparent 45%),
+      radial-gradient(circle at 80% 0%, hsl(var(--secondary) / 0.08), transparent 55%);
+    z-index: -2;
+  }
+
+  .modern-layout-root::after {
+    background: linear-gradient(180deg, hsl(var(--background)) 0%, hsl(var(--background)) 65%, transparent 100%);
+    z-index: -3;
   }
   
   /* Flexbox Utilities */


### PR DESCRIPTION
## Summary
- align the root skip link with the main content target and default the sidebar to expose navigation semantics
- add chat surface, meta bar, and card variant styles so the main window and sidebar render full backgrounds with depth
- wrap the chat interface in a styled panel and refresh the MetaBar container for consistent spacing

## Testing
- npm run lint *(fails: command prompts for eslint configuration in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6954f5f0083248ee2ab9f2d25a8a7