### PR TITLE
Handle missing plugin service in chat process route

### DIFF
--- a/src/ai_karen_engine/database/memory_manager.py
+++ b/src/ai_karen_engine/database/memory_manager.py
@@ -20,14 +20,13 @@ import time
 import uuid
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
-from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Tuple, Union
 
 import numpy as np
 from sqlalchemy import delete, select, text
 
 from ai_karen_engine.core.embedding_manager import EmbeddingManager  # Required
 from ai_karen_engine.core.milvus_client import MilvusClient  # Optional at runtime
-from ai_karen_engine.database.client import MultiTenantPostgresClient
 from ai_karen_engine.database.models import TenantMemoryItem
 
 # Optional metrics
@@ -111,6 +110,12 @@ class MemoryQuery:
 # ---------------------------------------------------------------------------
 # Manager
 # ---------------------------------------------------------------------------
+
+
+if TYPE_CHECKING:
+    from ai_karen_engine.database.client import MultiTenantPostgresClient
+else:  # pragma: no cover - used only for type checking to avoid circular imports
+    MultiTenantPostgresClient = Any  # type: ignore[misc,assignment]
 
 
 class MemoryManager:


### PR DESCRIPTION
## Summary
- make the web UI chat endpoint resilient when the plugin service is unavailable by resolving dependencies lazily and logging skipped plugin execution
- ensure module aliasing so patches against `src.ai_karen_engine` target the same router module during tests
- break a circular import in the memory manager by guarding the `MultiTenantPostgresClient` import behind TYPE_CHECKING

## Testing
- pytest -o addopts= tests/integration/api/test_web_ui_api_integration.py::TestWebUIAPIIntegration::test_chat_process_endpoint -q

------
https://chatgpt.com/codex/tasks/task_e_68d75efb16f08324845b260be9ca25ba