### PR TITLE
Improve NLP service startup for chat responses

### DIFF
--- a/src/ai_karen_engine/services/__init__.py
+++ b/src/ai_karen_engine/services/__init__.py
@@ -56,6 +56,8 @@ __all__ = [
     "SpacyService",
     "DistilBertService",
     "NLPServiceManager",
+    "get_nlp_service_manager",
+    "reset_nlp_service_manager",
     "NLPHealthMonitor",
     "NLPConfig",
     "SpacyConfig",
@@ -162,7 +164,12 @@ from ai_karen_engine.services.spacy_service import SpacyService, ParsedMessage
 from ai_karen_engine.services.distilbert_service import DistilBertService, EmbeddingResult
 from ai_karen_engine.services.nlp_health_monitor import NLPHealthMonitor
 from ai_karen_engine.services.nlp_config import NLPConfig, SpacyConfig, DistilBertConfig
-from ai_karen_engine.services.nlp_service_manager import NLPServiceManager, nlp_service_manager
+from ai_karen_engine.services.nlp_service_manager import (
+    NLPServiceManager,
+    get_nlp_service_manager,
+    reset_nlp_service_manager,
+    nlp_service_manager,
+)
 
 # Model Library service
 from ai_karen_engine.services.model_library_service import (

--- a/src/ai_karen_engine/services/nlp_config.py
+++ b/src/ai_karen_engine/services/nlp_config.py
@@ -28,7 +28,7 @@ class SpacyConfig(BaseModel):
         
         # Set defaults - enable parser for dependency parsing as required by task 3.2
         # Allow toggling auto-download behavior via env var
-        download_missing_env = os.getenv("SPACY_DOWNLOAD_MISSING", "true").lower() in ("1", "true", "yes")
+        download_missing_env = os.getenv("SPACY_DOWNLOAD_MISSING", "false").lower() in ("1", "true", "yes")
 
         defaults = {
             "model_name": model_name,


### PR DESCRIPTION
## Summary
- instantiate the NLP service manager lazily so chat imports no longer trigger heavy startup work
- expose helpers for accessing and resetting the shared NLP manager through the services package
- default spaCy auto-downloads to off so offline deployments fall back immediately

## Testing
- pytest -o addopts= tests/unit/api_routes/test_chat_runtime.py::test_chat_runtime_returns_response -q

------
https://chatgpt.com/codex/tasks/task_e_68d69e96f5188324839856b488c577e5