### PR TITLE
Show runtime metadata, receipt, and circuit-breaker warning in chat UI

### DIFF
--- a/src/ui_launchers/Karen-AI-Theme/src/components/chat/ChatInterface.tsx
+++ b/src/ui_launchers/Karen-AI-Theme/src/components/chat/ChatInterface.tsx
@@ -32,6 +32,9 @@ import { useUserPreferences } from './const/userPreferences';
 import { StatusIndicators, MessagesArea, ChatInput } from './interface';
 import AgentActivityPanel from './AgentActivityPanel';
 import DegradedModeBanner from './DegradedModeBanner';
+import RuntimeMetadataPanel from './RuntimeMetadataPanel';
+import RuntimeReceipt from './RuntimeReceipt';
+import CircuitBreakerWarning from './CircuitBreakerWarning';
 
 // Session Management Types
 export interface Session {
@@ -921,6 +924,37 @@ export default function ChatInterface() {
 
   const { applyModelSelection, getSelectableProviders } = useModelSettings();
 
+
+  const latestAssistantMetadata = useMemo(() => {
+    const lastAssistant = [...messages].reverse().find((message) => message.role === 'assistant');
+    const metadata = (lastAssistant?.metadata && typeof lastAssistant.metadata === 'object')
+      ? lastAssistant.metadata as Record<string, unknown>
+      : {};
+    const llm = (metadata.llm && typeof metadata.llm === 'object')
+      ? metadata.llm as Record<string, unknown>
+      : {};
+
+    const asText = (value: unknown): string | undefined =>
+      typeof value === 'string' && value.trim() ? value.trim() : undefined;
+
+    const degradedReason = asText(metadata.reason) || asText(metadata.degraded_reason) || asText(llm.reason);
+
+    return {
+      requestedProvider: asText(llm.requested_provider) || asText(metadata.requested_provider),
+      actualProvider: asText(llm.actual_provider) || asText(llm.provider) || asText(metadata.actual_provider),
+      requestedModel: asText(llm.requested_model) || asText(metadata.requested_model),
+      actualModel: asText(llm.actual_model) || asText(llm.model_id) || asText(metadata.actual_model),
+      runtimeEngine: asText(metadata.execution_path) || asText(llm.runtime_engine),
+      fallbackLevel: asText(llm.fallback_level),
+      correlationId: asText(metadata.correlation_id),
+      requestId: asText(metadata.request_id),
+      status: asText(metadata.status),
+      responseSource: asText(metadata.response_source) || asText(metadata.execution_path),
+      usedFallback: Boolean(llm.used_fallback || llm.is_fallback || metadata.used_fallback),
+      degradedReason,
+      showCircuitWarning: Boolean(metadata.circuit_breaker_open || metadata.dependency_degraded || degradedReason),
+    };
+  }, [messages]);
   const selectableProviders = useMemo(() => {
     return modelSettings ? getSelectableProviders(modelSettings) : [];
   }, [getSelectableProviders, modelSettings]);
@@ -1869,6 +1903,29 @@ export default function ChatInterface() {
         error={error}
         currentSession={currentSession}
         isLoading={isLoading}
+      />
+
+      <RuntimeMetadataPanel
+        requestedProvider={latestAssistantMetadata.requestedProvider}
+        actualProvider={latestAssistantMetadata.actualProvider}
+        requestedModel={latestAssistantMetadata.requestedModel}
+        actualModel={latestAssistantMetadata.actualModel}
+        runtimeEngine={latestAssistantMetadata.runtimeEngine}
+        fallbackLevel={latestAssistantMetadata.fallbackLevel}
+        correlationId={latestAssistantMetadata.correlationId}
+        requestId={latestAssistantMetadata.requestId}
+        status={latestAssistantMetadata.status}
+      />
+
+      <RuntimeReceipt
+        source={latestAssistantMetadata.responseSource}
+        usedFallback={latestAssistantMetadata.usedFallback}
+        degradedReason={latestAssistantMetadata.degradedReason}
+      />
+
+      <CircuitBreakerWarning
+        show={latestAssistantMetadata.showCircuitWarning}
+        reason={latestAssistantMetadata.degradedReason}
       />
 
       {degradedMode.active && (

--- a/src/ui_launchers/Karen-AI-Theme/src/components/chat/CircuitBreakerWarning.tsx
+++ b/src/ui_launchers/Karen-AI-Theme/src/components/chat/CircuitBreakerWarning.tsx
@@ -1,0 +1,20 @@
+import { AlertTriangle } from 'lucide-react';
+
+interface CircuitBreakerWarningProps {
+  show: boolean;
+  reason?: string;
+}
+
+export default function CircuitBreakerWarning({ show, reason }: CircuitBreakerWarningProps) {
+  if (!show) return null;
+
+  return (
+    <div className="mx-4 mb-3 rounded-md border border-amber-400/40 bg-amber-500/10 px-3 py-2 text-xs text-amber-900 dark:text-amber-200">
+      <div className="flex items-center gap-2 font-medium">
+        <AlertTriangle className="h-4 w-4" />
+        Circuit breaker or dependency degradation detected
+      </div>
+      {reason ? <div className="mt-1 opacity-90">{reason}</div> : null}
+    </div>
+  );
+}

--- a/src/ui_launchers/Karen-AI-Theme/src/components/chat/RuntimeMetadataPanel.tsx
+++ b/src/ui_launchers/Karen-AI-Theme/src/components/chat/RuntimeMetadataPanel.tsx
@@ -1,0 +1,39 @@
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+interface RuntimeMetadataPanelProps {
+  requestedProvider?: string;
+  actualProvider?: string;
+  requestedModel?: string;
+  actualModel?: string;
+  runtimeEngine?: string;
+  fallbackLevel?: string;
+  correlationId?: string;
+  requestId?: string;
+  status?: string;
+}
+
+const safe = (value?: string) => (value && value.trim() ? value : 'n/a');
+
+export default function RuntimeMetadataPanel(props: RuntimeMetadataPanelProps) {
+  return (
+    <Card className="mx-4 mb-3 border-primary/20 bg-card/70">
+      <CardHeader className="pb-2">
+        <CardTitle className="text-sm font-semibold">Runtime Metadata</CardTitle>
+      </CardHeader>
+      <CardContent className="grid gap-2 text-xs sm:grid-cols-2 lg:grid-cols-4">
+        <div><span className="text-muted-foreground">Requested Provider:</span> <strong>{safe(props.requestedProvider)}</strong></div>
+        <div><span className="text-muted-foreground">Actual Provider:</span> <strong>{safe(props.actualProvider)}</strong></div>
+        <div><span className="text-muted-foreground">Requested Model:</span> <strong>{safe(props.requestedModel)}</strong></div>
+        <div><span className="text-muted-foreground">Actual Model:</span> <strong>{safe(props.actualModel)}</strong></div>
+        <div><span className="text-muted-foreground">Runtime Engine:</span> <strong>{safe(props.runtimeEngine)}</strong></div>
+        <div><span className="text-muted-foreground">Fallback Level:</span> <strong>{safe(props.fallbackLevel)}</strong></div>
+        <div><span className="text-muted-foreground">Correlation ID:</span> <code>{safe(props.correlationId)}</code></div>
+        <div><span className="text-muted-foreground">Request ID:</span> <code>{safe(props.requestId)}</code></div>
+        <div className="sm:col-span-2 lg:col-span-4">
+          <Badge variant="outline">Status: {safe(props.status)}</Badge>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/ui_launchers/Karen-AI-Theme/src/components/chat/RuntimeReceipt.tsx
+++ b/src/ui_launchers/Karen-AI-Theme/src/components/chat/RuntimeReceipt.tsx
@@ -1,0 +1,19 @@
+import { Badge } from '@/components/ui/badge';
+
+interface RuntimeReceiptProps {
+  source?: string;
+  usedFallback?: boolean;
+  degradedReason?: string;
+}
+
+export default function RuntimeReceipt({ source, usedFallback, degradedReason }: RuntimeReceiptProps) {
+  return (
+    <div className="mx-4 mb-3 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+      <Badge variant="secondary">Source: {source || 'unknown'}</Badge>
+      <Badge variant={usedFallback ? 'destructive' : 'outline'}>
+        {usedFallback ? 'Fallback Used' : 'Primary Path'}
+      </Badge>
+      {degradedReason ? <Badge variant="outline">Reason: {degradedReason}</Badge> : null}
+    </div>
+  );
+}


### PR DESCRIPTION
### Motivation

- Surface runtime/LLM metadata for the latest assistant response so operators and users can see provider/model/runtime details and correlation IDs.
- Indicate when a fallback path was used and show a concise receipt of response source and degraded reason.
- Warn users when a circuit breaker or external dependency degradation is detected to improve visibility into reliability issues.

### Description

- Added a `latestAssistantMetadata` memo in `ChatInterface.tsx` to extract and normalize metadata from the last assistant message (requested/actual provider and model, runtime engine, fallback info, correlation/request IDs, status, degraded reason, and circuit breaker flag).
- Introduced three new UI components: `RuntimeMetadataPanel.tsx` to display metadata in a card, `RuntimeReceipt.tsx` to show response source and fallback usage, and `CircuitBreakerWarning.tsx` to render a visible warning when degradation is detected.
- Integrated the new components into the `ChatInterface` render flow above the messages list and wired props from `latestAssistantMetadata` into each component.
- Added safe-string handling and boolean flags to present clean values (e.g., `n/a`) and avoid rendering when metadata is absent.

### Testing

- Ran a TypeScript build (`yarn build`) to validate types and compilation, which completed successfully.
- Ran the linter (`yarn lint`) to ensure style and imports are correct, which completed successfully.
- No existing unit tests were modified as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3bcf2336483249831d211a221294c)