### PR TITLE
Improve startup runtime configuration defaults

### DIFF
--- a/src/ai_karen_engine/server/custom_server.py
+++ b/src/ai_karen_engine/server/custom_server.py
@@ -315,7 +315,9 @@ class ServerConfig:
         port: int = 8000,
         debug: bool = False,
         workers: int = 1,
+        reload: bool = False,
         ssl_context: Optional[ssl.SSLContext] = None,
+        log_level: str = "info",
         max_invalid_requests_per_connection: int = 10,
         enable_protocol_error_handling: bool = True,
         log_invalid_requests: bool = True,
@@ -325,7 +327,9 @@ class ServerConfig:
         self.port = port
         self.debug = debug
         self.workers = workers
+        self.reload = reload
         self.ssl_context = ssl_context
+        self.log_level = log_level.lower()
         self.max_invalid_requests_per_connection = max_invalid_requests_per_connection
         self.enable_protocol_error_handling = enable_protocol_error_handling
         self.log_invalid_requests = log_invalid_requests
@@ -351,8 +355,9 @@ class CustomUvicornServer:
             "app": self.app,
             "host": self.config.host,
             "port": self.config.port,
-            "reload": self.config.debug,
+            "reload": self.config.reload,
             "workers": self.config.workers,
+            "log_level": self.config.log_level,
             "log_config": log_config,
             "access_log": False,  # We handle access logging in middleware
             "timeout_keep_alive": 30,
@@ -511,6 +516,8 @@ def create_custom_server(
     port: int = 8000,
     debug: bool = False,
     ssl_context: Optional[ssl.SSLContext] = None,
+    reload: bool = False,
+    log_level: str = "INFO",
     **kwargs
 ) -> CustomUvicornServer:
     """Factory function to create a custom uvicorn server."""
@@ -518,8 +525,10 @@ def create_custom_server(
         host=host,
         port=port,
         debug=debug,
+        reload=reload,
         ssl_context=ssl_context,
+        log_level=log_level,
         **kwargs
     )
-    
+
     return CustomUvicornServer(app, config)

--- a/tests/unit/core/test_custom_server.py
+++ b/tests/unit/core/test_custom_server.py
@@ -196,12 +196,14 @@ class TestServerConfig:
     def test_default_config(self):
         """Test default server configuration."""
         config = ServerConfig()
-        
+
         assert config.host == "0.0.0.0"
         assert config.port == 8000
         assert config.debug is False
         assert config.workers == 1
+        assert config.reload is False
         assert config.ssl_context is None
+        assert config.log_level == "info"
         assert config.max_invalid_requests_per_connection == 10
         assert config.enable_protocol_error_handling is True
         assert config.log_invalid_requests is True
@@ -215,7 +217,9 @@ class TestServerConfig:
             port=9000,
             debug=True,
             workers=4,
+            reload=True,
             ssl_context=ssl_context,
+            log_level="WARNING",
             max_invalid_requests_per_connection=5,
             enable_protocol_error_handling=False,
             log_invalid_requests=False,
@@ -226,7 +230,9 @@ class TestServerConfig:
         assert config.port == 9000
         assert config.debug is True
         assert config.workers == 4
+        assert config.reload is True
         assert config.ssl_context == ssl_context
+        assert config.log_level == "warning"
         assert config.max_invalid_requests_per_connection == 5
         assert config.enable_protocol_error_handling is False
         assert config.log_invalid_requests is False
@@ -253,10 +259,12 @@ class TestCustomUvicornServer:
             port=9000,
             debug=True,
             workers=2,
+            reload=True,
+            log_level="WARNING",
             custom_param="test"
         )
         server = CustomUvicornServer("test:app", config)
-        
+
         uvicorn_config = server.create_server_config()
         
         assert uvicorn_config["app"] == "test:app"
@@ -264,6 +272,7 @@ class TestCustomUvicornServer:
         assert uvicorn_config["port"] == 9000
         assert uvicorn_config["reload"] is True
         assert uvicorn_config["workers"] == 2
+        assert uvicorn_config["log_level"] == "warning"
         assert uvicorn_config["custom_param"] == "test"
         assert "log_config" in uvicorn_config
         assert uvicorn_config["access_log"] is False
@@ -337,26 +346,32 @@ class TestCreateCustomServer:
         assert server.config.host == "0.0.0.0"
         assert server.config.port == 8000
         assert server.config.debug is False
+        assert server.config.reload is False
+        assert server.config.log_level == "info"
 
     def test_create_custom_server_custom_params(self):
         """Test creating custom server with custom parameters."""
         ssl_context = ssl.create_default_context()
-        
+
         server = create_custom_server(
             "test:app",
             host="127.0.0.1",
             port=9000,
             debug=True,
             ssl_context=ssl_context,
+            reload=True,
+            log_level="DEBUG",
             custom_param="test"
         )
-        
+
         assert isinstance(server, CustomUvicornServer)
         assert server.app == "test:app"
         assert server.config.host == "127.0.0.1"
         assert server.config.port == 9000
         assert server.config.debug is True
+        assert server.config.reload is True
         assert server.config.ssl_context == ssl_context
+        assert server.config.log_level == "debug"
         assert server.config.extra_config["custom_param"] == "test"
 
 


### PR DESCRIPTION
## Summary
- configure logging at startup using settings-driven defaults before parsing CLI options
- add environment-aware CLI parsing and validation for reload, workers, and log level before booting the server
- propagate reload/log-level options through the custom server factory and extend tests to cover the new configuration fields

## Testing
- pytest --override-ini addopts="" tests/unit/core/test_custom_server.py

------
https://chatgpt.com/codex/tasks/task_e_68d6a50c1548832496437f87489c9688