### PR TITLE
Allow data URI fonts in CSP middleware

### DIFF
--- a/ui_launchers/web_ui/src/middleware.ts
+++ b/ui_launchers/web_ui/src/middleware.ts
@@ -16,7 +16,7 @@ export function middleware(request: NextRequest) {
     "script-src 'self' 'unsafe-eval' 'unsafe-inline' https:",
     "style-src 'self' 'unsafe-inline' https:",
     "img-src 'self' data: https:",
-    "font-src 'self' https:",
+    "font-src 'self' data: https:",
     "connect-src 'self' http://localhost:* http://127.0.0.1:* https: wss: ws://localhost:* ws://127.0.0.1:*",
     "frame-ancestors 'none'",
     "base-uri 'self'",


### PR DESCRIPTION
## Summary
- allow data URI fonts in the middleware CSP header to align with the Next.js header configuration and unblock inline font loading

## Testing
- npm run typecheck *(fails: existing TypeScript errors in test files and e2e specs)*

------
https://chatgpt.com/codex/tasks/task_e_68d75ad9a7a88324a32203f64a6866b1