### PR TITLE
Optimize startup by reusing Settings and caching database_config

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -92,10 +92,7 @@ def create_app() -> FastAPI:
     # Load configuration (environment loading is handled in config module)
     settings = Settings()
     environment = settings.environment.lower()
-
-    # Environment loading is handled in config module
-    settings = Settings()
-    environment = settings.environment.lower()
+    app_settings = settings
     # Load performance configuration
     load_performance_settings(settings)
 
@@ -120,6 +117,7 @@ def create_app() -> FastAPI:
         redoc_url="/redoc" if settings.environment != "production" else None,
         lifespan=lifespan,
     )
+    app.state.settings = app_settings
 
     # Configure middleware
     configure_middleware(app, settings, REQUEST_COUNT, REQUEST_LATENCY, ERROR_COUNT)

--- a/server/startup.py
+++ b/server/startup.py
@@ -22,15 +22,22 @@ def register_startup_tasks(app: FastAPI) -> None:
     # Store database availability state in app
     app.state.database_available = False
 
+    def _get_settings() -> Settings:
+        settings = getattr(app.state, "settings", None)
+        if settings is None:
+            settings = Settings()
+            app.state.settings = settings
+        return settings
+
     @app.on_event("startup")
     async def _init_database_config() -> None:
         """Initialize database configuration with enhanced settings"""
         try:
             from .database_config import get_database_config
-            from .config import Settings
 
-            settings = Settings()
+            settings = _get_settings()
             db_config = get_database_config(settings)
+            app.state.database_config = db_config
 
             # Initialize database with enhanced configuration
             success = await db_config.initialize_database()
@@ -97,12 +104,11 @@ def register_startup_tasks(app: FastAPI) -> None:
             return
 
         try:
-            from .config import Settings
             from ai_karen_engine.extensions.platform.core.registry.database_service import (
                 initialize_database_service,
             )
 
-            settings = Settings()
+            settings = _get_settings()
             database_url = settings.database_url
 
             # Initialize extension database service
@@ -131,12 +137,11 @@ def register_startup_tasks(app: FastAPI) -> None:
             from .enhanced_database_health_monitor import (
                 get_enhanced_database_health_monitor,
             )
-            from .config import Settings
 
-            settings = Settings()
+            settings = _get_settings()
 
             # Get existing components for integration
-            database_config = get_database_config(settings)
+            database_config = getattr(app.state, "database_config", None) or get_database_config(settings)
             enhanced_health_monitor = get_enhanced_database_health_monitor()
 
             # Get extension manager if available


### PR DESCRIPTION
### Motivation
- Startup was performing repeated environment parsing and object construction (multiple `Settings()` instances and redundant database config acquisition), increasing boot time and resource usage.
- Centralizing and reusing configuration objects reduces wasted work during startup and makes readiness faster and more efficient.

### Description
- Persist the already-created `Settings()` instance on `app.state.settings` during `create_app()` so downstream code can reuse it instead of re-instantiating `Settings()`.
- Add a startup-local helper `_get_settings()` in `register_startup_tasks()` that returns the cached `app.state.settings` or lazily creates and stores one if missing, and replace direct `Settings()` calls with `_get_settings()`.
- Cache the resolved `database_config` on `app.state.database_config` after initialization and reuse it in the extension service recovery setup to avoid redundant `get_database_config()` calls.

### Testing
- Ran `python -m compileall server/app.py server/startup.py` and byte-compilation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3b15330d88324abedfe2d617f8221)