### PR TITLE
Respect user LLM preferences in chat runtime routing

### DIFF
--- a/tests/unit/api_routes/test_chat_runtime.py
+++ b/tests/unit/api_routes/test_chat_runtime.py
@@ -19,7 +19,11 @@ from ai_karen_engine.api_routes import chat_runtime
 class _FakeOrchestrator:
     """Minimal orchestrator used for route testing."""
 
+    def __init__(self) -> None:
+        self.calls: list[chat_runtime.ChatRequest] = []
+
     async def process_message(self, chat_request: chat_runtime.ChatRequest):  # type: ignore[override]
+        self.calls.append(chat_request)
         if chat_request.stream:
             async def _stream() -> AsyncIterator[SimpleNamespace]:
                 yield SimpleNamespace(type="metadata", metadata={"phase": "start"}, content="")
@@ -78,13 +82,20 @@ class _FakeResponseCoreOrchestrator:
 
 
 @pytest.fixture()
-def test_app(monkeypatch: pytest.MonkeyPatch) -> TestClient:
+def fake_orchestrator() -> _FakeOrchestrator:
+    return _FakeOrchestrator()
+
+
+@pytest.fixture()
+def test_app(
+    fake_orchestrator: _FakeOrchestrator, monkeypatch: pytest.MonkeyPatch
+) -> TestClient:
     """Create a FastAPI app with overridden dependencies for testing."""
 
     app = FastAPI()
     app.include_router(chat_runtime.router)
 
-    app.dependency_overrides[chat_runtime.get_chat_orchestrator] = lambda: _FakeOrchestrator()
+    app.dependency_overrides[chat_runtime.get_chat_orchestrator] = lambda: fake_orchestrator
     app.dependency_overrides[chat_runtime.get_current_user_context] = lambda: {"user_id": "tester"}
     app.dependency_overrides[chat_runtime.get_request_metadata] = lambda: {
         "ip_address": "127.0.0.1",
@@ -99,21 +110,51 @@ def test_app(monkeypatch: pytest.MonkeyPatch) -> TestClient:
     return TestClient(app)
 
 
-def test_chat_runtime_returns_response(test_app: TestClient) -> None:
+def test_chat_runtime_returns_response(
+    test_app: TestClient, fake_orchestrator: _FakeOrchestrator
+) -> None:
     """The non-streaming chat runtime route should return a JSON payload."""
 
-    response = test_app.post("/chat/runtime", json={"message": "Hello"})
+    response = test_app.post(
+        "/chat/runtime",
+        json={
+            "message": "Hello",
+            "provider": "user-provider",
+            "model": "user-model",
+            "temperature": 0.25,
+            "max_tokens": 256,
+        },
+    )
 
     assert response.status_code == 200
     payload = response.json()
     assert payload["content"] == "Hello world"
     assert payload["metadata"]["kire_metadata"]["provider"] == "test-provider"
+    assert payload["metadata"]["requested_generation"]["provider"] == "user-provider"
+    assert payload["metadata"]["requested_generation"]["model"] == "user-model"
+    assert payload["metadata"]["requested_generation"]["temperature"] == 0.25
+    assert payload["metadata"]["requested_generation"]["max_tokens"] == 256
+    assert fake_orchestrator.calls
+    last_call = fake_orchestrator.calls[-1]
+    assert last_call.metadata.get("preferred_llm_provider") == "user-provider"
+    assert last_call.metadata.get("preferred_model") == "user-model"
+    assert last_call.metadata["requested_generation"]["temperature"] == 0.25
 
 
-def test_chat_runtime_stream_emits_tokens(test_app: TestClient) -> None:
+def test_chat_runtime_stream_emits_tokens(
+    test_app: TestClient, fake_orchestrator: _FakeOrchestrator
+) -> None:
     """The streaming chat runtime route should emit SSE token events."""
 
-    with test_app.stream("POST", "/chat/runtime/stream", json={"message": "Stream please"}) as response:
+    with test_app.stream(
+        "POST",
+        "/chat/runtime/stream",
+        json={
+            "message": "Stream please",
+            "provider": "user-provider",
+            "model": "user-model",
+        },
+    ) as response:
         # Collect the streamed lines so json.dumps is exercised
         lines = list(response.iter_lines())
 
@@ -121,14 +162,33 @@ def test_chat_runtime_stream_emits_tokens(test_app: TestClient) -> None:
     # Ensure at least one token and completion event were emitted
     assert any("\"type\": \"token\"" in line for line in lines)
     assert any("\"type\": \"complete\"" in line for line in lines)
+    metadata_lines = [line for line in lines if '"type": "metadata"' in line]
+    assert metadata_lines
+    metadata_payload = json.loads(metadata_lines[0].split("data: ", 1)[1])
+    assert (
+        metadata_payload["data"]["requested_generation"]["provider"]
+        == "user-provider"
+    )
+    assert fake_orchestrator.calls
+    last_call = fake_orchestrator.calls[-1]
+    assert last_call.metadata.get("preferred_llm_provider") == "user-provider"
 
 
-def test_chat_runtime_stream_handles_missing_kire(test_app: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_chat_runtime_stream_handles_missing_kire(
+    test_app: TestClient, fake_orchestrator: _FakeOrchestrator, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Streaming should still work if the routing engine returns no decision."""
 
     monkeypatch.setattr(chat_runtime, "get_registry", lambda: _NoDecisionRegistry())
 
-    with test_app.stream("POST", "/chat/runtime/stream", json={"message": "Stream please"}) as response:
+    with test_app.stream(
+        "POST",
+        "/chat/runtime/stream",
+        json={
+            "message": "Stream please",
+            "provider": "user-provider",
+        },
+    ) as response:
         lines = list(response.iter_lines())
 
     assert response.status_code == 200
@@ -136,10 +196,16 @@ def test_chat_runtime_stream_handles_missing_kire(test_app: TestClient, monkeypa
     assert metadata_lines, "Expected at least one metadata event"
     payload = json.loads(metadata_lines[0].split("data: ", 1)[1])
     assert "kire" not in payload["data"]
+    assert payload["data"]["requested_generation"]["provider"] == "user-provider"
+    assert fake_orchestrator.calls
+    last_call = fake_orchestrator.calls[-1]
+    assert last_call.metadata.get("preferred_llm_provider") == "user-provider"
 
 
 def test_chat_runtime_response_core_round_trip(
-    test_app: TestClient, monkeypatch: pytest.MonkeyPatch
+    test_app: TestClient,
+    fake_orchestrator: _FakeOrchestrator,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """The response-core route should return prompt output when available."""
 


### PR DESCRIPTION
## Summary
- capture explicit provider/model/parameter hints from chat runtime requests and validate input
- propagate requested generation metadata through orchestrator calls, API responses, and SSE events so user preferences are honored
- expand chat runtime route tests to verify preference handling and metadata propagation

## Testing
- pytest --override-ini "addopts=" tests/unit/api_routes/test_chat_runtime.py

------
https://chatgpt.com/codex/tasks/task_e_68d7733f5ad883248997732d6f88fc9f