### PR TITLE
Defer DB initialization to startup, expose Settings on app.state, and add production audit script

### DIFF
--- a/scripts/production_chat_runtime_audit.sh
+++ b/scripts/production_chat_runtime_audit.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+echo "== Python compile =="
+python -m compileall src
+
+echo "== Backend lint/static =="
+if command -v ruff >/dev/null 2>&1; then
+  ruff check src tests
+else
+  echo "ruff not installed; skipping"
+fi
+
+if command -v mypy >/dev/null 2>&1; then
+  mypy src
+else
+  echo "mypy not installed; skipping"
+fi
+
+echo "== Architecture smell scan =="
+grep -R "mock\|dummy\|placeholder\|fake\|demo data" src tests -n || true
+grep -R "llamacpp\|llama_cpp\|llama-cpp\|llama.cpp\|local_gguf" src tests -n || true
+grep -R "hardcoded\|TODO\|FIXME" src tests -n || true
+
+echo "== Route-level forbidden logic scan =="
+grep -R "select.*provider\|fallback\|build_prompt\|memory_recall\|execute_plugin" src/ai_karen_engine/api src/ai_karen_engine/copilotkit -n || true
+
+echo "== UI forbidden truth ownership scan =="
+if [ -d "src/ui_launchers/Karen-AI-Theme" ]; then
+  grep -R "mock\|fake\|placeholder\|admin@example.com\|local_gguf\|llamacpp\|llama_cpp" src/ui_launchers/Karen-AI-Theme/src -n || true
+  cd src/ui_launchers/Karen-AI-Theme
+  npm run lint
+  npm run typecheck
+  npm run test
+  npm run build
+  cd "$ROOT"
+fi
+
+echo "== Backend tests =="
+pytest tests/ -q
+
+echo "== Docker compose validation =="
+docker compose config >/tmp/ai-karen-compose.yml
+if [ -f "docker-compose.cuda.yml" ]; then
+  docker compose -f docker-compose.cuda.yml config >/tmp/ai-karen-compose-cuda.yml
+fi
+
+echo "Production chat runtime audit complete."

--- a/server/app.py
+++ b/server/app.py
@@ -41,7 +41,6 @@ from .middleware import configure_middleware
 from .performance import load_performance_settings
 from .routers import wire_routers
 from .startup import create_lifespan, register_startup_tasks
-from .database_config import get_database_config, database_lifespan
 from .admin_endpoints import register_admin_endpoints
 from .health_endpoints import register_health_endpoints
 from .security import validate_environment_security
@@ -91,11 +90,6 @@ def create_app() -> FastAPI:
 
     # Load configuration (environment loading is handled in config module)
     settings = Settings()
-    environment = settings.environment.lower()
-
-    # Environment loading is handled in config module
-    settings = Settings()
-    environment = settings.environment.lower()
     # Load performance configuration
     load_performance_settings(settings)
 
@@ -108,9 +102,6 @@ def create_app() -> FastAPI:
     # Create lifespan manager with database configuration
     lifespan = create_lifespan(settings)
 
-    # Initialize database configuration
-    db_config = get_database_config(settings)
-
     # Create FastAPI app
     app = FastAPI(
         title="Kari AI Assistant API",
@@ -120,6 +111,7 @@ def create_app() -> FastAPI:
         redoc_url="/redoc" if settings.environment != "production" else None,
         lifespan=lifespan,
     )
+    app.state.settings = settings
 
     # Configure middleware
     configure_middleware(app, settings, REQUEST_COUNT, REQUEST_LATENCY, ERROR_COUNT)

--- a/server/startup.py
+++ b/server/startup.py
@@ -22,15 +22,22 @@ def register_startup_tasks(app: FastAPI) -> None:
     # Store database availability state in app
     app.state.database_available = False
 
+    def _get_settings() -> Settings:
+        settings = getattr(app.state, "settings", None)
+        if settings is None:
+            settings = Settings()
+            app.state.settings = settings
+        return settings
+
     @app.on_event("startup")
     async def _init_database_config() -> None:
         """Initialize database configuration with enhanced settings"""
         try:
             from .database_config import get_database_config
-            from .config import Settings
 
-            settings = Settings()
+            settings = _get_settings()
             db_config = get_database_config(settings)
+            app.state.database_config = db_config
 
             # Initialize database with enhanced configuration
             success = await db_config.initialize_database()
@@ -97,12 +104,11 @@ def register_startup_tasks(app: FastAPI) -> None:
             return
 
         try:
-            from .config import Settings
             from ai_karen_engine.extensions.platform.core.registry.database_service import (
                 initialize_database_service,
             )
 
-            settings = Settings()
+            settings = _get_settings()
             database_url = settings.database_url
 
             # Initialize extension database service
@@ -131,12 +137,11 @@ def register_startup_tasks(app: FastAPI) -> None:
             from .enhanced_database_health_monitor import (
                 get_enhanced_database_health_monitor,
             )
-            from .config import Settings
 
-            settings = Settings()
+            settings = _get_settings()
 
             # Get existing components for integration
-            database_config = get_database_config(settings)
+            database_config = getattr(app.state, "database_config", None) or get_database_config(settings)
             enhanced_health_monitor = get_enhanced_database_health_monitor()
 
             # Get extension manager if available


### PR DESCRIPTION
### Motivation
- Allow the FastAPI app to be instantiated without immediate DB connectivity and enable graceful degradation and extension recovery by moving DB setup to startup tasks.
- Make `Settings` available to all startup tasks and extension components via `app.state` to avoid repeated construction and inconsistent config sources.
- Provide a reproducible production runtime audit that validates code, linters, types, tests, and Docker compose for CI/ops checks.

### Description
- Removed eager database config initialization from `create_app` and set `app.state.settings` after app creation so startup tasks can reuse it.
- Added `scripts/production_chat_runtime_audit.sh` to run `python -m compileall`, conditional `ruff`/`mypy`, architecture scans, optional UI `npm` lint/typecheck/test/build, `pytest tests/ -q`, and `docker compose config` validations.
- Introduced `_get_settings()` in `server/startup.py` and moved DB initialization into an `@app.on_event("startup")` handler that sets `app.state.database_config` and `app.state.database_available` and calls `initialize_database()` and `setup_graceful_shutdown()`.
- Updated extension-related startup handlers to use `app.state.settings` and `app.state.database_config` (or fall back to `get_database_config(settings)`) and to skip initialization when DB is unavailable.

### Testing
- Ran bytecode verification with `python -m compileall` via the new audit script, which completed successfully.
- Executed unit tests with `pytest tests/ -q` as part of the audit script, which passed.
- Performed Docker compose validation with `docker compose config` from the audit script, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3b15330d88324abedfe2d617f8221)