### PR TITLE
Refine chat runtime integration

### DIFF
--- a/ui_launchers/web_ui/src/types/chat.ts
+++ b/ui_launchers/web_ui/src/types/chat.ts
@@ -61,21 +61,24 @@ export interface CreateConversationRequest {
 export interface ChatRuntimeRequest {
   message: string;
   conversation_id?: string;
+  stream?: boolean;
+  context?: Record<string, any>;
+  tools?: string[];
+  memory_context?: string;
+  user_preferences?: Record<string, any>;
+  platform?: string;
+  /** Optional hints for routing/model selection */
   model?: string;
   provider?: string;
   temperature?: number;
   max_tokens?: number;
-  stream?: boolean;
-  context?: Record<string, any>;
 }
 
 export interface ChatRuntimeResponse {
-  response: string;
-  conversation_id: string;
-  message_id: string;
-  model_used: string;
-  provider_used: string;
-  tokens_used?: number;
-  processing_time_ms?: number;
+  content: string;
+  conversation_id?: string;
   metadata?: Record<string, any>;
+  tool_calls?: Array<Record<string, any>>;
+  memory_operations?: Array<Record<string, any>>;
+  timestamp?: string;
 }


### PR DESCRIPTION
## Summary
- align the chat runtime request/response contracts with the backend schema
- route the web chat interface through /api/chat/runtime with structured payloads and fallback handling
- enrich streaming metadata aggregation and error reporting with endpoint origin details

## Testing
- npm --prefix ui_launchers/web_ui run typecheck *(fails: existing TypeScript errors in unrelated test suites)*

------
https://chatgpt.com/codex/tasks/task_e_68d7358385c48324b77f0c36f8605870