### PR TITLE
Organize stray tests into tests hierarchy

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -24,12 +24,13 @@ tests/
 │   ├── database/                   # Database integration tests (2 files)
 │   ├── auth/                       # Authentication flow tests
 │   ├── services/                   # Service integration tests (9 files)
+│   ├── marketplace/                # Marketplace example validation
 │   └── external/                   # External service integration (20 files)
 ├── e2e/                           # End-to-end tests
 ├── performance/                    # Performance and load tests (16 files)
 ├── security/                      # Security-focused tests (5 files)
-├── manual/                        # Manual test scripts and helpers (3 files)
-│   └── scripts/                   # Shell scripts for manual testing (3 files)
+├── manual/                        # Manual test scripts and helpers
+│   └── scripts/                   # Shell scripts for manual testing
 ├── stubs/                         # Test stubs and mocks
 └── data/                          # Test data and fixtures
 ```
@@ -44,16 +45,17 @@ tests/
 - **Middleware (21 files)**: Authentication, RBAC, session management
 - **Utils (9 files)**: Utility functions, encryption, validation
 
-### Integration Tests (44 files)
+### Integration Tests (45 files)
 - **External (20 files)**: Third-party service integrations
 - **API (13 files)**: API endpoint integration tests
 - **Services (9 files)**: Service-to-service integration
+- **Marketplace**: Marketplace example validation
 - **Database (2 files)**: Database integration flows
 
 ### Specialized Tests
 - **Performance (16 files)**: Load testing, benchmarks, optimization
 - **Security (5 files)**: Security components, threat detection
-- **Manual (6 files)**: Manual tests and scripts
+- **Manual**: Manual tests and scripts
 
 ## Running Tests
 

--- a/tests/integration/marketplace/test_hello_world_memory.py
+++ b/tests/integration/marketplace/test_hello_world_memory.py
@@ -1,8 +1,12 @@
 import asyncio
 import importlib.util
-from pathlib import Path
-import types
 import sys
+import types
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+MARKETPLACE_PATH = REPO_ROOT / "src" / "marketplace"
 
 
 def load_memory_helper():
@@ -21,7 +25,7 @@ def load_memory_helper():
     sys.modules.setdefault("ai_karen_engine.core.memory", memory_pkg)
     sys.modules.setdefault("ai_karen_engine.core.memory.manager", fake_manager)
 
-    path = Path(__file__).resolve().parents[1] / "memory_manager.py"
+    path = MARKETPLACE_PATH / "memory_manager.py"
     spec = importlib.util.spec_from_file_location("pm_memory_manager", path)
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)  # type: ignore[arg-type]
@@ -34,7 +38,7 @@ unified_memory = memory_mod.unified_memory
 
 
 def load_module():
-    path = Path(__file__).resolve().parents[1] / "examples/hello-world/handler.py"
+    path = MARKETPLACE_PATH / "examples/hello-world/handler.py"
     spec = importlib.util.spec_from_file_location("hello_world_handler", path)
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)  # type: ignore[arg-type]

--- a/tests/manual/scripts/database_stack_test_suite.sh
+++ b/tests/manual/scripts/database_stack_test_suite.sh
@@ -4,6 +4,10 @@ set -e
 # AI Karen Database Stack Test Suite
 # This script runs comprehensive tests on all database services
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+cd "$REPO_ROOT"
+
 echo "🧪 AI Karen Database Stack Test Suite"
 echo "===================================="
 


### PR DESCRIPTION
## Summary
- move the marketplace memory persistence test into the tests/integration tree and update its path handling
- relocate the database stack shell suite under tests/manual/scripts and ensure it executes from the repository root
- document the new integration and manual script layout in tests/README.md

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7d950a4b0832492b9d29afe6b188d