### PR TITLE
Unify chat/websocket/copilot orchestrator access through ChatRuntimeService

### DIFF
--- a/server/__tests__/unit/test_chat_runtime_entrypoint_routing.py
+++ b/server/__tests__/unit/test_chat_runtime_entrypoint_routing.py
@@ -1,0 +1,45 @@
+import pytest
+
+
+class _RuntimeStub:
+    def __init__(self):
+        self.calls = 0
+
+    async def get_orchestrator(self):
+        self.calls += 1
+        return object()
+
+
+@pytest.mark.asyncio
+async def test_runtime_route_uses_canonical_runtime_entrypoint(monkeypatch):
+    from ai_karen_engine.api_routes.chat import runtime as runtime_route
+
+    stub = _RuntimeStub()
+    monkeypatch.setattr(runtime_route, "get_chat_runtime_service", lambda: stub)
+
+    result = await runtime_route.get_chat_orchestrator()
+    assert result is not None
+    assert stub.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_websocket_gateway_uses_canonical_runtime_entrypoint():
+    from ai_karen_engine.api_routes.chat import websocket as websocket_route
+
+    stub = _RuntimeStub()
+
+    gateway = await websocket_route.get_websocket_gateway(runtime_service=stub)
+    assert gateway is not None
+    assert stub.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_copilot_route_uses_canonical_runtime_entrypoint(monkeypatch):
+    from ai_karen_engine.api_routes.chat import copilot as copilot_route
+
+    stub = _RuntimeStub()
+    monkeypatch.setattr(copilot_route, "get_chat_runtime_service", lambda: stub)
+
+    result = await copilot_route._get_chat_orchestrator()
+    assert result is not None
+    assert stub.calls == 1

--- a/src/ai_karen_engine/api_routes/chat/copilot.py
+++ b/src/ai_karen_engine/api_routes/chat/copilot.py
@@ -591,13 +591,11 @@ from ai_karen_engine.utils.chat_helpers import (
 
 
 async def _get_chat_orchestrator():
-    """Return the LangGraphOrchestrator for processing chat requests."""
+    """Return orchestrator via canonical chat runtime service."""
     try:
-        from ai_karen_engine.core.langgraph_orchestrator import get_default_orchestrator
-
         timeout_seconds = float(os.getenv("KAREN_COPILOT_ORCHESTRATOR_TIMEOUT", "5"))
         orchestrator = await asyncio.wait_for(
-            get_default_orchestrator(),
+            get_chat_runtime_service().get_orchestrator(),
             timeout=timeout_seconds,
         )
         logger.info(

--- a/src/ai_karen_engine/api_routes/chat/runtime.py
+++ b/src/ai_karen_engine/api_routes/chat/runtime.py
@@ -34,7 +34,6 @@ from ai_karen_engine.core.runtime.chat_runtime_control_plane import (
     runtime_response_http_status,
 )
 from ai_karen_engine.core.runtime.chat_runtime_service import get_chat_runtime_service
-from ai_karen_engine.core.langgraph_orchestrator import LangGraphOrchestrator
 from ai_karen_engine.models.shared_types import (
     CanonicalChatRequest,
     CanonicalChatResponse,
@@ -396,10 +395,8 @@ class ChatRuntimeHelper:
 
 # Dependency functions
 async def get_chat_orchestrator():
-    """Get chat orchestrator instance"""
-    from ai_karen_engine.core.langgraph_orchestrator import get_default_orchestrator
-
-    return await get_default_orchestrator()
+    """Get chat orchestrator instance through canonical runtime service."""
+    return await get_chat_runtime_service().get_orchestrator()
 
 
 async def get_stream_processor():

--- a/src/ai_karen_engine/api_routes/chat/websocket.py
+++ b/src/ai_karen_engine/api_routes/chat/websocket.py
@@ -26,7 +26,10 @@ from fastapi import (
 )
 from fastapi.responses import StreamingResponse
 
-from ai_karen_engine.core.langgraph_orchestrator import LangGraphOrchestrator
+from ai_karen_engine.core.runtime.chat_runtime_service import (
+    ChatRuntimeService,
+    get_chat_runtime_service,
+)
 from ai_karen_engine.models.shared_types import CanonicalChatRequest
 from ai_karen_engine.services.streaming.stream_processor import AsyncStreamProcessor
 from ai_karen_engine.services.streaming.websocket_gateway import WebSocketGateway
@@ -57,7 +60,6 @@ logger = logging.getLogger(__name__)
 # Global instances (will be initialized by dependency injection)
 websocket_gateway: Optional[WebSocketGateway] = None
 stream_processor: Optional[AsyncStreamProcessor] = None
-chat_orchestrator: Optional[LangGraphOrchestrator] = None
 
 router = APIRouter(tags=["websocket"])
 
@@ -131,16 +133,15 @@ class StreamMetricsResponse(BaseModel):
 
 
 # Dependency injection functions
-async def get_chat_orchestrator() -> LangGraphOrchestrator:
-    """Create or return the chat orchestrator instance."""
-    from ai_karen_engine.core.langgraph_orchestrator import get_default_orchestrator
-
-    return await get_default_orchestrator()
+def get_runtime_service() -> ChatRuntimeService:
+    return get_chat_runtime_service()
 
 
-async def get_websocket_gateway() -> WebSocketGateway:
+async def get_websocket_gateway(
+    runtime_service: ChatRuntimeService = Depends(get_runtime_service),
+) -> WebSocketGateway:
     """Get WebSocket gateway instance."""
-    return WebSocketGateway(await get_chat_orchestrator())
+    return WebSocketGateway(await runtime_service.get_orchestrator())
 
 
 def get_stream_processor() -> AsyncStreamProcessor:

--- a/src/ai_karen_engine/core/runtime/chat_runtime_service.py
+++ b/src/ai_karen_engine/core/runtime/chat_runtime_service.py
@@ -16,6 +16,12 @@ class ChatRuntimeService:
         control_plane = await get_chat_runtime_control_plane()
         return await control_plane.get_runtime_response(user_context=user_context)
 
+    async def get_orchestrator(self):
+        """Canonical runtime entrypoint for orchestrator access across routes."""
+        from ai_karen_engine.core.langgraph_orchestrator import get_default_orchestrator
+
+        return await get_default_orchestrator()
+
     async def build_router_fallback_assist_payload(
         self,
         *,


### PR DESCRIPTION
### Motivation
- Centralize route-level orchestration access behind a canonical runtime abstraction so API routes do not import or instantiate deep orchestrators directly. 
- Move provider/model routing and deep orchestration decisions behind the runtime service boundary while preserving control-plane ingress checks at route entry. 

### Description
- Added `ChatRuntimeService.get_orchestrator()` to provide a canonical orchestrator entrypoint for routes (`src/ai_karen_engine/core/runtime/chat_runtime_service.py`).
- Refactored the websocket gateway dependency to accept the runtime service via DI and call `runtime_service.get_orchestrator()` when constructing `WebSocketGateway` (`src/ai_karen_engine/api_routes/chat/websocket.py`).
- Updated the chat runtime route helper to resolve the orchestrator through `get_chat_runtime_service().get_orchestrator()` instead of direct imports (`src/ai_karen_engine/api_routes/chat/runtime.py`).
- Updated the copilot `_get_chat_orchestrator()` helper to use `get_chat_runtime_service().get_orchestrator()` while keeping the timeout and HTTP error handling (`src/ai_karen_engine/api_routes/chat/copilot.py`).
- Added regression unit tests asserting the runtime/chat/websocket/copilot paths use the canonical runtime entrypoint and do not instantiate orchestrators directly (`server/__tests__/unit/test_chat_runtime_entrypoint_routing.py`).

### Testing
- Ran the new unit tests with `pytest -q server/__tests__/unit/test_chat_runtime_entrypoint_routing.py` and observed `3 passed` (with warnings).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3c4b5ebb88324919714c9d1bacae8)