### PR TITLE
Align conversation APIs with authenticated sessions

### DIFF
--- a/ui_launchers/web_ui/src/app/api/chat/runtime/route.ts
+++ b/ui_launchers/web_ui/src/app/api/chat/runtime/route.ts
@@ -1,13 +1,16 @@
 import { NextRequest, NextResponse } from 'next/server';
 
 const BACKEND_URL = process.env.KAREN_BACKEND_URL || 'http://ai-karen-api:8000';
+const isVerboseLogging = process.env.NODE_ENV !== 'production';
 
 export async function POST(request: NextRequest) {
-  console.log('🔍 ChatRuntime API: Request received', {
-    url: request.url,
-    method: request.method,
-    headers: Object.fromEntries(request.headers.entries())
-  });
+  if (isVerboseLogging) {
+    console.log('🔍 ChatRuntime API: Request received', {
+      url: request.url,
+      method: request.method,
+      headers: Object.fromEntries(request.headers.entries())
+    });
+  }
 
   try {
     // Get authorization header from the request
@@ -17,22 +20,26 @@ export async function POST(request: NextRequest) {
     // Parse the request body for chat data
     const body = await request.json();
 
-    console.log('🔍 ChatRuntime API: Request body parsed', {
-      bodyKeys: Object.keys(body),
-      model: body.model,
-      messageCount: body.messages ? body.messages.length : 0,
-      hasStream: body.stream !== undefined,
-      bodyPreview: JSON.stringify(body).substring(0, 500) + (JSON.stringify(body).length > 500 ? '...' : '')
-    });
+    if (isVerboseLogging) {
+      console.log('🔍 ChatRuntime API: Request body parsed', {
+        bodyKeys: Object.keys(body),
+        model: body.model,
+        messageCount: body.messages ? body.messages.length : 0,
+        hasStream: body.stream !== undefined,
+        bodyPreview: JSON.stringify(body).substring(0, 500) + (JSON.stringify(body).length > 500 ? '...' : '')
+      });
+    }
 
     // Forward the request to the backend chat runtime endpoint
     const base = BACKEND_URL.replace(/\/+$/, '');
     const backendUrl = `${base}/api/chat/runtime`;
 
-    console.log('🔍 ChatRuntime API: Backend URL constructed', {
-      backendUrl,
-      baseUrl: base
-    });
+    if (isVerboseLogging) {
+      console.log('🔍 ChatRuntime API: Backend URL constructed', {
+        backendUrl,
+        baseUrl: base
+      });
+    }
 
     const headers: HeadersInit = {
       'Content-Type': 'application/json',
@@ -41,28 +48,34 @@ export async function POST(request: NextRequest) {
     // Forward auth headers if present
     if (authorization) {
       headers['Authorization'] = authorization;
-      console.log('🔍 ChatRuntime API: Authorization header found', {
-        hasAuth: true,
-        authPrefix: authorization.substring(0, 20) + '...'
-      });
-    } else {
+      if (isVerboseLogging) {
+        console.log('🔍 ChatRuntime API: Authorization header found', {
+          hasAuth: true,
+          authPrefix: authorization.substring(0, 20) + '...'
+        });
+      }
+    } else if (isVerboseLogging) {
       console.log('🔍 ChatRuntime API: No authorization header');
     }
     if (cookie) {
       headers['Cookie'] = cookie;
-      console.log('🔍 ChatRuntime API: Cookie header found', {
-        hasCookie: true,
-        cookiePrefix: cookie.substring(0, 50) + (cookie.length > 50 ? '...' : '')
-      });
-    } else {
+      if (isVerboseLogging) {
+        console.log('🔍 ChatRuntime API: Cookie header found', {
+          hasCookie: true,
+          cookiePrefix: cookie.substring(0, 50) + (cookie.length > 50 ? '...' : '')
+        });
+      }
+    } else if (isVerboseLogging) {
       console.log('🔍 ChatRuntime API: No cookie header');
     }
 
-    console.log('🔍 ChatRuntime API: Attempting backend fetch', {
-      backendUrl,
-      timeout: 60000,
-      headers: Object.keys(headers)
-    });
+    if (isVerboseLogging) {
+      console.log('🔍 ChatRuntime API: Attempting backend fetch', {
+        backendUrl,
+        timeout: 60000,
+        headers: Object.keys(headers)
+      });
+    }
 
     const response = await fetch(backendUrl, {
       method: 'POST',
@@ -71,24 +84,28 @@ export async function POST(request: NextRequest) {
       signal: AbortSignal.timeout(60000), // 60 second timeout for chat processing
     });
 
-    console.log('🔍 ChatRuntime API: Backend response received', {
-      status: response.status,
-      statusText: response.statusText,
-      headers: Object.fromEntries(response.headers.entries()),
-      ok: response.ok,
-      url: response.url
-    });
+    if (isVerboseLogging) {
+      console.log('🔍 ChatRuntime API: Backend response received', {
+        status: response.status,
+        statusText: response.statusText,
+        headers: Object.fromEntries(response.headers.entries()),
+        ok: response.ok,
+        url: response.url
+      });
+    }
 
     const data = await response.json();
 
-    console.log('🔍 ChatRuntime API: Backend response data', {
-      dataKeys: Object.keys(data),
-      hasContent: !!data.content,
-      contentLength: data.content ? data.content.length : 0,
-      hasError: !!data.error,
-      error: data.error,
-      dataPreview: JSON.stringify(data).substring(0, 500) + (JSON.stringify(data).length > 500 ? '...' : '')
-    });
+    if (isVerboseLogging) {
+      console.log('🔍 ChatRuntime API: Backend response data', {
+        dataKeys: Object.keys(data),
+        hasContent: !!data.content,
+        contentLength: data.content ? data.content.length : 0,
+        hasError: !!data.error,
+        error: data.error,
+        dataPreview: JSON.stringify(data).substring(0, 500) + (JSON.stringify(data).length > 500 ? '...' : '')
+      });
+    }
 
     // Return the backend response with appropriate status
     return NextResponse.json(data, {
@@ -110,7 +127,9 @@ export async function POST(request: NextRequest) {
       details: error instanceof Error ? error.message : 'Unknown error'
     };
 
-    console.log('🔍 ChatRuntime API: Returning error response', errorResponse);
+    if (isVerboseLogging) {
+      console.log('🔍 ChatRuntime API: Returning error response', errorResponse);
+    }
     return NextResponse.json(errorResponse, { status: 503 });
   }
 }


### PR DESCRIPTION
## Summary
- normalize conversation persistence to accept non-UUID user identifiers and guard access by authenticated owner
- expose a session-based conversation lookup endpoint and make list/create routes use the current user context
- update the web UI chat client and runtime proxy for production defaults, including quieter logging in production

## Testing
- `pytest -vv` *(fails: ModuleNotFoundError: No module named 'ai_karen_engine.api_routes.auth_session_routes')*

------
https://chatgpt.com/codex/tasks/task_e_68d7358385c48324b77f0c36f8605870