### PR TITLE
Disable simple auth fallbacks in production builds

### DIFF
--- a/ui_launchers/web_ui/src/app/api/auth/login-simple/route.ts
+++ b/ui_launchers/web_ui/src/app/api/auth/login-simple/route.ts
@@ -1,11 +1,17 @@
 import { NextRequest, NextResponse } from 'next/server';
 
 import { getBackendCandidates, withBackendPath } from '@/app/api/_utils/backend';
+import { isSimpleAuthEnabled } from '@/lib/auth/env';
 
 const BACKEND_BASES = getBackendCandidates();
 const AUTH_TIMEOUT_MS = Number(process.env.NEXT_PUBLIC_AUTH_PROXY_TIMEOUT_MS || process.env.KAREN_AUTH_PROXY_TIMEOUT_MS || 30000);
 
 export async function POST(request: NextRequest) {
+  if (!isSimpleAuthEnabled()) {
+    console.warn('Login-simple endpoint invoked but simple auth is disabled for this environment.');
+    return NextResponse.json({ error: 'Simple auth is disabled' }, { status: 404 });
+  }
+
   try {
     const body = await request.json();
     

--- a/ui_launchers/web_ui/src/lib/auth/env.ts
+++ b/ui_launchers/web_ui/src/lib/auth/env.ts
@@ -1,0 +1,66 @@
+const FLAG_TRUE = new Set(['true', '1', 'yes', 'on']);
+const FLAG_FALSE = new Set(['false', '0', 'no', 'off']);
+
+function readEnv(keys: string[]): string | undefined {
+  for (const key of keys) {
+    const value = process.env[key];
+    if (typeof value !== 'undefined') {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function toBooleanFlag(value: string | undefined, defaultValue: boolean): boolean {
+  if (typeof value !== 'string') {
+    return defaultValue;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  if (FLAG_TRUE.has(normalized)) {
+    return true;
+  }
+  if (FLAG_FALSE.has(normalized)) {
+    return false;
+  }
+  return defaultValue;
+}
+
+export function isProductionEnvironment(): boolean {
+  return process.env.NODE_ENV === 'production';
+}
+
+export function isDevLoginEnabled(): boolean {
+  const explicit = readEnv([
+    'NEXT_PUBLIC_ENABLE_DEV_LOGIN',
+    'ENABLE_DEV_LOGIN',
+    'KAREN_ENABLE_DEV_LOGIN',
+  ]);
+
+  return toBooleanFlag(explicit, !isProductionEnvironment());
+}
+
+export function isSimpleAuthEnabled(): boolean {
+  const explicit = readEnv([
+    'NEXT_PUBLIC_ENABLE_SIMPLE_AUTH',
+    'ENABLE_SIMPLE_AUTH',
+    'KAREN_ENABLE_SIMPLE_AUTH',
+  ]);
+
+  if (typeof explicit !== 'undefined') {
+    return toBooleanFlag(explicit, false);
+  }
+
+  // Fall back to dev login flag to preserve backwards compatibility
+  const devLoginFlag = readEnv([
+    'NEXT_PUBLIC_ENABLE_DEV_LOGIN',
+    'ENABLE_DEV_LOGIN',
+    'KAREN_ENABLE_DEV_LOGIN',
+  ]);
+
+  if (typeof devLoginFlag !== 'undefined') {
+    return toBooleanFlag(devLoginFlag, false);
+  }
+
+  return !isProductionEnvironment();
+}


### PR DESCRIPTION
## Summary
- add a shared auth environment helper for consistent feature flag handling
- block the session manager from using simple auth or dev login fallbacks when the environment disallows them
- guard Next.js auth proxy routes so production deployments never reach dev-only endpoints

## Testing
- npm run lint *(fails: Next CLI is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d7e0d569a88324a7c4758b8d8aa305