### PR TITLE
Improve layout backgrounds and reasoning test UI

### DIFF
--- a/ui_launchers/web_ui/src/app/layout.tsx
+++ b/ui_launchers/web_ui/src/app/layout.tsx
@@ -65,9 +65,9 @@ export default function RootLayout({
       </head>
       <body className={`${inter.variable} ${robotoMono.variable} font-sans antialiased scroll-smooth`}>
         {/* Skip to main content link for accessibility */}
-        <a 
-          href="#main-content" 
-          className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 bg-primary text-primary-foreground px-4 py-2 rounded-md z-50 interactive"
+        <a
+          href="#main-content"
+          className="skip-link sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 bg-primary text-primary-foreground px-4 py-2 rounded-md z-50 interactive"
           aria-label="Skip to main content"
         >
           Skip to main content
@@ -124,12 +124,15 @@ export default function RootLayout({
           }}
         />
         
-        {/* Accessible skip link for keyboard users */}
-        <a href="#content" className="skip-link">Skip to content</a>
         <ThemeBridge>
           <Providers>
             <HealthStatusBadge />
-            <main id="content" role="main" className="min-h-dvh focus:outline-none smooth-transition content-area">
+            <main
+              id="main-content"
+              role="main"
+              tabIndex={-1}
+              className="min-h-dvh focus:outline-none smooth-transition content-area"
+            >
               <div className="container-fluid modern-layout-root">
                 {children}
               </div>

--- a/ui_launchers/web_ui/src/components/extensions/ExtensionSidebar.tsx
+++ b/ui_launchers/web_ui/src/components/extensions/ExtensionSidebar.tsx
@@ -25,16 +25,20 @@ function SidebarInner() {
   return (
     <>
       <SidebarRail />
-      <Sidebar variant="sidebar" collapsible="icon" className="border-r z-20">
+      <Sidebar
+        variant="sidebar"
+        collapsible="icon"
+        className="border-r z-20 sidebar-enhanced"
+      >
         <ExtensionHeader />
-      <SidebarContent className="p-2 space-y-2 overflow-auto">
-        <SidebarNavigation />
-      </SidebarContent>
-      <SidebarFooter className="p-2 border-t">
-        <p className="text-xs text-muted-foreground text-center">
-          Extension Manager
-        </p>
-      </SidebarFooter>
+        <SidebarContent className="p-2 space-y-2 overflow-auto scroll-smooth">
+          <SidebarNavigation />
+        </SidebarContent>
+        <SidebarFooter className="p-2 border-t">
+          <p className="text-xs text-muted-foreground text-center">
+            Extension Manager
+          </p>
+        </SidebarFooter>
       </Sidebar>
     </>
   );

--- a/ui_launchers/web_ui/src/styles/globals.css
+++ b/ui_launchers/web_ui/src/styles/globals.css
@@ -114,6 +114,8 @@
     -moz-osx-font-smoothing: grayscale;
     min-height: 100vh;
     position: relative;
+    background-color: hsl(var(--background));
+    color: hsl(var(--foreground));
   }
   
   /* Ensure proper stacking context for modals and overlays */
@@ -175,11 +177,13 @@
     display: grid;
     grid-template-columns: auto 1fr;
     grid-template-rows: auto 1fr;
-    grid-template-areas: 
+    grid-template-areas:
       "header header"
       "sidebar main";
     min-height: 100vh;
     width: 100%;
+    background: hsl(var(--background));
+    color: hsl(var(--foreground));
   }
   
   .app-header {
@@ -199,14 +203,18 @@
     background: hsl(var(--sidebar-background));
     overflow-y: auto;
     max-height: calc(100vh - var(--header-height, 4rem));
+    color: hsl(var(--sidebar-foreground));
+    box-shadow: 1px 0 0 rgb(0 0 0 / 0.02);
   }
-  
+
   .app-main {
     grid-area: main;
     padding: 1.5rem;
     overflow-y: auto;
     max-height: calc(100vh - var(--header-height, 4rem));
     background: hsl(var(--background));
+    color: hsl(var(--foreground));
+    box-shadow: inset 0 1px 0 rgb(0 0 0 / 0.01);
   }
   
   /* Chat Layout Grid */
@@ -441,6 +449,14 @@
     background: hsl(var(--background));
     min-height: calc(100vh - 4rem);
     padding: 1.5rem;
+    color: hsl(var(--foreground));
+  }
+
+  .modern-layout-root {
+    display: flex;
+    flex-direction: column;
+    gap: clamp(1rem, 3vw, 2rem);
+    padding-block: clamp(1rem, 2vw, 2rem);
   }
   
   /* Scroll area styling */
@@ -465,5 +481,15 @@
   
   .scroll-smooth::-webkit-scrollbar-thumb:hover {
     background: hsl(var(--muted-foreground) / 0.5);
+  }
+}
+
+@supports (min-height: 100svh) {
+  body {
+    min-height: 100svh;
+  }
+
+  .app-grid {
+    min-height: 100svh;
   }
 }

--- a/ui_launchers/web_ui/test-reasoning.html
+++ b/ui_launchers/web_ui/test-reasoning.html
@@ -1,62 +1,411 @@
 <!DOCTYPE html>
-<html>
-<head>
-    <title>Test Reasoning System</title>
-</head>
-<body>
-    <h1>Test Reasoning System</h1>
-    <div>
-        <input type="text" id="input" placeholder="Enter your question" style="width: 300px;">
-        <button onclick="testReasoning()">Test Reasoning</button>
-    </div>
-    <div id="result" style="margin-top: 20px; padding: 10px; border: 1px solid #ccc;"></div>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Karen AI – Reasoning API Tester</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+        --page-bg: linear-gradient(180deg, hsl(240 33% 99%) 0%, hsl(240 33% 97%) 100%);
+        --page-bg-dark: linear-gradient(180deg, hsl(220 15% 16%) 0%, hsl(220 16% 12%) 100%);
+        --surface: hsl(0 0% 100%);
+        --surface-dark: hsl(220 16% 20%);
+        --surface-border: hsl(240 7% 86%);
+        --surface-border-dark: hsl(220 14% 28%);
+        --text: hsl(240 10% 16%);
+        --text-muted: hsl(240 5% 40%);
+        --text-dark: hsl(210 20% 96%);
+        --accent: hsl(263 94% 51%);
+        --accent-dark: hsl(263 100% 70%);
+        --success: hsl(142 76% 36%);
+        --warning: hsl(38 92% 50%);
+        --error: hsl(0 84% 60%);
+        --radius: 18px;
+        --shadow: 0 18px 45px -25px rgb(15 23 42 / 0.35);
+        --transition: 180ms cubic-bezier(0.4, 0, 0.2, 1);
+        --gap: clamp(1rem, 2vw, 1.5rem);
+      }
 
-    <script>
-        async function testReasoning() {
-            const input = document.getElementById('input').value;
-            const resultDiv = document.getElementById('result');
-            
-            if (!input) {
-                resultDiv.innerHTML = 'Please enter a question';
-                return;
-            }
-            
-            resultDiv.innerHTML = 'Testing reasoning system...';
-            
-            try {
-                const response = await fetch('/api/karen/api/reasoning/analyze', {
-                    method: 'POST',
-                    headers: {
-                        'Content-Type': 'application/json',
-                    },
-                    body: JSON.stringify({
-                        input: input,
-                        context: {
-                            user_id: 'test',
-                            conversation_id: 'test_' + Date.now()
-                        }
-                    })
-                });
-                
-                if (!response.ok) {
-                    throw new Error(`HTTP ${response.status}: ${response.statusText}`);
-                }
-                
-                const data = await response.json();
-                
-                resultDiv.innerHTML = `
-                    <h3>Reasoning Response:</h3>
-                    <p><strong>Success:</strong> ${data.success}</p>
-                    <p><strong>Method:</strong> ${data.reasoning_method}</p>
-                    <p><strong>Fallback Used:</strong> ${data.fallback_used}</p>
-                    <p><strong>Content:</strong> ${data.response.content}</p>
-                    ${data.errors ? `<p><strong>Errors:</strong> ${JSON.stringify(data.errors)}</p>` : ''}
-                `;
-                
-            } catch (error) {
-                resultDiv.innerHTML = `<p style="color: red;">Error: ${error.message}</p>`;
-            }
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --surface: var(--surface-dark);
+          --surface-border: var(--surface-border-dark);
+          --text: var(--text-dark);
+          --text-muted: hsl(210 20% 78%);
         }
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        color: var(--text);
+        background-color: #f7f7fb;
+        background-image: var(--page-bg);
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        padding: clamp(1.5rem, 4vw, 3rem) clamp(1rem, 4vw, 3rem);
+        transition: background var(--transition), color var(--transition);
+      }
+
+      @media (prefers-color-scheme: dark) {
+        body {
+          background-color: #0f172a;
+          background-image: var(--page-bg-dark);
+        }
+      }
+
+      .page-header {
+        width: min(960px, 100%);
+        text-align: center;
+        margin-bottom: clamp(1.5rem, 4vw, 3rem);
+      }
+
+      .page-header h1 {
+        margin: 0 0 0.5rem;
+        font-size: clamp(2rem, 3vw, 2.75rem);
+        letter-spacing: -0.02em;
+      }
+
+      .page-header p {
+        margin: 0;
+        color: var(--text-muted);
+        font-size: clamp(1rem, 1.5vw, 1.125rem);
+      }
+
+      main {
+        width: min(960px, 100%);
+        display: grid;
+        gap: var(--gap);
+      }
+
+      .panel {
+        background: var(--surface);
+        border: 1px solid var(--surface-border);
+        border-radius: var(--radius);
+        padding: clamp(1.25rem, 2.5vw, 2rem);
+        box-shadow: var(--shadow);
+        transition: border-color var(--transition), box-shadow var(--transition), background var(--transition);
+      }
+
+      .panel:hover {
+        box-shadow: 0 22px 55px -25px rgb(79 70 229 / 0.4);
+      }
+
+      form {
+        display: grid;
+        gap: var(--gap);
+      }
+
+      label {
+        font-weight: 600;
+        font-size: 0.95rem;
+        color: var(--text-muted);
+      }
+
+      .input-row {
+        display: grid;
+        gap: 0.75rem;
+      }
+
+      input[type="text"],
+      textarea {
+        width: 100%;
+        border-radius: calc(var(--radius) / 2);
+        border: 1px solid var(--surface-border);
+        padding: 0.85rem 1rem;
+        font-size: 1rem;
+        color: inherit;
+        background: transparent;
+        transition: border-color var(--transition), box-shadow var(--transition);
+      }
+
+      input[type="text"]:focus,
+      textarea:focus {
+        outline: none;
+        border-color: var(--accent);
+        box-shadow: 0 0 0 4px color-mix(in srgb, var(--accent) 30%, transparent);
+      }
+
+      button[type="submit"] {
+        justify-self: start;
+        border: none;
+        border-radius: 999px;
+        padding: 0.75rem 1.75rem;
+        font-weight: 600;
+        font-size: 1rem;
+        color: white;
+        background: linear-gradient(135deg, var(--accent) 0%, var(--accent-dark) 100%);
+        cursor: pointer;
+        transition: transform var(--transition), box-shadow var(--transition), opacity var(--transition);
+      }
+
+      button[type="submit"]:hover:not(:disabled) {
+        transform: translateY(-2px);
+        box-shadow: 0 18px 35px -20px rgba(79, 70, 229, 0.6);
+      }
+
+      button[type="submit"]:disabled {
+        cursor: not-allowed;
+        opacity: 0.65;
+      }
+
+      .result {
+        min-height: 140px;
+        display: grid;
+        gap: 0.75rem;
+        align-content: start;
+        border-color: var(--surface-border);
+      }
+
+      .result[data-tone="info"] {
+        border-color: var(--surface-border);
+        border-color: color-mix(in srgb, var(--accent) 35%, var(--surface-border));
+      }
+
+      .result[data-tone="success"] {
+        border-color: var(--surface-border);
+        border-color: color-mix(in srgb, var(--success) 50%, var(--surface-border));
+      }
+
+      .result[data-tone="warning"] {
+        border-color: var(--surface-border);
+        border-color: color-mix(in srgb, var(--warning) 50%, var(--surface-border));
+      }
+
+      .result[data-tone="error"] {
+        border-color: var(--surface-border);
+        border-color: color-mix(in srgb, var(--error) 45%, var(--surface-border));
+      }
+
+      .status-pill {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+        padding: 0.35rem 0.85rem;
+        border-radius: 999px;
+        font-size: 0.875rem;
+        font-weight: 600;
+        background: rgba(99, 102, 241, 0.14);
+        background: color-mix(in srgb, var(--accent) 18%, transparent);
+        color: rgb(79, 70, 229);
+        color: color-mix(in srgb, var(--accent) 65%, black);
+      }
+
+      .result[data-tone="success"] .status-pill {
+        background: rgba(34, 197, 94, 0.14);
+        background: color-mix(in srgb, var(--success) 18%, transparent);
+        color: rgb(22, 163, 74);
+        color: color-mix(in srgb, var(--success) 70%, black);
+      }
+
+      .result[data-tone="warning"] .status-pill {
+        background: rgba(245, 158, 11, 0.2);
+        background: color-mix(in srgb, var(--warning) 20%, transparent);
+        color: rgb(217, 119, 6);
+        color: color-mix(in srgb, var(--warning) 65%, black);
+      }
+
+      .result[data-tone="error"] .status-pill {
+        background: rgba(239, 68, 68, 0.18);
+        background: color-mix(in srgb, var(--error) 20%, transparent);
+        color: rgb(185, 28, 28);
+        color: color-mix(in srgb, var(--error) 65%, black);
+      }
+
+      dl {
+        margin: 0;
+        display: grid;
+        gap: 0.5rem;
+      }
+
+      dt {
+        font-weight: 600;
+      }
+
+      dd {
+        margin: 0;
+        color: var(--text-muted);
+        word-break: break-word;
+      }
+
+      pre {
+        margin: 0;
+        padding: 1rem;
+        border-radius: calc(var(--radius) / 2);
+        background: color-mix(in srgb, black 5%, transparent);
+        overflow-x: auto;
+        font-size: 0.95rem;
+      }
+
+      @media (max-width: 640px) {
+        button[type="submit"] {
+          width: 100%;
+          justify-self: stretch;
+        }
+      }
+
+      @media (prefers-reduced-motion: reduce) {
+        *, *::before, *::after {
+          animation-duration: 0.01ms !important;
+          animation-iteration-count: 1 !important;
+          transition-duration: 0.01ms !important;
+          scroll-behavior: auto !important;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <header class="page-header">
+      <h1>Karen AI Reasoning Tester</h1>
+      <p>Send a quick prompt to the reasoning service and inspect the structured response.</p>
+    </header>
+    <main aria-labelledby="tester-heading">
+      <section class="panel" aria-describedby="tester-instructions">
+        <h2 id="tester-heading" style="margin-top: 0">Reasoning API request</h2>
+        <p id="tester-instructions" style="margin-top: 0; color: var(--text-muted);">
+          Enter a question below. The demo will send a POST request to
+          <code>/api/karen/api/reasoning/analyze</code> with temporary identifiers.
+        </p>
+        <form id="reasoning-form" novalidate>
+          <label for="question">Question</label>
+          <div class="input-row">
+            <input
+              id="question"
+              name="question"
+              type="text"
+              placeholder="e.g. Summarise the latest project updates"
+              autocomplete="off"
+              required
+              aria-required="true"
+            />
+          </div>
+          <button type="submit">Test reasoning</button>
+        </form>
+      </section>
+      <section
+        id="result"
+        class="panel result"
+        data-tone="info"
+        aria-live="polite"
+        aria-busy="false"
+      >
+        <p class="status-pill">Waiting for a request…</p>
+        <p style="margin: 0; color: var(--text-muted);">
+          Results from the API will appear here, including diagnostic metadata and any errors.
+        </p>
+      </section>
+    </main>
+    <script>
+      const form = document.getElementById("reasoning-form");
+      const questionInput = document.getElementById("question");
+      const resultPanel = document.getElementById("result");
+      const submitButton = form.querySelector('button[type="submit"]');
+
+      const escapeHtml = (value) =>
+        value
+          .replace(/&/g, "&amp;")
+          .replace(/</g, "&lt;")
+          .replace(/>/g, "&gt;")
+          .replace(/"/g, "&quot;")
+          .replace(/'/g, "&#39;");
+
+      const setResult = (content, tone = "info", busy = false) => {
+        resultPanel.setAttribute("data-tone", tone);
+        resultPanel.setAttribute("aria-busy", String(busy));
+        resultPanel.innerHTML = content;
+      };
+
+      form.addEventListener("submit", async (event) => {
+        event.preventDefault();
+        const question = questionInput.value.trim();
+
+        if (!question) {
+          setResult(
+            '<p class="status-pill">Please enter a question</p><p style="margin:0; color: var(--text-muted);">A short question or instruction helps Karen craft a response.</p>',
+            "warning",
+            false
+          );
+          questionInput.focus();
+          return;
+        }
+
+        setResult('<p class="status-pill">Testing reasoning system…</p>', "info", true);
+        submitButton.disabled = true;
+
+        try {
+          const response = await fetch("/api/karen/api/reasoning/analyze", {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+              input: question,
+              context: {
+                user_id: "test",
+                conversation_id: `test_${Date.now()}`,
+              },
+            }),
+          });
+
+          if (!response.ok) {
+            throw new Error(`Request failed with status ${response.status}`);
+          }
+
+          const data = await response.json();
+
+          const responseHtml = `
+            <div class="status-pill">Reasoning response received</div>
+            <dl>
+              <div>
+                <dt>Success</dt>
+                <dd>${escapeHtml(String(data.success))}</dd>
+              </div>
+              <div>
+                <dt>Method</dt>
+                <dd>${escapeHtml(data.reasoning_method ?? "Unknown")}</dd>
+              </div>
+              <div>
+                <dt>Fallback used</dt>
+                <dd>${escapeHtml(String(data.fallback_used ?? false))}</dd>
+              </div>
+              ${
+                data?.response?.content
+                  ? `<div><dt style="font-weight:600; margin-top:0.75rem;">Content</dt><dd>${escapeHtml(
+                      data.response.content
+                    )}</dd></div>`
+                  : ""
+              }
+              ${
+                data?.errors?.length
+                  ? `<div><dt style="font-weight:600; margin-top:0.75rem;">Errors</dt><dd><pre>${escapeHtml(
+                      JSON.stringify(data.errors, null, 2)
+                    )}</pre></dd></div>`
+                  : ""
+              }
+            </dl>
+          `;
+
+          setResult(responseHtml, data.success ? "success" : "warning", false);
+        } catch (error) {
+          setResult(
+            `<div class="status-pill">Request error</div><p style="margin:0; color: var(--text-muted);">${escapeHtml(
+              error instanceof Error ? error.message : String(error)
+            )}</p>`,
+            "error",
+            false
+          );
+        } finally {
+          submitButton.disabled = false;
+          resultPanel.setAttribute("aria-busy", "false");
+        }
+      });
     </script>
-</body>
+  </body>
 </html>


### PR DESCRIPTION
## Summary
- align the global skip link with the main content region and make the primary layout container focusable for keyboard users
- extend global styling so the grid, sidebar, and content panes share consistent foreground/background colors and spacing, and apply the sidebar gradient to the extensions panel
- overhaul the standalone reasoning test page with modern theming, accessibility-friendly markup, and resilient status handling

## Testing
- npm run lint *(fails: command prompts for interactive ESLint configuration and cannot complete in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6954f5f0083248ee2ab9f2d25a8a7