### PR TITLE
Infuse cognitive reasoning into KIRE routing

### DIFF
--- a/reports/kire_production_audit.md
+++ b/reports/kire_production_audit.md
@@ -1,0 +1,51 @@
+# KIRE Production Readiness Audit
+
+## Executive Summary
+- **Overall status:** Kari Intelligent Routing Engine (KIRE) is feature-complete for adaptive provider selection, but several production-critical hardening tasks remain before declaring GA readiness.
+- **Strengths:** The router composes caching, deduplication, profile-aware assignments, and warm-up flows with structured logging and Prometheus metrics, aligning with the platform's modular objective.
+- **Key risks:** Cache-key collisions, permissive health fallbacks, and the absence of automated validation/testing expose the system to incorrect routing and undetected regressions.
+
+## Architecture & Functionality Review
+### Router Core
+- `KIRERouter` builds on shared cache utilities and emits metrics for cache hits/misses and latency, while deduplicating concurrent routing decisions; decisions embed profile assignments, analyzer output, and fallback chains for downstream consumers.【F:src/ai_karen_engine/routing/kire_router.py†L10-L169】
+- Refinement logic checks provider health, prefers step-specific models, enforces rudimentary cost ceilings, and falls back to degraded mode when health checks fail, supporting progressive enhancement of routing intelligence.【F:src/ai_karen_engine/routing/kire_router.py†L172-L226】
+- Cache invalidation helpers and diagnostics expose cache/dedup stats for operations tooling and align with the project mandate for modular observability hooks.【F:src/ai_karen_engine/routing/kire_router.py†L266-L289】
+
+### Profile & Assignment Resolution
+- `ProfileResolver` gracefully bridges multiple profile backends (JSON/YAML/config service) to a unified assignment schema, defaulting to sensible providers/models when explicit mappings are absent.【F:src/ai_karen_engine/routing/profile_resolver.py†L15-L140】
+- Routing dataclasses keep request/decision metadata explicit, easing serialization across engines and UI layers.【F:src/ai_karen_engine/routing/types.py†L9-L47】
+
+### Integrations & Warm-Up
+- Routing actions register KIRE with the predictor system, enforce RBAC on mutating operations, and expose audit/dry-run utilities for operators.【F:src/ai_karen_engine/routing/actions.py†L15-L200】
+- Startup routines explicitly import routing actions, perform provider health checks, and attempt proactive cache warm-ups to reduce cold-start latency.【F:src/ai_karen_engine/integrations/startup.py†L21-L138】
+- The LLM registry lazily instantiates the KIRE adapter and provides fallback behavior if routing fails, preventing total outages when routing is unavailable.【F:src/ai_karen_engine/integrations/llm_registry.py†L768-L814】
+
+### Observability & Diagnostics
+- Decision logging publishes structured OSIRIS-compatible events, pushes to the event bus, and retains a rolling in-memory audit trail for quick inspections.【F:src/ai_karen_engine/routing/decision_logger.py†L30-L130】
+- Prometheus-compatible counters/histograms instrument routing decisions, cache usage, and action invocations with safe fallbacks when Prometheus is missing.【F:src/ai_karen_engine/monitoring/kire_metrics.py†L6-L52】
+- FastAPI diagnostics endpoints surface cache and deduplication stats behind admin gating, supporting production SRE workflows.【F:src/ai_karen_engine/api_routes/kire_routes.py†L1-L35】
+
+## Production Readiness Risks
+1. **Cache key collisions:** `_generate_cache_key` omits the user query and context, so distinct prompts with identical requirements/tasks collide, causing stale or incorrect routing decisions to be served from cache.【F:src/ai_karen_engine/routing/kire_router.py†L242-L247】 Prioritize including the query signature (or hashed intent features) in the key before launch.
+2. **Health gate fallback defaults to "healthy":** If the `provider_status` integration fails to import, the fallback `ProviderHealth` class always reports providers as healthy, defeating resilience logic and masking outages.【F:src/ai_karen_engine/routing/kire_router.py†L27-L45】 Production deployment should fail fast or degrade confidence when health instrumentation is unavailable.
+3. **Task analysis heuristics are brittle:** Keyword-only detection lacks intent weighting, user/profile context, or model capability scoring, risking misclassification for enterprise workloads (e.g., compliance, multilingual).【F:src/ai_karen_engine/integrations/task_analyzer.py†L22-L78】 Consider augmenting with telemetry-trained models or configurable rules before GA.
+4. **No automated test coverage:** Repository tests do not reference KIRE modules, leaving routing logic, RBAC, and cache safety unvalidated in CI.【a486d0†L1-L2】 Add unit/integration suites that exercise routing paths, health fallbacks, and cache invalidation.
+5. **RBAC bypass on selection:** `routing.select` lacks explicit RBAC or rate limiting; hostile tenants could brute-force routing metadata. Evaluate auth requirements or throttling consistent with production policies.【F:src/ai_karen_engine/routing/actions.py†L48-L86】
+
+## Operational Gaps & TODOs
+- **Cache invalidation strategy:** Provide hooks for provider health webhooks to call `invalidate_provider_cache` so incidents clear stale entries automatically.【F:src/ai_karen_engine/routing/kire_router.py†L266-L279】
+- **Metrics enrichment:** Include decision confidence buckets and provider/model labels in metrics to improve production dashboards.【F:src/ai_karen_engine/monitoring/kire_metrics.py†L9-L45】
+- **Audit persistence:** Current decision history is in-memory only; persisting to durable storage would support incident forensics and compliance reporting.【F:src/ai_karen_engine/routing/decision_logger.py†L30-L130】
+
+## Alignment with Project Objectives
+- KIRE adheres to the modular doctrine by living under `ai_karen_engine.routing`, using absolute imports, and integrating cleanly with registries and startup warm-ups, supporting future package extraction.【F:src/ai_karen_engine/routing/kire_router.py†L10-L289】【F:src/ai_karen_engine/integrations/startup.py†L21-L138】
+- Routing actions and diagnostics expose enterprise-ready controls (profiles, health, audit), aligning with the platform goal of operational transparency.【F:src/ai_karen_engine/routing/actions.py†L15-L200】【F:src/ai_karen_engine/api_routes/kire_routes.py†L1-L35】
+
+## Verification Performed
+- `python -m compileall src/ai_karen_engine/routing` (ensures syntax integrity across routing modules).【f1976b†L1-L7】
+
+## Recommended Next Steps
+1. Patch cache key generation and add targeted regression tests for cache correctness and fallback behavior.
+2. Harden provider health integration (fail closed or lower confidence) and add monitoring alerts when Prometheus metrics degrade to dummies.
+3. Expand task analysis through configurable classifiers or ML models and capture accuracy metrics before production rollout.
+4. Implement CI coverage for routing actions, RBAC guards, and API diagnostics to ensure ongoing compliance with readiness criteria.

--- a/src/ai_karen_engine/integrations/task_analyzer.py
+++ b/src/ai_karen_engine/integrations/task_analyzer.py
@@ -7,7 +7,8 @@ inform KIRE routing decisions and KHRP step selection.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional
+import re
+from typing import Any, Dict, List, Optional, Tuple
 
 
 @dataclass
@@ -17,20 +18,22 @@ class TaskAnalysis:
     khrp_step_hint: Optional[str] = None
     hints: Dict[str, Any] = field(default_factory=dict)
     confidence: float = 0.75
+    tool_intents: List[str] = field(default_factory=list)
+    user_need_state: Dict[str, Any] = field(default_factory=dict)
 
 
 class TaskAnalyzer:
     """Pattern-based query classifier with provider capability mapping."""
 
-    # Task keyword patterns (simple heuristic)
-    _TASK_PATTERNS: Dict[str, List[str]] = {
-        "code": ["code", "bug", "fix", "function", "class", "python", "typescript", "typescript", "compile", "refactor"],
-        "reasoning": ["reason", "explain", "analyze", "logic", "why", "prove", "derive"],
-        "summarization": ["summarize", "tl;dr", "brief", "condense", "summary"],
-        "embedding": ["embed", "embedding", "semantic", "vector"],
-        "lookup": ["search", "lookup", "find", "retrieve", "fetch"],
-        "calc": ["calculate", "compute", "sum", "average", "mean", "median", "arithmetic"],
-        "chat": ["chat", "talk", "discuss", "conversation", "help"],
+    # Task keyword patterns (weighted heuristic)
+    _TASK_PATTERNS: Dict[str, List[Tuple[str, float]]] = {
+        "code": [("code", 1.0), ("bug", 1.0), ("fix", 0.9), ("function", 0.6), ("class", 0.6), ("python", 1.1), ("typescript", 1.1), ("compile", 0.8), ("refactor", 1.0)],
+        "reasoning": [("reason", 0.8), ("explain", 0.7), ("analyze", 0.9), ("logic", 0.9), ("why", 0.6), ("prove", 1.0), ("derive", 1.0), ("theorem", 1.2)],
+        "summarization": [("summarize", 1.0), ("tl;dr", 1.2), ("brief", 0.7), ("condense", 0.8), ("summary", 0.7)],
+        "embedding": [("embed", 1.0), ("embedding", 1.0), ("semantic", 0.7), ("vector", 0.7), ("similarity", 0.6)],
+        "lookup": [("search", 0.8), ("lookup", 0.8), ("find", 0.6), ("retrieve", 0.9), ("fetch", 0.6), ("documentation", 0.7)],
+        "calc": [("calculate", 0.9), ("compute", 0.9), ("sum", 0.6), ("average", 0.6), ("mean", 0.6), ("median", 0.6), ("arithmetic", 0.8), ("equation", 1.1)],
+        "chat": [("chat", 0.4), ("talk", 0.4), ("discuss", 0.5), ("conversation", 0.4), ("help", 0.2)],
     }
 
     # Capability mapping per task
@@ -53,25 +56,205 @@ class TaskAnalyzer:
         "gemini": ["text", "vision"],
     }
 
+    _ROLE_TASK_HINTS: Dict[str, Tuple[str, float]] = {
+        "developer": ("code", 0.8),
+        "engineer": ("code", 0.5),
+        "analyst": ("reasoning", 0.5),
+        "support": ("chat", 0.4),
+    }
+
+    _TOOL_PATTERNS: Dict[str, List[Tuple[str, float]]] = {
+        "web_browse": [("browser", 1.1), ("web", 0.8), ("search", 0.9), ("lookup", 0.8), ("internet", 1.0)],
+        "code_execution": [("run", 1.0), ("execute", 1.0), ("script", 0.8), ("test", 0.6), ("stack trace", 0.9)],
+        "data_viz": [("chart", 0.8), ("plot", 0.8), ("visualize", 0.9)],
+        "retrieval": [("document", 0.7), ("knowledge base", 1.0), ("wiki", 0.8), ("reference", 0.7)],
+        "function_calling": [("tool", 0.6), ("call", 0.6), ("api", 0.8), ("function", 0.7), ("automation", 0.8)],
+    }
+
+    _EXPLICIT_TOOL_MAP: Dict[str, str] = {
+        "browser": "web_browse",
+        "web_browser": "web_browse",
+        "web_search": "web_browse",
+        "code_runner": "code_execution",
+        "executor": "code_execution",
+        "sandbox": "code_execution",
+        "retriever": "retrieval",
+        "vector_search": "retrieval",
+        "function_call": "function_calling",
+    }
+
+    _AFFECTIVE_CUES: Dict[str, Tuple[str, float]] = {
+        "urgent": ("high", 0.45),
+        "asap": ("high", 0.5),
+        "right now": ("high", 0.4),
+        "stuck": ("elevated", 0.35),
+        "blocked": ("elevated", 0.35),
+        "confused": ("elevated", 0.25),
+        "frustrated": ("elevated", 0.25),
+        "important": ("elevated", 0.2),
+        "curious": ("curious", 0.2),
+    }
+
     def analyze(self, query: str, user_ctx: Optional[Dict[str, Any]] = None, context: Optional[Dict[str, Any]] = None) -> TaskAnalysis:
         q = (query or "").lower()
+        context = context or {}
+        history_fragments: List[str] = []
+        history = context.get("conversation_history")
+        if isinstance(history, list):
+            for entry in history[-3:]:
+                if isinstance(entry, dict):
+                    content = (entry.get("content") or "").lower()
+                    if content:
+                        history_fragments.append(content)
+        augmented_query = " ".join([q] + history_fragments)
 
-        # Determine task type by keywords (first match precedence)
-        for task, keywords in self._TASK_PATTERNS.items():
-            if any(k in q for k in keywords):
-                caps = self._TASK_CAPABILITIES.get(task, ["text"])
-                # Basic step hints
-                step = None
-                if task in ("reasoning", "calc"):
-                    step = "reasoning_core"
-                elif task == "summarization":
-                    step = "output_rendering"
-                elif task == "lookup":
-                    step = "evidence_gathering"
-                return TaskAnalysis(task_type=task, required_capabilities=caps, khrp_step_hint=step, hints={}, confidence=0.85)
+        tokens = set(re.findall(r"\w+", augmented_query))
+        scores: Dict[str, float] = {task: 0.0 for task in self._TASK_PATTERNS}
+        hints: Dict[str, Any] = {}
 
-        # Default to chat
-        return TaskAnalysis(task_type="chat", required_capabilities=self._TASK_CAPABILITIES["chat"], khrp_step_hint=None, hints={}, confidence=0.6)
+        for task, patterns in self._TASK_PATTERNS.items():
+            for keyword, weight in patterns:
+                if keyword in augmented_query:
+                    scores[task] += weight
+                elif keyword in tokens:
+                    scores[task] += weight * 0.9
+
+        requirements = context.get("requirements", {})
+
+        task_hint = (context.get("task_hint") or context.get("task_type") or "").lower()
+        if task_hint in scores:
+            scores[task_hint] += 2.5
+            hints["task_hint"] = task_hint
+
+        capability_hints = requirements.get("capabilities") or context.get("capability_hints")
+        if capability_hints:
+            caps = {c.lower() for c in capability_hints}
+            for task, task_caps in self._TASK_CAPABILITIES.items():
+                overlap = caps.intersection({c.lower() for c in task_caps})
+                if overlap:
+                    scores[task] += 0.6 + 0.2 * len(overlap)
+            hints["capabilities"] = list(caps)
+
+        roles = {r.lower() for r in (user_ctx or {}).get("roles", [])}
+        for role in roles:
+            task_hint_role = self._ROLE_TASK_HINTS.get(role)
+            if task_hint_role:
+                hinted_task, boost = task_hint_role
+                scores[hinted_task] += boost
+                hints.setdefault("role_hints", set()).add(role)
+
+        if "role_hints" in hints and isinstance(hints["role_hints"], set):
+            hints["role_hints"] = sorted(hints["role_hints"])
+
+        tool_scores: Dict[str, float] = {tool: 0.0 for tool in self._TOOL_PATTERNS}
+        for tool, patterns in self._TOOL_PATTERNS.items():
+            for keyword, weight in patterns:
+                if keyword in augmented_query:
+                    tool_scores[tool] += weight
+                elif keyword in tokens:
+                    tool_scores[tool] += weight * 0.85
+
+        explicit_tools = context.get("tool_suggestions") or context.get("tools")
+        if isinstance(explicit_tools, (list, tuple)):
+            for tool in explicit_tools:
+                if isinstance(tool, str):
+                    key = tool.lower()
+                    canonical = self._EXPLICIT_TOOL_MAP.get(key, key)
+                    tool_scores.setdefault(canonical, 0.0)
+                    tool_scores[canonical] += 1.2
+
+        tool_intents = sorted(tool for tool, score in tool_scores.items() if score >= 1.2)
+        if tool_intents:
+            hints["tools"] = tool_intents
+            if "code_execution" in tool_intents:
+                scores["code"] += 1.1
+            if "web_browse" in tool_intents:
+                scores["lookup"] += 0.8
+            if "function_calling" in tool_intents:
+                scores["reasoning"] += 0.5
+
+        affect_signals: List[str] = []
+        urgency_level = "normal"
+        affect_state = "neutral"
+        for cue, (level, boost) in self._AFFECTIVE_CUES.items():
+            if cue in augmented_query:
+                affect_signals.append(cue)
+                if level == "high":
+                    urgency_level = "high"
+                elif level == "elevated" and urgency_level != "high":
+                    urgency_level = "elevated"
+                if level in {"high", "elevated"}:
+                    scores["reasoning"] += boost * 0.6
+                    scores["chat"] += boost * 0.4
+                    affect_state = "stressed"
+                elif level == "curious" and affect_state == "neutral":
+                    affect_state = "curious"
+
+        # Detect multilingual queries (non-ascii) -> reasoning/chat bias
+        if any(ord(ch) > 127 for ch in q):
+            scores["chat"] += 0.3
+            scores["reasoning"] += 0.3
+            hints["multilingual"] = True
+
+        best_task = max(scores, key=scores.get)
+        best_score = scores[best_task]
+        if best_score <= 0.3:
+            best_task = "chat"
+            best_score = scores.get("chat", 0.0)
+
+        ordered_scores = sorted(scores.items(), key=lambda item: item[1], reverse=True)
+        secondary_candidates = [task for task, score in ordered_scores[1:3] if score and (best_score - score) <= 0.8]
+        if secondary_candidates:
+            hints["secondary_tasks"] = secondary_candidates
+
+        caps = self._TASK_CAPABILITIES.get(best_task, ["text"])
+        step = None
+        if best_task in ("reasoning", "calc"):
+            step = "reasoning_core"
+        elif best_task == "summarization":
+            step = "output_rendering"
+        elif best_task == "lookup":
+            step = "evidence_gathering"
+
+        confidence = 0.55 + min(best_score / 5.0, 0.35)
+        if urgency_level == "high":
+            confidence += 0.05
+        confidence = min(confidence, 0.95)
+
+        need_mode = "informational"
+        if best_task == "code":
+            need_mode = "problem_solving"
+        elif best_task == "reasoning":
+            need_mode = "analysis"
+        elif best_task == "summarization":
+            need_mode = "synthesis"
+        elif best_task == "embedding":
+            need_mode = "retrieval"
+
+        if "code_execution" in tool_intents and need_mode == "informational":
+            need_mode = "problem_solving"
+
+        user_need_state = {
+            "mode": need_mode,
+            "urgency": urgency_level,
+            "affect": affect_state,
+            "signals": affect_signals,
+        }
+        if secondary_candidates:
+            user_need_state["adjacent_tasks"] = secondary_candidates
+
+        if tool_intents:
+            user_need_state["tool_bias"] = tool_intents
+
+        return TaskAnalysis(
+            task_type=best_task,
+            required_capabilities=caps,
+            khrp_step_hint=step,
+            hints=hints,
+            confidence=confidence,
+            tool_intents=tool_intents,
+            user_need_state=user_need_state,
+        )
 
     def provider_supports(self, provider: str, required_caps: List[str]) -> bool:
         caps = self._PROVIDER_CAPABILITIES.get(provider.lower(), ["text"])  # assume at least text

--- a/src/ai_karen_engine/monitoring/kire_metrics.py
+++ b/src/ai_karen_engine/monitoring/kire_metrics.py
@@ -27,6 +27,17 @@ try:  # pragma: no cover - optional dependency
         "Total KIRE action invocations",
         ["action", "status"],
     )
+    KIRE_PROVIDER_SELECTION_TOTAL = Counter(
+        "kire_provider_selection_total",
+        "KIRE provider/model selection outcomes",
+        ["provider", "model", "status", "task_type"],
+    )
+    KIRE_DECISION_CONFIDENCE = Histogram(
+        "kire_routing_decision_confidence",
+        "Confidence distribution for routing decisions",
+        ["task_type", "provider", "model"],
+        buckets=(0.0, 0.25, 0.5, 0.65, 0.8, 0.9, 0.96, 1.01),
+    )
 except Exception:  # pragma: no cover - fallback
 
     class _Dummy:
@@ -43,10 +54,14 @@ except Exception:  # pragma: no cover - fallback
     KIRE_CACHE_EVENTS_TOTAL = _Dummy()
     KIRE_LATENCY_SECONDS = _Dummy()
     KIRE_ACTIONS_TOTAL = _Dummy()
+    KIRE_PROVIDER_SELECTION_TOTAL = _Dummy()
+    KIRE_DECISION_CONFIDENCE = _Dummy()
 
 __all__ = [
     "KIRE_DECISIONS_TOTAL",
     "KIRE_CACHE_EVENTS_TOTAL",
     "KIRE_LATENCY_SECONDS",
     "KIRE_ACTIONS_TOTAL",
+    "KIRE_PROVIDER_SELECTION_TOTAL",
+    "KIRE_DECISION_CONFIDENCE",
 ]

--- a/src/ai_karen_engine/routing/cognitive_reasoner.py
+++ b/src/ai_karen_engine/routing/cognitive_reasoner.py
@@ -1,0 +1,134 @@
+"""Cognitive scaffolding for KIRE routing decisions.
+
+The :class:`CognitiveReasoner` implements a lightweight cognitive
+architecture inspired by global workspace theory and dual process models.
+It synthesizes task analysis signals, user state, and profile metadata
+to produce a deliberative vector that the router can use to steer model
+selection in a more human-like manner.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+from ai_karen_engine.integrations.task_analyzer import TaskAnalysis
+from ai_karen_engine.routing.types import RouteRequest, UserProfile
+
+
+@dataclass
+class RoutingCognition:
+    """Structured cognition surface for routing.
+
+    Attributes mirror components from contemporary cognitive science:
+
+    * ``primary_goal`` represents the conscious spotlight (global workspace)
+    * ``secondary_goals`` models peripheral intents competing for attention
+    * ``recommended_tools`` suggests affordances for tool-augmented flows
+    * ``need_urgency`` and ``persona_bias`` emulate affective modulation
+    * ``decision_vector`` encodes normalized weights across cognitive axes
+    * ``narrative`` is a natural language trace for observability
+    """
+
+    primary_goal: str
+    secondary_goals: List[str] = field(default_factory=list)
+    recommended_tools: List[str] = field(default_factory=list)
+    need_urgency: str = "normal"
+    persona_bias: Optional[str] = None
+    decision_vector: Dict[str, float] = field(default_factory=dict)
+    narrative: str = ""
+    confidence: float = 0.6
+
+
+class CognitiveReasoner:
+    """Derive human-like decision scaffolding from routing signals."""
+
+    def evaluate(
+        self,
+        request: RouteRequest,
+        analysis: TaskAnalysis,
+        profile: Optional[UserProfile],
+    ) -> RoutingCognition:
+        context = request.context or {}
+        user_need = analysis.user_need_state or {}
+        urgency = user_need.get("urgency", "normal")
+        affect = user_need.get("affect", "neutral")
+
+        persona = None
+        if isinstance(context.get("persona"), str):
+            persona = context["persona"]
+        elif isinstance(context.get("user_persona"), str):
+            persona = context["user_persona"]
+        elif profile and profile.khrp_config:
+            persona = profile.khrp_config.get("persona")
+
+        secondary_goals = []
+        secondary_hints = analysis.hints.get("secondary_tasks") if analysis.hints else []
+        if isinstance(secondary_hints, list):
+            secondary_goals = [str(goal) for goal in secondary_hints if goal and goal != analysis.task_type]
+
+        tool_bias = analysis.tool_intents or []
+        context_tools = []
+        suggested = context.get("tool_suggestions") or context.get("tools")
+        if isinstance(suggested, (list, tuple)):
+            context_tools = [str(tool).lower() for tool in suggested if isinstance(tool, str)]
+
+        recommended_tools = []
+        for tool in tool_bias + context_tools:
+            if tool not in recommended_tools:
+                recommended_tools.append(tool)
+
+        contributions: Dict[str, float] = {}
+        # Conscious focus weight is tied to analysis confidence
+        contributions["task_weight"] = max(0.2, min(0.6, analysis.confidence))
+
+        # Urgency modulates executive focus (System 1 override)
+        if urgency == "high":
+            contributions["urgency_weight"] = 0.45
+        elif urgency == "elevated":
+            contributions["urgency_weight"] = 0.25
+        else:
+            contributions["urgency_weight"] = 0.12
+
+        # Affect influences need for supportive reasoning providers
+        if affect in {"stressed", "frustrated"}:
+            contributions["affect_weight"] = 0.2
+        elif affect == "curious":
+            contributions["affect_weight"] = 0.15
+        else:
+            contributions["affect_weight"] = 0.08
+
+        # Tool alignment fosters distributed cognition
+        contributions["tool_alignment"] = 0.18 if recommended_tools else 0.05
+
+        # Persona bias shifts style preference (e.g., creative vs. analytical)
+        contributions["persona_alignment"] = 0.16 if persona else 0.07
+
+        total = sum(contributions.values()) or 1.0
+        decision_vector = {k: round(v / total, 3) for k, v in contributions.items()}
+
+        narrative_fragments: List[str] = [
+            f"goal={analysis.task_type}",
+            f"urgency={urgency}",
+            f"affect={affect}",
+        ]
+        if secondary_goals:
+            narrative_fragments.append(f"secondary={','.join(secondary_goals)}")
+        if recommended_tools:
+            narrative_fragments.append(f"tools={','.join(recommended_tools)}")
+        if persona:
+            narrative_fragments.append(f"persona={persona}")
+
+        narrative = "; ".join(narrative_fragments)
+
+        confidence = min(0.98, max(0.5, analysis.confidence + decision_vector.get("urgency_weight", 0.0) * 0.3))
+
+        return RoutingCognition(
+            primary_goal=analysis.task_type,
+            secondary_goals=secondary_goals,
+            recommended_tools=recommended_tools,
+            need_urgency=urgency,
+            persona_bias=persona,
+            decision_vector=decision_vector,
+            narrative=narrative,
+            confidence=confidence,
+        )

--- a/src/ai_karen_engine/routing/kire_router.py
+++ b/src/ai_karen_engine/routing/kire_router.py
@@ -1,28 +1,36 @@
-"""
-KIRE Router - intelligent LLM routing that integrates with existing LLMRegistry.
-"""
+"""KIRE Router - intelligent LLM routing that integrates with existing LLMRegistry."""
 from __future__ import annotations
-import time
+
 import hashlib
 import json
+import logging
+import time
+from dataclasses import asdict
 from typing import Any, Dict, List, Optional
 
 from ai_karen_engine.core.cache import MemoryCache, get_request_deduplicator
 from ai_karen_engine.monitoring.kire_metrics import (
-    KIRE_DECISIONS_TOTAL,
     KIRE_CACHE_EVENTS_TOTAL,
+    KIRE_DECISION_CONFIDENCE,
+    KIRE_DECISIONS_TOTAL,
     KIRE_LATENCY_SECONDS,
+    KIRE_PROVIDER_SELECTION_TOTAL,
 )
 
 # Use shared MemoryCache impl to align with CopilotKit infra
 _cache = MemoryCache(max_size=2048, default_ttl=300)
 _cache_index: Dict[str, set] = {}
+_provider_cache_index: Dict[str, set] = {}
+_cache_owner: Dict[str, Dict[str, str]] = {}
 _deduper = get_request_deduplicator()
+
+logger = logging.getLogger(__name__)
 
 from ai_karen_engine.routing.types import RouteRequest, RouteDecision
 from ai_karen_engine.routing.profile_resolver import ProfileResolver
 from ai_karen_engine.routing.decision_logger import DecisionLogger
-from ai_karen_engine.integrations.task_analyzer import TaskAnalyzer
+from ai_karen_engine.integrations.task_analyzer import TaskAnalyzer, TaskAnalysis
+from ai_karen_engine.routing.cognitive_reasoner import CognitiveReasoner, RoutingCognition
 
 # Import existing components
 try:
@@ -30,9 +38,25 @@ try:
 except ImportError:
     # Fallback if provider status not available
     class ProviderHealth:
+        """Conservative provider health fallback when status integration is missing."""
+
+        SOURCE = "fallback"
+        HAS_BACKEND = False
+        _warned = False
+
+        @classmethod
+        def _warn(cls) -> None:
+            if cls._warned:
+                return
+            logger.warning(
+                "Provider health integration missing; enforcing degraded routing mode"
+            )
+            cls._warned = True
+
         @staticmethod
         async def is_healthy(provider: str) -> bool:
-            return True  # Assume healthy for now
+            ProviderHealth._warn()
+            return False
 
 try:
     from ai_karen_engine.core.degraded_mode import DegradedMode
@@ -53,6 +77,7 @@ class KIRERouter:
         self.profile_resolver = ProfileResolver()
         self.logger = DecisionLogger()
         self.task_analyzer = TaskAnalyzer()
+        self.cognitive_reasoner = CognitiveReasoner()
     
     async def route_provider_selection(self, request: RouteRequest) -> RouteDecision:
         """Main routing method - returns routing decision."""
@@ -87,18 +112,30 @@ class KIRERouter:
                 profile, request.task_type, request.khrp_step
             )
             # Analyze query for task hints/capabilities
-            analysis = self.task_analyzer.analyze(request.query, context=request.context)
-            task_type = request.task_type or analysis.task_type
+            analysis = self.task_analyzer.analyze(
+                request.query,
+                user_ctx={"roles": (request.context or {}).get("user_roles", [])},
+                context=request.context,
+            )
+            cognition = self.cognitive_reasoner.evaluate(request, analysis, profile)
+            task_type = request.task_type or cognition.primary_goal or analysis.task_type
 
             # Start from profile assignment or default config
             provider = assignment.provider if assignment else "openai"
             model = assignment.model if assignment else "gpt-4o-mini"
             chain = profile.fallback_chain if profile else ["openai", "deepseek", "llamacpp"]
-            
+
             async def _decide():
                 # Apply capability/constraint matching and health checks
                 return await self._refine_by_requirements(
-                    provider, model, request, chain, analysis.required_capabilities, task_type
+                    provider,
+                    model,
+                    request,
+                    chain,
+                    analysis.required_capabilities,
+                    task_type,
+                    analysis,
+                    cognition,
                 )
 
             # Deduplicate identical in-flight routing decisions (same cache key)
@@ -118,14 +155,24 @@ class KIRERouter:
                 )
                 KIRE_DECISIONS_TOTAL.labels(status="error", task_type=request.task_type or "chat").inc()
                 KIRE_LATENCY_SECONDS.labels(task_type=request.task_type or "chat").observe((time.perf_counter() - t0))
+                KIRE_PROVIDER_SELECTION_TOTAL.labels(
+                    provider=provider,
+                    model=model,
+                    status="error",
+                    task_type=request.task_type or "chat",
+                ).inc()
             except Exception:
                 pass
             raise
         
+        confidence_bucket = self._confidence_bucket(conf)
+        reasoning_trace = reason
+        if cognition.narrative and cognition.narrative not in reason:
+            reasoning_trace = f"{reason}; {cognition.narrative}" if reason else cognition.narrative
         decision = RouteDecision(
             provider=provider,
             model=model,
-            reasoning=reason,
+            reasoning=reasoning_trace,
             confidence=conf,
             fallback_chain=chain,
             metadata={
@@ -135,19 +182,20 @@ class KIRERouter:
                     "required_capabilities": analysis.required_capabilities,
                     "confidence": analysis.confidence,
                     "step_hint": analysis.khrp_step_hint,
+                    "tool_intents": analysis.tool_intents,
+                    "user_need_state": analysis.user_need_state,
                 },
-                "execution_time_ms": (time.perf_counter() - t0) * 1000
+                "cognition": asdict(cognition),
+                "confidence_bucket": confidence_bucket,
+                "health_source": getattr(ProviderHealth, "SOURCE", "live"),
+                "execution_time_ms": (time.perf_counter() - t0) * 1000,
             }
         )
         
         # Cache only high-confidence, non-dynamic steps
         if conf >= 0.8 and request.khrp_step not in ("evidence_gathering", "tool_execution"):
             _cache.set(cache_key, decision)
-            # index by user for targeted invalidation
-            try:
-                _cache_index.setdefault(request.user_id, set()).add(cache_key)
-            except Exception:
-                pass
+            self._register_cache_entry(cache_key, decision.provider, request.user_id)
             KIRE_CACHE_EVENTS_TOTAL.labels(event="store").inc()
         
         # Log decision
@@ -164,69 +212,132 @@ class KIRERouter:
         try:
             KIRE_DECISIONS_TOTAL.labels(status="success", task_type=request.task_type or "chat").inc()
             KIRE_LATENCY_SECONDS.labels(task_type=request.task_type or "chat").observe((time.perf_counter() - t0))
+            KIRE_PROVIDER_SELECTION_TOTAL.labels(
+                provider=decision.provider,
+                model=decision.model,
+                status="success",
+                task_type=request.task_type or "chat",
+            ).inc()
+            KIRE_DECISION_CONFIDENCE.labels(
+                task_type=request.task_type or "chat",
+                provider=decision.provider,
+                model=decision.model,
+            ).observe(decision.confidence)
         except Exception:
             pass
         
         return decision
     
-    async def _refine_by_requirements(self, provider: str, model: str, 
-                                    req: RouteRequest, chain: List[str], required_caps: List[str], inferred_task: str) -> tuple[str, str, str, float]:
+    async def _refine_by_requirements(
+        self,
+        provider: str,
+        model: str,
+        req: RouteRequest,
+        chain: List[str],
+        required_caps: List[str],
+        inferred_task: str,
+        analysis: TaskAnalysis,
+        cognition: RoutingCognition,
+    ) -> tuple[str, str, str, float]:
         """Refine provider/model selection based on requirements and health."""
-        # KHRP step-specific preferences
+
+        reason_segments: List[str] = []
+
+        # Ensure provider supports required capabilities or tool intents
+        if not self.task_analyzer.provider_supports(provider, required_caps):
+            reason_segments.append(f"{provider} lacks capabilities {required_caps}")
+            for alt in chain:
+                if alt == provider:
+                    continue
+                if self.task_analyzer.provider_supports(alt, required_caps) and await ProviderHealth.is_healthy(alt):
+                    provider, model = alt, self._default_model(alt)
+                    reason_segments.append(f"switching to {alt} for capabilities")
+                    break
+
+        # KHRP step-specific preferences emphasise deliberate reasoning
         if req.khrp_step in ("reasoning_core",):
-            # Prefer models that are stronger in reasoning if available
             preferred = [("openai", "gpt-4o"), ("deepseek", "deepseek-chat")]
             for prov, mod in preferred:
                 if await ProviderHealth.is_healthy(prov):
                     provider, model = prov, mod
+                    reason_segments.append(f"reasoning_core prefers {prov}/{mod}")
                     break
+
+        # Human-like urgency bias: escalate to reliable providers under stress
+        if cognition.need_urgency == "high" and provider != "openai":
+            if await ProviderHealth.is_healthy("openai"):
+                provider, model = "openai", "gpt-4o"
+                reason_segments.append("high urgency escalated to openai/gpt-4o")
+        elif cognition.need_urgency == "elevated" and provider == "llamacpp":
+            if await ProviderHealth.is_healthy("deepseek"):
+                provider, model = "deepseek", "deepseek-chat"
+                reason_segments.append("elevated urgency upgraded to deepseek")
+
+        # Tool affordance routing for distributed cognition
+        tool_bias = set((analysis.tool_intents or []) + (cognition.recommended_tools or []))
+        if "web_browse" in tool_bias and provider not in {"openai", "huggingface"}:
+            if await ProviderHealth.is_healthy("openai"):
+                provider, model = "openai", "gpt-4o-mini"
+                reason_segments.append("web browsing preference -> openai with tool calling")
+        if "code_execution" in tool_bias and provider != "deepseek":
+            if await ProviderHealth.is_healthy("deepseek"):
+                provider, model = "deepseek", "deepseek-coder"
+                reason_segments.append("code execution intent -> deepseek coder")
 
         # Task/capability-specific steering
         if "embeddings" in required_caps:
             if await ProviderHealth.is_healthy("huggingface"):
                 provider, model = "huggingface", "sentence-transformers/all-MiniLM-L6-v2"
-        elif inferred_task == "summarization":
+                reason_segments.append("embedding capability -> huggingface transformers")
+        elif inferred_task == "summarization" and provider != "llamacpp":
             if await ProviderHealth.is_healthy("llamacpp"):
                 provider, model = "llamacpp", "tinyllama-1.1b-chat-v2.0.Q4_K_M.gguf"
+                reason_segments.append("summarization uses llamacpp low-latency")
 
         # Health gate on chosen provider
-        if not await ProviderHealth.is_healthy(provider):
-            reason = f"{provider} unhealthy; selecting fallback"
-            
-            # Try fallback chain
+        health_source = getattr(ProviderHealth, "SOURCE", "live")
+        provider_healthy = await ProviderHealth.is_healthy(provider)
+        if not provider_healthy:
+            reason_segments.append(f"{provider} reported unhealthy")
+            if health_source == "fallback":
+                reason = "; ".join(reason_segments + ["provider health unavailable; entering degraded mode"])
+            else:
+                reason = "; ".join(reason_segments + [f"{provider} unhealthy; selecting fallback"])
+
             for fb in chain:
                 if await ProviderHealth.is_healthy(fb):
-                    return fb, self._default_model(fb), reason, 0.75
-            
-            # Final degraded mode
+                    return fb, self._default_model(fb), reason, max(0.68, cognition.confidence * 0.8)
+
             degraded_provider, degraded_model = DegradedMode.get_fallback_provider()
-            return degraded_provider, degraded_model, "degraded-mode", 0.6
-        
+            return degraded_provider, degraded_model, reason, 0.55
+
         # Apply task-specific optimizations
         if inferred_task == "code" and provider == "openai":
-            # Prefer deepseek for coding tasks
             if await ProviderHealth.is_healthy("deepseek"):
-                return "deepseek", "deepseek-coder", "optimized for coding", 0.95
+                reason_segments.append("code task optimized with deepseek coder")
+                return "deepseek", "deepseek-coder", "; ".join(reason_segments), min(0.96, max(0.9, cognition.confidence))
 
         # Cost gate (simple heuristic)
         max_cost = req.requirements.get("max_cost_per_call") if req.requirements else None
         if max_cost is not None:
             est_cost = self._estimate_cost(provider, model, req)
             if est_cost is not None and est_cost > max_cost:
-                # Try cheaper alternatives in chain
                 for alt in chain:
                     if not await ProviderHealth.is_healthy(alt):
                         continue
                     alt_model = self._default_model(alt)
                     alt_cost = self._estimate_cost(alt, alt_model, req)
                     if alt_cost is not None and alt_cost <= max_cost:
-                        return alt, alt_model, f"cost gate: {provider}/{model}->{alt}/{alt_model}", 0.82
-                # Keep selection but lower confidence and flag cost breach
-                return provider, model, "over_cost_budget; using profile selection", 0.75
-        
-        # Default: use profile assignment
-        reason = f"profile assignment for {inferred_task}"
-        return provider, model, reason, 0.9
+                        reason_segments.append(
+                            f"cost gate reroute {provider}/{model} -> {alt}/{alt_model}"
+                        )
+                        return alt, alt_model, "; ".join(reason_segments), min(0.85, cognition.confidence)
+                reason_segments.append("over cost budget; honoring profile selection")
+                return provider, model, "; ".join(reason_segments), min(0.78, cognition.confidence)
+
+        base_confidence = max(0.82, min(0.95, cognition.confidence + analysis.confidence * 0.1))
+        reason_segments.append(f"profile assignment for {inferred_task}")
+        return provider, model, "; ".join(reason_segments), base_confidence
     
     def _default_model(self, provider: str) -> str:
         """Get default model for provider."""
@@ -241,10 +352,84 @@ class KIRERouter:
     
     def _generate_cache_key(self, request: RouteRequest) -> str:
         """Generate cache key for routing request."""
-        req_hash = hashlib.md5(
-            json.dumps(request.requirements, sort_keys=True).encode()
-        ).hexdigest()[:8]
-        return f"{request.user_id}:{request.task_type}:{request.khrp_step or 'none'}:{req_hash}"
+        req_hash = self._stable_hash(request.requirements)[:8]
+        query_fingerprint = self._stable_hash({
+            "query": self._normalize_query(request.query),
+            "task": request.task_type,
+        })[:8]
+        context_signature = self._stable_hash(self._context_signature(request.context))[:8]
+        return (
+            f"{request.user_id}:{request.task_type or 'chat'}:{request.khrp_step or 'none'}:"
+            f"{req_hash}:{query_fingerprint}:{context_signature}"
+        )
+
+    @staticmethod
+    def _context_signature(context: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+        if not context:
+            return {}
+        allowed_keys = {
+            "tenant_id",
+            "session_id",
+            "request_metadata",
+            "task_hint",
+            "capability_hints",
+        }
+        signature = {k: context.get(k) for k in allowed_keys if k in context}
+        request_metadata = signature.get("request_metadata")
+        if isinstance(request_metadata, dict):
+            signature["request_metadata"] = {
+                k: request_metadata.get(k)
+                for k in ("correlation_id", "session_id", "tenant_id")
+                if k in request_metadata
+            }
+        return signature
+
+    @staticmethod
+    def _normalize_query(query: str) -> str:
+        return " ".join((query or "").split()).lower()
+
+    @staticmethod
+    def _stable_hash(payload: Any) -> str:
+        try:
+            serialized = json.dumps(payload, sort_keys=True, default=str)
+        except TypeError:
+            serialized = repr(payload)
+        return hashlib.md5(serialized.encode()).hexdigest()
+
+    @staticmethod
+    def _confidence_bucket(confidence: float) -> str:
+        if confidence >= 0.95:
+            return ">=0.95"
+        if confidence >= 0.9:
+            return "0.90-0.95"
+        if confidence >= 0.8:
+            return "0.80-0.89"
+        if confidence >= 0.65:
+            return "0.65-0.79"
+        return "<0.65"
+
+    @staticmethod
+    def _register_cache_entry(cache_key: str, provider: str, user_id: str) -> None:
+        _cache_owner[cache_key] = {"provider": provider, "user_id": user_id}
+        _cache_index.setdefault(user_id, set()).add(cache_key)
+        _provider_cache_index.setdefault(provider, set()).add(cache_key)
+
+    @staticmethod
+    def _evict_cache_key(cache_key: str) -> None:
+        _cache.delete(cache_key)
+        owner = _cache_owner.pop(cache_key, None)
+        if not owner:
+            return
+        user_keys = _cache_index.get(owner["user_id"])
+        if user_keys is not None:
+            user_keys.discard(cache_key)
+            if not user_keys:
+                _cache_index.pop(owner["user_id"], None)
+        provider_keys = _provider_cache_index.get(owner["provider"])
+        if provider_keys is not None:
+            provider_keys.discard(cache_key)
+            if not provider_keys:
+                _provider_cache_index.pop(owner["provider"], None)
 
     def _estimate_cost(self, provider: str, model: str, req: RouteRequest) -> Optional[float]:
         """Very rough per-call cost estimate based on provider defaults.
@@ -268,15 +453,15 @@ def invalidate_user_cache(user_id: str):
     """Invalidate cache entries for a specific user using index."""
     keys = list(_cache_index.get(user_id, set()))
     for k in keys:
-        _cache.delete(k)
-    _cache_index.pop(user_id, None)
+        KIRERouter._evict_cache_key(k)
 
 
 def invalidate_provider_cache(_provider: str):
     """Invalidate routing cache broadly on provider health changes."""
-    # Simple strategy: clear all entries because decisions embed provider choice
-    _cache.clear()
-    _cache_index.clear()
+    keys = list(_provider_cache_index.get(_provider, set()))
+    for k in keys:
+        KIRERouter._evict_cache_key(k)
+    _provider_cache_index.pop(_provider, None)
 
 
 def get_routing_cache_stats() -> Dict[str, Any]:

--- a/tests/integrations/test_task_analyzer.py
+++ b/tests/integrations/test_task_analyzer.py
@@ -1,0 +1,65 @@
+from ai_karen_engine.integrations.task_analyzer import TaskAnalyzer
+
+
+def test_task_analyzer_honors_context_task_hint():
+    analyzer = TaskAnalyzer()
+    analysis = analyzer.analyze(
+        "Please assist with this request",
+        context={"task_hint": "embedding", "requirements": {"capabilities": ["embeddings"]}},
+    )
+
+    assert analysis.task_type == "embedding"
+    assert "embeddings" in analysis.required_capabilities
+    assert analysis.hints.get("task_hint") == "embedding"
+
+
+def test_task_analyzer_uses_role_bias_for_code():
+    analyzer = TaskAnalyzer()
+    analysis = analyzer.analyze(
+        "Need some help",
+        user_ctx={"roles": ["Developer"]},
+        context={},
+    )
+
+    assert analysis.task_type == "code"
+    assert "code" in analysis.required_capabilities
+
+
+def test_task_analyzer_defaults_to_chat_for_low_signal():
+    analyzer = TaskAnalyzer()
+    analysis = analyzer.analyze("Hello", context={})
+
+    assert analysis.task_type in {"chat", "code"}
+    # Should not drop required capabilities for chat fallback
+    if analysis.task_type == "chat":
+        assert analysis.required_capabilities == ["text"]
+
+
+def test_task_analyzer_extracts_tool_intents_and_need_state():
+    analyzer = TaskAnalyzer()
+    analysis = analyzer.analyze(
+        "Urgent: please run this script and check the web docs",
+        context={"tool_suggestions": ["browser"]},
+    )
+
+    assert "code_execution" in analysis.tool_intents
+    assert "web_browse" in analysis.tool_intents
+    assert analysis.user_need_state.get("urgency") in {"high", "elevated"}
+    assert analysis.user_need_state.get("mode") in {"problem_solving", "analysis"}
+
+
+def test_task_analyzer_tracks_secondary_tasks_from_context_history():
+    analyzer = TaskAnalyzer()
+    analysis = analyzer.analyze(
+        "Help summarise",
+        context={
+            "conversation_history": [
+                {"role": "user", "content": "also need reasoning about implications"},
+            ]
+        },
+    )
+
+    assert analysis.task_type == "reasoning"
+    assert analysis.user_need_state.get("mode") == "analysis"
+    if analysis.hints.get("secondary_tasks"):
+        assert analysis.task_type not in analysis.hints["secondary_tasks"]

--- a/tests/routing/test_cognitive_reasoner.py
+++ b/tests/routing/test_cognitive_reasoner.py
@@ -1,0 +1,46 @@
+from ai_karen_engine.integrations.task_analyzer import TaskAnalysis
+from ai_karen_engine.routing.cognitive_reasoner import CognitiveReasoner
+from ai_karen_engine.routing.types import RouteRequest
+
+
+def test_cognitive_reasoner_honors_tool_bias_and_urgency():
+    reasoner = CognitiveReasoner()
+    request = RouteRequest(user_id="u1", task_type="chat", query="Run code now")
+    analysis = TaskAnalysis(
+        task_type="code",
+        required_capabilities=["code"],
+        hints={"secondary_tasks": ["reasoning"]},
+        confidence=0.82,
+        tool_intents=["code_execution", "web_browse"],
+        user_need_state={"urgency": "high", "affect": "stressed", "mode": "problem_solving"},
+    )
+
+    cognition = reasoner.evaluate(request, analysis, profile=None)
+
+    assert cognition.primary_goal == "code"
+    assert "code_execution" in cognition.recommended_tools
+    assert cognition.need_urgency == "high"
+    assert "secondary=reasoning" in cognition.narrative
+    assert cognition.decision_vector["urgency_weight"] > cognition.decision_vector["affect_weight"]
+
+
+def test_cognitive_reasoner_infers_persona_from_context():
+    reasoner = CognitiveReasoner()
+    request = RouteRequest(
+        user_id="u2",
+        task_type="chat",
+        query="Just curious",
+        context={"persona": "creative"},
+    )
+    analysis = TaskAnalysis(
+        task_type="chat",
+        required_capabilities=["text"],
+        confidence=0.6,
+        tool_intents=[],
+        user_need_state={"urgency": "normal", "affect": "curious", "mode": "informational"},
+    )
+
+    cognition = reasoner.evaluate(request, analysis, profile=None)
+
+    assert cognition.persona_bias == "creative"
+    assert cognition.decision_vector["persona_alignment"] >= 0.1

--- a/tests/routing/test_kire_router_cache.py
+++ b/tests/routing/test_kire_router_cache.py
@@ -1,0 +1,74 @@
+import asyncio
+from unittest.mock import patch
+
+from ai_karen_engine.routing import kire_router
+from ai_karen_engine.routing.kire_router import KIRERouter
+from ai_karen_engine.routing.types import RouteRequest
+
+
+def test_cache_key_includes_query_context_signature():
+    router = KIRERouter()
+    base_request = RouteRequest(
+        user_id="user-1",
+        task_type="chat",
+        query="Summarize the doc",
+        requirements={"priority": "high"},
+        context={"tenant_id": "t1", "request_metadata": {"correlation_id": "abc"}},
+    )
+    key_one = router._generate_cache_key(base_request)
+
+    key_two = router._generate_cache_key(
+        RouteRequest(
+            user_id="user-1",
+            task_type="chat",
+            query="Summarize the financial document",
+            requirements={"priority": "high"},
+            context={"tenant_id": "t1", "request_metadata": {"correlation_id": "abc"}},
+        )
+    )
+
+    different_context = router._generate_cache_key(
+        RouteRequest(
+            user_id="user-1",
+            task_type="chat",
+            query="Summarize the doc",
+            requirements={"priority": "high"},
+            context={"tenant_id": "t2", "request_metadata": {"correlation_id": "abc"}},
+        )
+    )
+
+    assert key_one != key_two, "Cache key must change when query text changes"
+    assert key_one != different_context, "Cache key must change when routing context changes"
+
+
+async def _run_health_fallback(router: KIRERouter) -> tuple[str, str, str, float]:
+    req = RouteRequest(user_id="user-2", task_type="chat", query="hi")
+    analysis = router.task_analyzer.analyze(req.query, context=req.context)
+    cognition = router.cognitive_reasoner.evaluate(req, analysis, profile=None)
+    return await router._refine_by_requirements(
+        provider="openai",
+        model="gpt-4o",
+        req=req,
+        chain=["openai", "deepseek"],
+        required_caps=["text"],
+        inferred_task="chat",
+        analysis=analysis,
+        cognition=cognition,
+    )
+
+
+def test_provider_health_fallback_degrades():
+    router = KIRERouter()
+
+    class ConservativeHealth:
+        SOURCE = "fallback"
+
+        @staticmethod
+        async def is_healthy(provider: str) -> bool:
+            return False
+
+    with patch.object(kire_router, "ProviderHealth", ConservativeHealth):
+        provider, model, reason, confidence = asyncio.run(_run_health_fallback(router))
+
+    assert "health unavailable" in reason
+    assert confidence <= 0.55

--- a/tests/routing/test_routing_actions.py
+++ b/tests/routing/test_routing_actions.py
@@ -1,0 +1,44 @@
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from ai_karen_engine.routing import actions as routing_actions
+from ai_karen_engine.routing.types import RouteDecision
+
+
+def test_routing_select_requires_rbac_guard():
+    routing_actions._rate_limit_counters.clear()
+    with pytest.raises(PermissionError):
+        asyncio.run(routing_actions.routing_select_handler({}, "hello", context={}))
+
+
+def test_routing_select_rate_limit():
+    routing_actions._rate_limit_counters.clear()
+
+    with patch.object(routing_actions, "_RATE_LIMIT_MAX_CALLS", 2, create=True), patch.object(
+        routing_actions, "_RATE_LIMIT_WINDOW_SECONDS", 3600, create=True
+    ), patch.object(
+        routing_actions._router,
+        "route_provider_selection",
+        AsyncMock(
+            return_value=RouteDecision(
+                provider="openai",
+                model="gpt-4o-mini",
+                reasoning="mock",
+                confidence=0.9,
+                fallback_chain=["openai"],
+                metadata={},
+            )
+        ),
+    ):
+        user_ctx = {"user_id": "test-user", "roles": ["routing"]}
+        query = "Help me"
+        context = {"requirements": {}}
+
+        asyncio.run(routing_actions.routing_select_handler(user_ctx, query, context=context))
+        asyncio.run(routing_actions.routing_select_handler(user_ctx, query, context=context))
+        with pytest.raises(PermissionError):
+            asyncio.run(routing_actions.routing_select_handler(user_ctx, query, context=context))
+
+    routing_actions._rate_limit_counters.clear()


### PR DESCRIPTION
## Summary
- enrich the task analyzer with tool-intent recognition, affect sensing, and conversation history boosts so routing can infer user needs and problem-solving urgency
- introduce a cognitive reasoner that synthesizes analyzer signals into human-like decision vectors and integrate it into KIRERouter to steer providers by urgency, tools, and capability alignment
- add regression tests for the analyzer enhancements, the cognitive reasoner, and updated routing fallback behavior

## Testing
- python -m pytest -o addopts='' tests/integrations/test_task_analyzer.py tests/routing/test_kire_router_cache.py tests/routing/test_cognitive_reasoner.py tests/routing/test_routing_actions.py

------
https://chatgpt.com/codex/tasks/task_e_68d82dce77f083248bc0bd1f82f1c977