### PR TITLE
Handle registry provider failures with fallback

### DIFF
--- a/tests/unit/utils/test_llm_utils.py
+++ b/tests/unit/utils/test_llm_utils.py
@@ -2,7 +2,12 @@ import importlib
 import sys
 
 from ai_karen_engine.integrations import llm_utils
-from ai_karen_engine.integrations.llm_utils import LLMUtils, LLMProviderBase
+from ai_karen_engine.integrations.llm_utils import (
+    GenerationFailed,
+    LLMProviderBase,
+    LLMUtils,
+)
+from ai_karen_engine.integrations.providers.fallback_provider import FallbackProvider
 
 
 class _DummyProvider(LLMProviderBase):
@@ -30,5 +35,41 @@ def test_record_llm_metric_without_prometheus(monkeypatch):
     llm_utils.record_llm_metric("test", 0.01, True, "dummy")
     importlib.reload(llm_utils)
 
+
+
+def test_generate_text_skips_failing_registry_providers(monkeypatch):
+    monkeypatch.setenv("AI_KAREN_ENABLE_FULL_REGISTRY", "true")
+
+    fallback = FallbackProvider()
+
+    class FakeRegistry:
+        def get_available_providers(self):
+            return ["broken", "fallback"]
+
+        def auto_select_provider(self, requirements):
+            return "fallback"
+
+        def default_chain(self, healthy_only=False):
+            return ["broken"]
+
+        def list_providers(self):
+            return ["broken", "fallback"]
+
+        def get_provider(self, name, **_kwargs):
+            if name == "broken":
+                raise GenerationFailed("boom")
+            if name == "fallback":
+                return fallback
+            raise GenerationFailed("unknown provider")
+
+    monkeypatch.setattr(
+        "ai_karen_engine.integrations.llm_registry.get_registry",
+        lambda: FakeRegistry(),
+    )
+
+    llm = LLMUtils(default="broken", use_registry=True)
+    response = llm.generate_text("Ensure fallback")
+
+    assert "fallback assistant" in response
 
 


### PR DESCRIPTION
## Summary
- guard `LLMUtils` registry lookups so provider initialization failures fall back gracefully
- add unit coverage to verify prompts still get responses when the primary provider raises an error

## Testing
- pytest -o addopts= tests/unit/utils/test_llm_utils.py


------
https://chatgpt.com/codex/tasks/task_e_68d69e96f5188324839856b488c577e5