### PR TITLE
Harden chat routes for production

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -50,6 +50,7 @@ def create_app() -> FastAPI:
     
     # Load configuration (environment loading is handled in config module)
     settings = Settings()
+    environment = settings.environment.lower()
     
     # Configure logging
     configure_logging()
@@ -95,10 +96,17 @@ def create_app() -> FastAPI:
     # Register endpoint groups
     register_admin_endpoints(app, settings)
     register_health_endpoints(app)
-    register_debug_endpoints(app, settings)
-    
-    # Setup developer API
-    setup_developer_api(app)
+
+    if settings.debug and environment != "production":
+        register_debug_endpoints(app, settings)
+    else:
+        logger.info("Debug endpoints disabled for non-debug or production environments")
+
+    # Setup developer API (non-production only)
+    if environment != "production":
+        setup_developer_api(app)
+    else:
+        logger.info("Developer API disabled in production environment")
     
     # Add compatibility aliases for copilot
     try:

--- a/server/config.py
+++ b/server/config.py
@@ -76,7 +76,7 @@ class Settings(BaseSettings):
     prometheus_enabled: bool = True
     https_redirect: bool = False
     rate_limit: str = "300/minute"
-    debug: bool = True
+    debug: bool = Field(default=False, env="KARI_DEBUG_MODE")
     plugin_dir: str = "/app/plugins"
     llm_refresh_interval: int = 3600
     

--- a/server/debug_endpoints.py
+++ b/server/debug_endpoints.py
@@ -16,6 +16,10 @@ logger = logging.getLogger("kari")
 
 def register_debug_endpoints(app: FastAPI, settings: Settings) -> None:
     """Register all debug and development endpoints"""
+
+    if settings.environment.lower() == "production" or not getattr(settings, "debug", False):
+        logger.info("Skipping debug endpoints in production or when debug mode is disabled")
+        return
     
     @app.get("/api/system/dev-warnings", tags=["system"])
     async def get_dev_warnings():

--- a/ui_launchers/web_ui/src/app/chat-test/page.tsx
+++ b/ui_launchers/web_ui/src/app/chat-test/page.tsx
@@ -1,15 +1,5 @@
-'use client';
-
-import React from 'react';
-import { ChatInterface } from '@/components/ChatInterface';
+import { notFound } from "next/navigation";
 
 export default function ChatTestPage() {
-  return (
-    <div className="min-h-screen bg-background">
-      <div className="container mx-auto p-4">
-        <h1 className="text-2xl font-bold mb-4">Chat Test (No Auth)</h1>
-        <ChatInterface />
-      </div>
-    </div>
-  );
+  notFound();
 }

--- a/ui_launchers/web_ui/src/app/chat/page.tsx
+++ b/ui_launchers/web_ui/src/app/chat/page.tsx
@@ -46,10 +46,9 @@ const ExtensionSidebar = dynamic(() => import("@/components/extensions/Extension
 
 export default function ChatPage() {
   return (
-    // Temporarily bypass ProtectedRoute for testing
-    // <ProtectedRoute>
+    <ProtectedRoute>
       <ChatView />
-    // </ProtectedRoute>
+    </ProtectedRoute>
   );
 }
 


### PR DESCRIPTION
## Summary
- default backend debug mode to off and prevent debug/developer endpoints from being exposed in production
- secure the chat interface by re-enabling the protected route and retiring the unauthenticated chat test page

## Testing
- pytest --no-cov tests/unit/ai/test_chat_orchestrator.py

------
https://chatgpt.com/codex/tasks/task_e_68d7358385c48324b77f0c36f8605870