### PR TITLE
Align reasoning and degraded-mode routes for production

### DIFF
--- a/FRONTEND_BACKEND_DEBUG_GUIDE.md
+++ b/FRONTEND_BACKEND_DEBUG_GUIDE.md
@@ -23,7 +23,7 @@ Based on your console logs, here are the main issues and their fixes:
 **Root Cause**: Backend URL mismatch (now fixed)
 
 ### 4. Degraded Mode Service (503 Error)
-**Problem**: `http://10.96.136.74:8010/api/karen/api/health/degraded-mode` returning 503
+**Problem**: `http://10.96.136.74:8010/api/health/degraded-mode` returning 503
 
 **Root Cause**: This endpoint doesn't exist on your backend - it's a configuration issue
 

--- a/server/debug_endpoints.py
+++ b/server/debug_endpoints.py
@@ -133,7 +133,7 @@ def register_debug_endpoints(app: FastAPI, settings: Settings) -> None:
                 "error": str(e)
             }
     
-    @app.post("/api/reasoning/analyze", tags=["reasoning"])
+    @app.post("/api/debug/reasoning/analyze", tags=["reasoning", "debug"])
     async def analyze_with_reasoning(request: dict):
         """Analyze user input using the reasoning system with fallbacks"""
         try:

--- a/server/routers.py
+++ b/server/routers.py
@@ -38,6 +38,7 @@ from ai_karen_engine.api_routes.tool_routes import router as tool_router
 from ai_karen_engine.api_routes.web_api_compatibility import router as web_api_router
 from ai_karen_engine.api_routes.websocket_routes import router as websocket_router
 from ai_karen_engine.api_routes.chat_runtime import router as chat_runtime_router
+from ai_karen_engine.api_routes.degraded_mode_routes import router as degraded_mode_router
 from ai_karen_engine.api_routes.llm_routes import router as llm_router
 from ai_karen_engine.api_routes.provider_routes import router as provider_router
 from ai_karen_engine.api_routes.provider_routes import public_router as provider_public_router
@@ -57,6 +58,7 @@ from ai_karen_engine.api_routes.provider_compatibility_routes import router as p
 from ai_karen_engine.api_routes.model_orchestrator_routes import router as model_orchestrator_router
 from ai_karen_engine.api_routes.validation_metrics_routes import router as validation_metrics_router
 from ai_karen_engine.api_routes.performance_routes import router as performance_routes
+from ai_karen_engine.api_routes.reasoning_routes import router as reasoning_router
 
 
 def wire_routers(app: FastAPI, settings: Settings) -> None:
@@ -152,3 +154,5 @@ def wire_routers(app: FastAPI, settings: Settings) -> None:
     app.include_router(validation_metrics_router, tags=["validation-metrics"])
     app.include_router(performance_routes, prefix="/api/performance", tags=["performance"])
     app.include_router(settings_router)
+    app.include_router(degraded_mode_router)
+    app.include_router(reasoning_router)

--- a/src/ai_karen_engine/api_routes/degraded_mode_routes.py
+++ b/src/ai_karen_engine/api_routes/degraded_mode_routes.py
@@ -1,6 +1,7 @@
 """API routes for degraded mode management."""
 
 import logging
+import time
 from typing import Any, Dict
 
 from ai_karen_engine.core.degraded_mode import get_degraded_mode_manager, DegradedModeReason
@@ -172,6 +173,3 @@ async def get_degraded_mode_metrics() -> Dict[str, Any]:
         logger.error(f"Failed to get degraded mode metrics: {e}")
         raise HTTPException(status_code=500, detail="Failed to get degraded mode metrics")
 
-
-# Add time import that was missing
-import time

--- a/src/ai_karen_engine/api_routes/reasoning_routes.py
+++ b/src/ai_karen_engine/api_routes/reasoning_routes.py
@@ -1,0 +1,235 @@
+"""Production reasoning endpoints for the Kari API."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Optional
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+
+from ai_karen_engine.core.degraded_mode import generate_degraded_mode_response
+from ai_karen_engine.core.service_registry import get_service_registry, initialize_services
+from ai_karen_engine.models.shared_types import FlowInput
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/reasoning", tags=["reasoning"])
+
+
+class ReasoningRequest(BaseModel):
+    """Payload sent from the web UI reasoning client."""
+
+    input: str = Field(..., min_length=1, description="User input that needs analysis")
+    context: Dict[str, Any] = Field(default_factory=dict, description="Optional reasoning context")
+
+
+class ReasoningResponse(BaseModel):
+    """Standard response envelope returned to the frontend."""
+
+    success: bool
+    response: Dict[str, Any]
+    reasoning_method: str
+    fallback_used: bool
+    errors: Optional[Dict[str, Any]] = None
+
+
+def _normalize_response_payload(payload: Any) -> Dict[str, Any]:
+    """Convert orchestrator or fallback outputs into a consistent shape."""
+
+    if isinstance(payload, dict):
+        normalized = dict(payload)
+        normalized.setdefault("type", "text")
+        if "content" not in normalized:
+            normalized["content"] = str(payload)
+        return normalized
+
+    if hasattr(payload, "model_dump"):
+        try:
+            return _normalize_response_payload(payload.model_dump())
+        except Exception:  # pragma: no cover - defensive
+            pass
+
+    if hasattr(payload, "dict"):
+        try:
+            return _normalize_response_payload(payload.dict())
+        except Exception:  # pragma: no cover - defensive
+            pass
+
+    if hasattr(payload, "__dict__"):
+        return _normalize_response_payload(vars(payload))
+
+    return {"content": str(payload), "type": "text", "metadata": {"raw_type": type(payload).__name__}}
+
+
+def _enhanced_simple_fallback(user_input: str) -> Dict[str, Any]:
+    """Return a user friendly fallback response when everything else fails."""
+
+    text = user_input.strip().lower()
+
+    if any(word in text for word in ["function", "code", "python", "javascript", "programming", "algorithm"]):
+        content = (
+            "I can help with coding questions! You asked about: "
+            f"{user_input}\n\nWhile I'm in fallback mode, here are a few tips:\n"
+            "1. Break the problem into small steps.\n"
+            "2. Use descriptive variable names.\n"
+            "3. Add comments explaining tricky logic.\n"
+            "4. Test incrementally to verify each change.\n\n"
+            "Let me know what part you'd like to dive into."
+        )
+    elif text.endswith("?") or any(word in text for word in ["what", "how", "why", "when", "where", "help"]):
+        content = (
+            f"I understand you're asking: {user_input}\n\n"
+            "I'm operating with limited capabilities right now, but I'm still here to help."
+            " Can you share more specific details so I can provide better guidance?"
+        )
+    elif any(word in text for word in ["hello", "hi", "hey", "greetings"]):
+        content = (
+            "Hello! I'm Karen, your AI assistant. I'm currently in a reduced capability mode,"
+            " but I can still help with many questions. What would you like to work on today?"
+        )
+    elif any(word in text for word in ["create", "make", "build", "write", "generate"]):
+        content = (
+            f"I'd love to help with: {user_input}\n\n"
+            "I'm in fallback mode, so my responses may be more high-level."
+            " Could you outline the steps or details you're looking for so we can tackle it together?"
+        )
+    else:
+        content = (
+            f"I received your message: {user_input}\n\n"
+            "I'm experiencing limited functionality at the moment,"
+            " but I still want to assist. Could you rephrase or provide more context?"
+        )
+
+    return {
+        "content": content,
+        "type": "text",
+        "metadata": {
+            "fallback_mode": True,
+            "local_processing": True,
+            "enhanced_simple_response": True,
+        },
+    }
+
+
+async def _orchestrator_available(registry: Any) -> bool:
+    """Ensure the AI orchestrator is initialized and ready."""
+
+    try:
+        services = registry.list_services()
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning("Unable to list services: %s", exc)
+        services = {}
+
+    if services.get("ai_orchestrator", {}).get("status") == "ready":
+        return True
+
+    try:
+        await initialize_services()
+        services = registry.list_services()
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning("Service initialization failed: %s", exc)
+        return False
+
+    return services.get("ai_orchestrator", {}).get("status") == "ready"
+
+
+@router.post("/analyze", response_model=ReasoningResponse)
+async def analyze_reasoning(request: ReasoningRequest) -> ReasoningResponse:
+    """Primary reasoning endpoint used by the production web UI."""
+
+    user_input = request.input.strip()
+    if not user_input:
+        raise HTTPException(status_code=400, detail="Input cannot be empty")
+
+    context = request.context or {}
+
+    try:
+        registry = get_service_registry()
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.error("Service registry unavailable: %s", exc)
+        fallback_payload = _normalize_response_payload(
+            generate_degraded_mode_response(user_input=user_input, context=context)
+        )
+        return ReasoningResponse(
+            success=True,
+            response=fallback_payload,
+            reasoning_method="local_fallback",
+            fallback_used=True,
+            errors={"registry_error": str(exc)},
+        )
+
+    orchestrator_ready = await _orchestrator_available(registry)
+
+    if orchestrator_ready:
+        try:
+            orchestrator = await registry.get_service("ai_orchestrator")
+            flow_input = FlowInput(
+                prompt=user_input,
+                context=context,
+                user_id=context.get("user_id", "anonymous"),
+                conversation_history=context.get("conversation_history", []),
+                user_settings=context.get("user_settings", {}),
+            )
+
+            flow_output = await orchestrator.conversation_processing_flow(flow_input)
+            payload = _normalize_response_payload(flow_output)
+
+            return ReasoningResponse(
+                success=True,
+                response=payload,
+                reasoning_method="ai_orchestrator",
+                fallback_used=False,
+            )
+        except Exception as exc:
+            logger.warning("AI orchestrator reasoning failed, using fallback: %s", exc)
+            try:
+                fallback_payload = _normalize_response_payload(
+                    generate_degraded_mode_response(user_input=user_input, context=context)
+                )
+            except Exception as fallback_error:  # pragma: no cover - defensive
+                logger.error("Degraded mode reasoning failed: %s", fallback_error)
+                fallback_payload = _enhanced_simple_fallback(user_input)
+                return ReasoningResponse(
+                    success=True,
+                    response=fallback_payload,
+                    reasoning_method="enhanced_simple_fallback",
+                    fallback_used=True,
+                    errors={
+                        "ai_error": str(exc),
+                        "fallback_error": str(fallback_error),
+                    },
+                )
+
+            return ReasoningResponse(
+                success=True,
+                response=fallback_payload,
+                reasoning_method="local_fallback",
+                fallback_used=True,
+                errors={"ai_error": str(exc)},
+            )
+
+    # Orchestrator not available even after initialization attempts
+    try:
+        fallback_payload = _normalize_response_payload(
+            generate_degraded_mode_response(user_input=user_input, context=context)
+        )
+    except Exception as fallback_error:  # pragma: no cover - defensive
+        logger.error("Failed to generate degraded mode response: %s", fallback_error)
+        fallback_payload = _enhanced_simple_fallback(user_input)
+        return ReasoningResponse(
+            success=True,
+            response=fallback_payload,
+            reasoning_method="enhanced_simple_fallback",
+            fallback_used=True,
+            errors={"fallback_error": str(fallback_error)},
+        )
+
+    return ReasoningResponse(
+        success=True,
+        response=fallback_payload,
+        reasoning_method="local_fallback",
+        fallback_used=True,
+        errors={"reason": "ai_orchestrator_unavailable"},
+    )
+

--- a/tests/unit/core/test_connection.html
+++ b/tests/unit/core/test_connection.html
@@ -20,7 +20,7 @@
     <div class="info">
         <strong>Testing connections to:</strong><br>
         • Backend (Direct): http://127.0.0.1:8000<br>
-        • Frontend Proxy: http://localhost:8010/api/karen<br>
+        • Frontend Proxy: http://localhost:8010/api<br>
     </div>
 
     <button onclick="testDirectConnection()">Test Direct Backend</button>
@@ -62,7 +62,7 @@
             results.innerHTML = '<div class="info">Testing frontend proxy connection...</div>';
             
             try {
-                const response = await fetch('http://localhost:8010/api/karen/api/health/degraded-mode');
+                const response = await fetch('http://localhost:8010/api/health/degraded-mode');
                 const data = await response.json();
                 
                 results.innerHTML = `
@@ -109,7 +109,7 @@
             
             // Test proxy connection
             try {
-                const response = await fetch('http://localhost:8010/api/karen/api/health/degraded-mode');
+                const response = await fetch('http://localhost:8010/api/health/degraded-mode');
                 const data = await response.json();
                 html += `
                     <div class="success">

--- a/tests/unit/core/test_frontend_status.py
+++ b/tests/unit/core/test_frontend_status.py
@@ -15,7 +15,7 @@ def test_frontend_status():
     try:
         # Test the degraded mode endpoint
         print("\n1. Testing degraded mode endpoint...")
-        response = requests.get("http://localhost:8010/api/karen/api/health/degraded-mode")
+        response = requests.get("http://localhost:8010/api/health/degraded-mode")
         
         if response.status_code == 200:
             data = response.json()

--- a/ui_launchers/web_ui/src/components/ui/degraded-mode-banner.tsx
+++ b/ui_launchers/web_ui/src/components/ui/degraded-mode-banner.tsx
@@ -61,7 +61,7 @@ export function DegradedModeBanner({
       // Use the Next.js proxy route instead of direct backend URL with a timeout
       const controller = new AbortController()
       const t = setTimeout(() => controller.abort(), 15000)
-      const response = await fetch('/api/karen/api/health/degraded-mode/recover', {
+      const response = await fetch('/api/health/degraded-mode/recover', {
         method: 'POST',
         signal: controller.signal,
       })

--- a/ui_launchers/web_ui/src/services/reasoningService.ts
+++ b/ui_launchers/web_ui/src/services/reasoningService.ts
@@ -42,7 +42,7 @@ class ReasoningService {
   async analyze(request: ReasoningRequest): Promise<ReasoningResponse> {
     try {
       // Use the Next.js proxy route instead of direct backend URL
-      const response = await fetch('/api/karen/api/reasoning/analyze', {
+      const response = await fetch('/api/reasoning/analyze', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/ui_launchers/web_ui/test-reasoning.html
+++ b/ui_launchers/web_ui/test-reasoning.html
@@ -24,7 +24,7 @@
             resultDiv.innerHTML = 'Testing reasoning system...';
             
             try {
-                const response = await fetch('/api/karen/api/reasoning/analyze', {
+                const response = await fetch('/api/reasoning/analyze', {
                     method: 'POST',
                     headers: {
                         'Content-Type': 'application/json',


### PR DESCRIPTION
## Summary
- add a production-ready `/api/reasoning/analyze` FastAPI router with graceful fallbacks and register it in the main router wiring
- ensure degraded-mode APIs are included server-side and update the web UI proxy endpoints to target `/api/health/degraded-mode` and the new reasoning path
- refresh related docs and helper test utilities to reflect the corrected URLs

## Testing
- `pytest --override-ini addopts="" tests/unit/core/test_soft_reasoning.py` *(fails: ModuleNotFoundError: No module named 'ai_karen_engine.core.soft_reasoning_engine')*

------
https://chatgpt.com/codex/tasks/task_e_68d7462a71908324a8c8e9588d7f61db