### PR TITLE
Fix sanitize content route signature

### DIFF
--- a/src/ai_karen_engine/api_routes/privacy_routes.py
+++ b/src/ai_karen_engine/api_routes/privacy_routes.py
@@ -350,8 +350,8 @@ if FASTAPI_AVAILABLE:
     @router.post("/content/sanitize")
     async def sanitize_content(
         content: str,
-        max_length: int = 100,
         http_request: Request,
+        max_length: int = 100,
         privacy_service: PrivacyComplianceService = Depends(get_privacy_service)
     ):
         """


### PR DESCRIPTION
## Summary
- reorder the sanitize_content endpoint parameters so non-default arguments come first
- ensure the privacy routes module loads without syntax errors when the API routes package is imported

## Testing
- python -m compileall src/ai_karen_engine/api_routes/privacy_routes.py

------
https://chatgpt.com/codex/tasks/task_e_68d69e96f5188324839856b488c577e5