### PR TITLE
Improve web UI layout backgrounds and navigation semantics

### DIFF
--- a/ui_launchers/web_ui/src/app/chat/page.tsx
+++ b/ui_launchers/web_ui/src/app/chat/page.tsx
@@ -59,7 +59,7 @@ function ChatView() {
   return (
     <SidebarProvider>
       <div className="chat-grid">
-        <header className="chat-header header-enhanced">
+        <header className="chat-header header-enhanced" role="banner">
           <div className="container-fluid flex-between">
             <div className="flex-start space-x-3">
               <AppSidebarTrigger className="mr-1 md:mr-2 smooth-transition interactive" />
@@ -91,59 +91,72 @@ function ChatView() {
           {webUIConfig.enableExtensions ? (
             <ExtensionSidebar />
           ) : (
-            <Sidebar variant="sidebar" collapsible="icon" className="border-r z-20 sidebar-enhanced">
+            <Sidebar
+              variant="sidebar"
+              collapsible="icon"
+              className="border-r z-20 sidebar-enhanced"
+              aria-label="Main navigation"
+            >
               <AppSidebarHeader className="p-4">
-                <h2 className="text-lg font-semibold tracking-tight">Navigation</h2>
+                <h2 id="chat-primary-nav-title" className="text-lg font-semibold tracking-tight">
+                  Navigation
+                </h2>
               </AppSidebarHeader>
               <Separator className="my-1" />
               <AppSidebarContent className="p-2 scroll-smooth">
-                <SidebarMenu>
-                  <SidebarMenuItem>
-                    <SidebarMenuButton asChild isActive={pathname === "/chat"} className="w-full">
-                      <Link href="/chat">
-                        <MessageSquare />
-                        Chat
-                      </Link>
-                    </SidebarMenuButton>
-                  </SidebarMenuItem>
-                  <SidebarMenuItem>
-                    <SidebarMenuButton asChild className="w-full">
-                      <Link href="/?view=dashboard">
-                        <LayoutGrid />
-                        Dashboard
-                      </Link>
-                    </SidebarMenuButton>
-                  </SidebarMenuItem>
-                  <SidebarMenuItem>
-                    <SidebarMenuButton asChild className="w-full">
-                      <Link href="/?view=settings">
-                        <SettingsIconLucide />
-                        Settings
-                      </Link>
-                    </SidebarMenuButton>
-                  </SidebarMenuItem>
-                  <SidebarMenuItem>
-                    <SidebarMenuButton asChild className="w-full">
-                      <Link href="/?view=commsCenter">
-                        <Bell />
-                        Comms Center
-                      </Link>
-                    </SidebarMenuButton>
-                  </SidebarMenuItem>
-                </SidebarMenu>
-                <Separator className="my-2" />
-                <SidebarGroup>
-                  <SidebarGroupLabel className="text-sm">Plugins</SidebarGroupLabel>
+                <nav aria-labelledby="chat-primary-nav-title">
                   <SidebarMenu>
                     <SidebarMenuItem>
+                      <SidebarMenuButton asChild isActive={pathname === "/chat"} className="w-full">
+                        <Link href="/chat">
+                          <MessageSquare />
+                          Chat
+                        </Link>
+                      </SidebarMenuButton>
+                    </SidebarMenuItem>
+                    <SidebarMenuItem>
                       <SidebarMenuButton asChild className="w-full">
-                        <Link href="/?view=pluginOverview">
-                          <PlugZap />
-                          Plugin Overview
+                        <Link href="/?view=dashboard">
+                          <LayoutGrid />
+                          Dashboard
+                        </Link>
+                      </SidebarMenuButton>
+                    </SidebarMenuItem>
+                    <SidebarMenuItem>
+                      <SidebarMenuButton asChild className="w-full">
+                        <Link href="/?view=settings">
+                          <SettingsIconLucide />
+                          Settings
+                        </Link>
+                      </SidebarMenuButton>
+                    </SidebarMenuItem>
+                    <SidebarMenuItem>
+                      <SidebarMenuButton asChild className="w-full">
+                        <Link href="/?view=commsCenter">
+                          <Bell />
+                          Comms Center
                         </Link>
                       </SidebarMenuButton>
                     </SidebarMenuItem>
                   </SidebarMenu>
+                </nav>
+                <Separator className="my-2" />
+                <SidebarGroup>
+                  <SidebarGroupLabel asChild className="text-sm font-medium">
+                    <h3 id="chat-plugins-nav-title">Plugins</h3>
+                  </SidebarGroupLabel>
+                  <nav aria-labelledby="chat-plugins-nav-title">
+                    <SidebarMenu>
+                      <SidebarMenuItem>
+                        <SidebarMenuButton asChild className="w-full">
+                          <Link href="/?view=pluginOverview">
+                            <PlugZap />
+                            Plugin Overview
+                          </Link>
+                        </SidebarMenuButton>
+                      </SidebarMenuItem>
+                    </SidebarMenu>
+                  </nav>
                 </SidebarGroup>
               </AppSidebarContent>
               <AppSidebarFooter className="p-2 border-t">

--- a/ui_launchers/web_ui/src/app/page.tsx
+++ b/ui_launchers/web_ui/src/app/page.tsx
@@ -89,7 +89,7 @@ function AuthenticatedHomePage() {
   return (
     <SidebarProvider>
       <div className="app-grid">
-        <header className="app-header header-enhanced">
+        <header className="app-header header-enhanced" role="banner">
           <div className="container-fluid flex-between py-3 md:py-4">
             <div className="flex-start space-x-3">
               <AppSidebarTrigger className="mr-1 md:mr-2 smooth-transition interactive">
@@ -125,82 +125,131 @@ function AuthenticatedHomePage() {
           {webUIConfig.enableExtensions ? (
             <ExtensionSidebar />
           ) : (
-            <Sidebar variant="sidebar" collapsible="icon" className="border-r z-20 sidebar-enhanced">
+            <Sidebar
+              variant="sidebar"
+              collapsible="icon"
+              className="border-r z-20 sidebar-enhanced"
+              aria-label="Main navigation"
+            >
               <AppSidebarHeader className="p-4">
-                <h2 className="text-lg font-semibold tracking-tight">Navigation</h2>
+                <h2 id="home-primary-nav-title" className="text-lg font-semibold tracking-tight">
+                  Navigation
+                </h2>
               </AppSidebarHeader>
               <Separator className="my-1" />
               <AppSidebarContent className="p-2 scroll-smooth">
-                <SidebarMenu>
-                  <SidebarMenuItem>
-                    <SidebarMenuButton asChild className="w-full" isActive={pathname === '/chat'}>
-                      <Link href="/chat">
-                        <MessageSquare />
-                        Chat
-                      </Link>
-                    </SidebarMenuButton>
-                  </SidebarMenuItem>
-                  <SidebarMenuItem>
-                    <SidebarMenuButton onClick={() => navigate('dashboard')} isActive={activeMainView === 'dashboard'} className="w-full">
-                      <LayoutGrid />
-                      Dashboard
-                    </SidebarMenuButton>
-                  </SidebarMenuItem>
-                  <SidebarMenuItem>
-                    <SidebarMenuButton onClick={() => navigate('settings')} isActive={activeMainView === 'settings'} className="w-full">
-                      <SettingsIconLucide />
-                      Settings
-                    </SidebarMenuButton>
-                  </SidebarMenuItem>
-                  <SidebarMenuItem>
-                    <SidebarMenuButton onClick={() => navigate('commsCenter')} isActive={activeMainView === 'commsCenter'} className="w-full">
-                      <Bell />
-                      Comms Center
-                    </SidebarMenuButton>
-                  </SidebarMenuItem>
-                </SidebarMenu>
-
-                <Separator className="my-2" />
-                <SidebarGroup>
-                  <SidebarGroupLabel className="text-sm">Plugins</SidebarGroupLabel>
+                <nav aria-labelledby="home-primary-nav-title">
                   <SidebarMenu>
                     <SidebarMenuItem>
-                      <SidebarMenuButton onClick={() => navigate('pluginOverview')} isActive={activeMainView === 'pluginOverview'} className="w-full">
-                        <PlugZap />
-                        Plugin Overview
+                      <SidebarMenuButton asChild className="w-full" isActive={pathname === '/chat'}>
+                        <Link href="/chat">
+                          <MessageSquare />
+                          Chat
+                        </Link>
                       </SidebarMenuButton>
                     </SidebarMenuItem>
                     <SidebarMenuItem>
-                      <SidebarMenuButton onClick={() => navigate('pluginDatabaseConnector')} isActive={activeMainView === 'pluginDatabaseConnector'} className="w-full">
-                        <Database />
-                        Database Connector
+                      <SidebarMenuButton
+                        onClick={() => navigate('dashboard')}
+                        isActive={activeMainView === 'dashboard'}
+                        className="w-full"
+                      >
+                        <LayoutGrid />
+                        Dashboard
                       </SidebarMenuButton>
                     </SidebarMenuItem>
                     <SidebarMenuItem>
-                      <SidebarMenuButton onClick={() => navigate('pluginFacebook')} isActive={activeMainView === 'pluginFacebook'} className="w-full">
-                        <Facebook />
-                        Facebook Plugin
+                      <SidebarMenuButton
+                        onClick={() => navigate('settings')}
+                        isActive={activeMainView === 'settings'}
+                        className="w-full"
+                      >
+                        <SettingsIconLucide />
+                        Settings
                       </SidebarMenuButton>
                     </SidebarMenuItem>
                     <SidebarMenuItem>
-                      <SidebarMenuButton onClick={() => navigate('pluginGmail')} isActive={activeMainView === 'pluginGmail'} className="w-full">
-                        <Mail />
-                        Gmail Plugin
-                      </SidebarMenuButton>
-                    </SidebarMenuItem>
-                    <SidebarMenuItem>
-                      <SidebarMenuButton onClick={() => navigate('pluginDateTime')} isActive={activeMainView === 'pluginDateTime'} className="w-full">
-                        <CalendarDays />
-                        Date/Time Plugin
-                      </SidebarMenuButton>
-                    </SidebarMenuItem>
-                    <SidebarMenuItem>
-                      <SidebarMenuButton onClick={() => navigate('pluginWeather')} isActive={activeMainView === 'pluginWeather'} className="w-full">
-                        <CloudSun />
-                        Weather Service
+                      <SidebarMenuButton
+                        onClick={() => navigate('commsCenter')}
+                        isActive={activeMainView === 'commsCenter'}
+                        className="w-full"
+                      >
+                        <Bell />
+                        Comms Center
                       </SidebarMenuButton>
                     </SidebarMenuItem>
                   </SidebarMenu>
+                </nav>
+
+                <Separator className="my-2" />
+                <SidebarGroup>
+                  <SidebarGroupLabel asChild className="text-sm font-medium">
+                    <h3 id="home-plugins-nav-title">Plugins</h3>
+                  </SidebarGroupLabel>
+                  <nav aria-labelledby="home-plugins-nav-title">
+                    <SidebarMenu>
+                      <SidebarMenuItem>
+                        <SidebarMenuButton
+                          onClick={() => navigate('pluginOverview')}
+                          isActive={activeMainView === 'pluginOverview'}
+                          className="w-full"
+                        >
+                          <PlugZap />
+                          Plugin Overview
+                        </SidebarMenuButton>
+                      </SidebarMenuItem>
+                      <SidebarMenuItem>
+                        <SidebarMenuButton
+                          onClick={() => navigate('pluginDatabaseConnector')}
+                          isActive={activeMainView === 'pluginDatabaseConnector'}
+                          className="w-full"
+                        >
+                          <Database />
+                          Database Connector
+                        </SidebarMenuButton>
+                      </SidebarMenuItem>
+                      <SidebarMenuItem>
+                        <SidebarMenuButton
+                          onClick={() => navigate('pluginFacebook')}
+                          isActive={activeMainView === 'pluginFacebook'}
+                          className="w-full"
+                        >
+                          <Facebook />
+                          Facebook Plugin
+                        </SidebarMenuButton>
+                      </SidebarMenuItem>
+                      <SidebarMenuItem>
+                        <SidebarMenuButton
+                          onClick={() => navigate('pluginGmail')}
+                          isActive={activeMainView === 'pluginGmail'}
+                          className="w-full"
+                        >
+                          <Mail />
+                          Gmail Plugin
+                        </SidebarMenuButton>
+                      </SidebarMenuItem>
+                      <SidebarMenuItem>
+                        <SidebarMenuButton
+                          onClick={() => navigate('pluginDateTime')}
+                          isActive={activeMainView === 'pluginDateTime'}
+                          className="w-full"
+                        >
+                          <CalendarDays />
+                          Date/Time Plugin
+                        </SidebarMenuButton>
+                      </SidebarMenuItem>
+                      <SidebarMenuItem>
+                        <SidebarMenuButton
+                          onClick={() => navigate('pluginWeather')}
+                          isActive={activeMainView === 'pluginWeather'}
+                          className="w-full"
+                        >
+                          <CloudSun />
+                          Weather Service
+                        </SidebarMenuButton>
+                      </SidebarMenuItem>
+                    </SidebarMenu>
+                  </nav>
                 </SidebarGroup>
               </AppSidebarContent>
               <AppSidebarFooter className="p-2 border-t">

--- a/ui_launchers/web_ui/src/components/ui/sidebar.tsx
+++ b/ui_launchers/web_ui/src/components/ui/sidebar.tsx
@@ -267,8 +267,9 @@ const SidebarTrigger = React.forwardRef<
   HTMLButtonElement,
   React.ComponentProps<typeof Button> & { asChild?: boolean; children?: React.ReactNode }
 >(({ className, onClick, asChild = false, children, ...props }, ref) => {
-  const { toggleSidebar } = useSidebar();
+  const { toggleSidebar, isMobile, open, openMobile } = useSidebar();
   const Comp = asChild ? Slot : Button;
+  const expanded = isMobile ? openMobile : open;
 
   return (
     <Comp
@@ -276,14 +277,16 @@ const SidebarTrigger = React.forwardRef<
       data-sidebar="trigger"
       variant="ghost"
       size="icon"
+      aria-expanded={expanded}
       onClick={(event: React.MouseEvent<HTMLButtonElement>) => {
         if (onClick) {
-          onClick(event as any); 
+          onClick(event as any);
         }
         toggleSidebar();
       }}
+      type={asChild ? undefined : "button"}
       {...props}
-      className={cn(className)} 
+      className={cn(className)}
     >
       {asChild ? children : (
         <>
@@ -503,7 +506,6 @@ const SidebarMenu = React.forwardRef<
   <ul
     ref={ref}
     data-sidebar="menu"
-    role="menu"
     className={cn("flex w-full min-w-0 flex-col gap-1", className)}
     {...props}
   />
@@ -567,6 +569,7 @@ const SidebarMenuButton = React.forwardRef<
   ) => {
     const Comp = asChild ? Slot : "button"
     const { isMobile, state } = useSidebar()
+    const ariaCurrent = isActive ? "page" : undefined
 
     const button = (
       <Comp
@@ -574,13 +577,8 @@ const SidebarMenuButton = React.forwardRef<
         data-sidebar="menu-button"
         data-size={size}
         data-active={isActive}
-        role="menuitem"
-        onKeyDown={(e: React.KeyboardEvent<HTMLButtonElement>) => {
-          if (e.key === "Enter" || e.key === " ") {
-            e.preventDefault();
-            (props.onClick as any)?.(e as any);
-          }
-        }}
+        aria-current={ariaCurrent}
+        type={asChild ? undefined : "button"}
         className={cn(sidebarMenuButtonVariants({ variant, size }), className)}
         {...props}
       />
@@ -731,6 +729,7 @@ const SidebarMenuSubButton = React.forwardRef<
   }
 >(({ asChild = false, size = "md", isActive, className, ...props }, ref) => {
   const Comp = asChild ? Slot : "a"
+  const ariaCurrent = isActive ? "page" : undefined
 
   return (
     <Comp
@@ -738,14 +737,8 @@ const SidebarMenuSubButton = React.forwardRef<
       data-sidebar="menu-sub-button"
       data-size={size}
       data-active={isActive}
-      role="menuitem"
+      aria-current={ariaCurrent}
       tabIndex={0}
-      onKeyDown={(e: React.KeyboardEvent<HTMLAnchorElement>) => {
-        if (e.key === "Enter" || e.key === " ") {
-          e.preventDefault();
-          (props.onClick as any)?.(e as any);
-        }
-      }}
       className={cn(
         "flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 text-sidebar-foreground outline-none ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0 [&>svg]:text-sidebar-accent-foreground",
         "data-[active=true]:bg-sidebar-accent data-[active=true]:text-sidebar-accent-foreground",

--- a/ui_launchers/web_ui/src/styles/globals.css
+++ b/ui_launchers/web_ui/src/styles/globals.css
@@ -9,6 +9,7 @@
   :root {
     /* Advertise dual color schemes to the UA */
     color-scheme: light dark;
+    --header-height: 4rem;
     --background: 0 0% 100%;
     --foreground: 240 10% 3.9%;
     --card: 0 0% 100%;
@@ -94,28 +95,46 @@
   }
 }
 
+@media (min-width: 768px) {
+  @layer base {
+    :root {
+      --header-height: 4.5rem;
+    }
+  }
+}
+
 @layer base {
   * {
     @apply border-border;
     box-sizing: border-box;
   }
-  
+
   html {
-    -webkit-text-size-adjust: 100%; 
+    -webkit-text-size-adjust: 100%;
     text-size-adjust: 100%;
     scroll-behavior: smooth;
+    background-color: #f8f9fb;
+    color: #0f172a;
   }
-  
+
   body {
+    background-color: #f8f9fb;
+    color: #0f172a;
     @apply bg-background text-foreground;
     line-height: 1.6;
     text-rendering: optimizeLegibility;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
     min-height: 100vh;
+    min-height: 100dvh;
     position: relative;
   }
-  
+
+  .dark body {
+    background-color: #111827;
+    color: #f8fafc;
+  }
+
   /* Ensure proper stacking context for modals and overlays */
   #__next, [data-reactroot] {
     isolation: isolate;
@@ -175,13 +194,17 @@
     display: grid;
     grid-template-columns: auto 1fr;
     grid-template-rows: auto 1fr;
-    grid-template-areas: 
+    grid-template-areas:
       "header header"
       "sidebar main";
     min-height: 100vh;
+    min-height: 100dvh;
     width: 100%;
+    background-color: #f8f9fb;
+    background-color: hsl(var(--background));
+    color: hsl(var(--foreground));
   }
-  
+
   .app-header {
     grid-area: header;
     position: sticky;
@@ -191,57 +214,73 @@
     -webkit-backdrop-filter: blur(8px);
     border-bottom: 1px solid hsl(var(--border));
     background: hsl(var(--background) / 0.9);
+    min-height: var(--header-height);
+    display: flex;
+    align-items: center;
   }
-  
+
   .app-sidebar {
     grid-area: sidebar;
     border-right: 1px solid hsl(var(--border));
+    background-color: #eef2f6;
     background: hsl(var(--sidebar-background));
     overflow-y: auto;
-    max-height: calc(100vh - var(--header-height, 4rem));
+    max-height: calc(100vh - var(--header-height));
+    max-height: calc(100dvh - var(--header-height));
   }
-  
+
   .app-main {
     grid-area: main;
     padding: 1.5rem;
     overflow-y: auto;
-    max-height: calc(100vh - var(--header-height, 4rem));
+    max-height: calc(100vh - var(--header-height));
+    max-height: calc(100dvh - var(--header-height));
+    background-color: #f8f9fb;
     background: hsl(var(--background));
   }
-  
+
   /* Chat Layout Grid */
   .chat-grid {
     display: grid;
     grid-template-rows: auto 1fr auto;
     height: 100vh;
+    min-height: 100dvh;
     width: 100%;
+    background-color: #f8f9fb;
     background: hsl(var(--background));
   }
-  
+
   .chat-header {
     padding: 1rem 1.5rem;
     border-bottom: 1px solid hsl(var(--border));
+    background-color: #f8f9fb;
     background: hsl(var(--background) / 0.95);
     backdrop-filter: blur(8px);
     -webkit-backdrop-filter: blur(8px);
+    min-height: var(--header-height);
+    display: flex;
+    align-items: center;
   }
-  
+
   .chat-messages {
     overflow-y: auto;
     padding: 1rem;
     flex: 1;
+    background-color: #f8f9fb;
     background: hsl(var(--background));
   }
-  
+
   .chat-input {
     padding: 1rem 1.5rem;
     border-top: 1px solid hsl(var(--border));
+    background-color: #f8f9fb;
     background: hsl(var(--background));
   }
 
   .chat-surface {
     gap: clamp(1rem, 2vw, 1.5rem);
     padding: clamp(1rem, 2vw, 1.5rem);
+    background-color: #f8f9fb;
     background: linear-gradient(
       180deg,
       hsl(var(--background)) 0%,
@@ -251,6 +290,7 @@
   }
 
   .chat-panel {
+    background-color: #ffffff;
     background: hsl(var(--card));
     border: 1px solid hsl(var(--border));
     border-radius: calc(var(--radius) + 2px);
@@ -284,6 +324,7 @@
   }
   
   .dashboard-card {
+    background-color: #ffffff;
     background: hsl(var(--card));
     border: 1px solid hsl(var(--border));
     border-radius: calc(var(--radius) - 2px); /* Even simpler radius */
@@ -322,6 +363,7 @@
   
   /* Modern Card Component */
   .modern-card {
+    background-color: #ffffff;
     background: hsl(var(--card));
     border: 1px solid hsl(var(--border));
     border-radius: calc(var(--radius) - 2px); /* Ultra-clean radius */
@@ -336,6 +378,7 @@
   }
 
   .modern-card-elevated {
+    background-color: #ffffff;
     background: hsl(var(--card));
     border: 1px solid hsl(var(--border) / 0.7);
     box-shadow:
@@ -344,11 +387,13 @@
   }
 
   .modern-card-outlined {
+    background-color: #f8f9fb;
     background: hsl(var(--background));
     border: 1px dashed hsl(var(--border));
   }
 
   .modern-card-glass {
+    background-color: rgba(248, 249, 251, 0.82);
     background: hsl(var(--background) / 0.82);
     border: 1px solid hsl(var(--border) / 0.6);
     backdrop-filter: blur(18px);
@@ -404,6 +449,7 @@
     flex-direction: column;
     gap: clamp(1.5rem, 3vw, 3rem);
     padding-block: clamp(1.5rem, 4vw, 3.5rem);
+    background-color: #f8f9fb;
   }
 
   .modern-layout-root::before,
@@ -504,6 +550,7 @@
   
   /* Sidebar enhancements */
   .sidebar-enhanced {
+    background-color: #eef2f6;
     background: linear-gradient(
       180deg,
       hsl(var(--sidebar-background)) 0%,
@@ -511,9 +558,10 @@
     );
     border-right: 1px solid hsl(var(--sidebar-border));
   }
-  
+
   /* Header enhancements */
   .header-enhanced {
+    background-color: #f8f9fb;
     background: linear-gradient(
       90deg,
       hsl(var(--background) / 0.95) 0%,
@@ -525,8 +573,10 @@
   
   /* Content area improvements */
   .content-area {
+    background-color: #f8f9fb;
     background: hsl(var(--background));
-    min-height: calc(100vh - 4rem);
+    min-height: calc(100vh - var(--header-height));
+    min-height: calc(100dvh - var(--header-height));
     padding: 1.5rem;
   }
   


### PR DESCRIPTION
## Summary
- add fallback colors, header sizing variables, and consistent shell backgrounds for the web UI layout
- wrap primary and plugin sidebar menus in semantic navigation landmarks on the home and chat pages
- enhance the shared sidebar component with accessible states including aria attributes and safe button defaults

## Testing
- `npm run lint` *(fails: command prompts for interactive eslint setup in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d69dd9be288324aab4fddf12db3753