### PR TITLE
Show runtime metadata & circuit-breaker UI; improve transient auth/runtime error handling and admin API paths

### DIFF
--- a/src/ui_launchers/Karen-AI-Theme/src/components/SessionWarning.tsx
+++ b/src/ui_launchers/Karen-AI-Theme/src/components/SessionWarning.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { AlertTriangle, Clock, RefreshCw } from 'lucide-react';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
@@ -14,6 +14,7 @@ export default function SessionWarning({ onExtendSession }: SessionWarningProps)
   const [showWarning, setShowWarning] = useState(false);
   const [timeUntilExpiry, setTimeUntilExpiry] = useState<number | null>(null);
   const [isRefreshing, setIsRefreshing] = useState(false);
+  const [refreshError, setRefreshError] = useState<string | null>(null);
 
   useEffect(() => {
     const handleSessionWarning = (event: CustomEvent) => {
@@ -63,6 +64,7 @@ export default function SessionWarning({ onExtendSession }: SessionWarningProps)
 
   const handleExtendSession = async () => {
     setIsRefreshing(true);
+    setRefreshError(null);
     try {
       // This will trigger a proactive refresh
       await apiClient.get('/api/auth/me');
@@ -70,11 +72,21 @@ export default function SessionWarning({ onExtendSession }: SessionWarningProps)
       setTimeUntilExpiry(null);
       onExtendSession?.();
     } catch (error) {
-      console.error('Failed to extend session:', error);
+      const message = error instanceof Error ? error.message : 'Unable to extend session right now.';
+      setRefreshError(message);
     } finally {
       setIsRefreshing(false);
     }
   };
+
+
+  const refreshErrorHint = useMemo(() => {
+    if (!refreshError) return null;
+    if (refreshError.includes('503') || refreshError.toLowerCase().includes('database unavailable')) {
+      return 'Session service is temporarily unavailable. Your current session remains active until expiry.';
+    }
+    return refreshError;
+  }, [refreshError]);
 
   if (!showWarning || timeUntilExpiry === null) {
     return null;
@@ -90,6 +102,7 @@ export default function SessionWarning({ onExtendSession }: SessionWarningProps)
             Your session will expire in {formatTimeRemaining(timeUntilExpiry)}
           </span>
         </div>
+        <div className="flex items-center gap-2">
         <Button
           variant="outline"
           size="sm"
@@ -104,7 +117,9 @@ export default function SessionWarning({ onExtendSession }: SessionWarningProps)
           )}
           Extend Session
         </Button>
+        </div>
       </AlertDescription>
+      {refreshErrorHint ? <p className="mt-2 text-xs text-amber-700 dark:text-amber-300">{refreshErrorHint}</p> : null}
     </Alert>
   );
 }

--- a/src/ui_launchers/Karen-AI-Theme/src/components/admin/MaintenancePanel.tsx
+++ b/src/ui_launchers/Karen-AI-Theme/src/components/admin/MaintenancePanel.tsx
@@ -126,6 +126,17 @@ const getErrorMessage = (error: unknown, fallback: string) => {
   return fallback;
 };
 
+const sanitizeRuntimeError = (message: string): string => {
+  const trimmed = message.trim();
+  if (!trimmed) return "Runtime control endpoint is unavailable.";
+
+  if (trimmed.startsWith('<!DOCTYPE html>') || trimmed.startsWith('<html')) {
+    return "Runtime control endpoint returned an HTML 404 page. Verify backend admin runtime routes are enabled.";
+  }
+
+  return trimmed;
+};
+
 const formatDateTime = (value: string | null | undefined) => {
   if (!value) {
     return "Not recorded";
@@ -271,9 +282,9 @@ export default function MaintenancePanel() {
 
     try {
       const [statusResponse, notificationsResponse] = await Promise.all([
-        apiClient.get<RuntimeStatusResponse>("/admin/runtime/status"),
+        apiClient.get<RuntimeStatusResponse>("/api/admin/runtime/status"),
         apiClient.get<NotificationSubscriptionResponse>(
-          "/admin/runtime/maintenance/notifications",
+          "/api/admin/runtime/maintenance/notifications",
         ),
       ]);
 
@@ -285,7 +296,7 @@ export default function MaintenancePanel() {
       );
       setMaintenanceEta(formatDateTimeForInput(statusResponse.estimated_completion_time));
     } catch (error) {
-      const message = getErrorMessage(error, "Could not load runtime control data.");
+      const message = sanitizeRuntimeError(getErrorMessage(error, "Could not load runtime control data."));
       setRuntimeError(message);
 
       toast({
@@ -302,7 +313,7 @@ export default function MaintenancePanel() {
     setRuntimeLoading(true);
 
     try {
-      await apiClient.post("/admin/runtime/check-health", {});
+      await apiClient.post("/api/admin/runtime/check-health", {});
       await fetchRuntimeStatus();
 
       toast({
@@ -340,7 +351,7 @@ export default function MaintenancePanel() {
         const autoEndPolicy = estimatedCompletionTime ? "at_time" : "manual";
 
         if (action === "enable") {
-          await apiClient.post("/admin/runtime/maintenance/enable", {
+          await apiClient.post("/api/admin/runtime/maintenance/enable", {
             reason: maintenanceReason.trim(),
             message: maintenanceMessage.trim(),
             estimated_completion_time: estimatedCompletionTime,
@@ -349,7 +360,7 @@ export default function MaintenancePanel() {
         }
 
         if (action === "update") {
-          await apiClient.put("/admin/runtime/maintenance/update", {
+          await apiClient.put("/api/admin/runtime/maintenance/update", {
             message: maintenanceMessage.trim(),
             estimated_completion_time: estimatedCompletionTime,
             auto_end_policy: autoEndPolicy,
@@ -357,7 +368,7 @@ export default function MaintenancePanel() {
         }
 
         if (action === "disable") {
-          await apiClient.post("/admin/runtime/maintenance/disable", {});
+          await apiClient.post("/api/admin/runtime/maintenance/disable", {});
         }
 
         await fetchRuntimeStatus();

--- a/src/ui_launchers/Karen-AI-Theme/src/components/automation/AgentsPage.tsx
+++ b/src/ui_launchers/Karen-AI-Theme/src/components/automation/AgentsPage.tsx
@@ -104,6 +104,17 @@ export default function AgentsPage() {
 
   const isAdmin = user?.roles?.includes("admin") ?? false;
 
+  const isTransientAuthOrRuntimeError = useCallback((message: string): boolean => {
+    const lower = message.toLowerCase();
+    return (
+      lower.includes("database unavailable") ||
+      lower.includes("session not found in memory") ||
+      lower.includes("503") ||
+      lower.includes("gateway") ||
+      lower.includes("timeout")
+    );
+  }, []);
+
   const resetCreateForm = () => {
     setNewAgentName("");
     setNewAgentDescription("");
@@ -184,7 +195,7 @@ export default function AgentsPage() {
      if (!isAuthenticated) {
        setAgents([]);
        setSystemMetrics(null);
-       setErrorMsg("Sign in to manage agents.");
+       setErrorMsg("Authentication is temporarily unavailable. Please retry in a moment.");
        setIsLoading(false);
        return;
      }
@@ -209,11 +220,15 @@ export default function AgentsPage() {
      } catch (err: unknown) {
        const message = err instanceof Error ? err.message : "Failed to fetch agents.";
        console.error(err);
-       setErrorMsg(message);
+       setErrorMsg(
+         isTransientAuthOrRuntimeError(message)
+           ? "Agent system is temporarily unavailable (runtime/auth dependency degraded). Please retry shortly."
+           : message,
+       );
      } finally {
        setIsLoading(false);
      }
-   }, [isAuthenticated, isAdmin]);
+   }, [isAuthenticated, isAdmin, isTransientAuthOrRuntimeError]);
 
   useEffect(() => {
     if (isAuthLoading) {

--- a/src/ui_launchers/Karen-AI-Theme/src/components/chat/ChatInterface.tsx
+++ b/src/ui_launchers/Karen-AI-Theme/src/components/chat/ChatInterface.tsx
@@ -32,6 +32,9 @@ import { useUserPreferences } from './const/userPreferences';
 import { StatusIndicators, MessagesArea, ChatInput } from './interface';
 import AgentActivityPanel from './AgentActivityPanel';
 import DegradedModeBanner from './DegradedModeBanner';
+import RuntimeMetadataPanel from './RuntimeMetadataPanel';
+import RuntimeReceipt from './RuntimeReceipt';
+import CircuitBreakerWarning from './CircuitBreakerWarning';
 
 // Session Management Types
 export interface Session {
@@ -921,6 +924,37 @@ export default function ChatInterface() {
 
   const { applyModelSelection, getSelectableProviders } = useModelSettings();
 
+
+  const latestAssistantMetadata = useMemo(() => {
+    const lastAssistant = [...messages].reverse().find((message) => message.role === 'assistant');
+    const metadata = (lastAssistant?.metadata && typeof lastAssistant.metadata === 'object')
+      ? lastAssistant.metadata as Record<string, unknown>
+      : {};
+    const llm = (metadata.llm && typeof metadata.llm === 'object')
+      ? metadata.llm as Record<string, unknown>
+      : {};
+
+    const asText = (value: unknown): string | undefined =>
+      typeof value === 'string' && value.trim() ? value.trim() : undefined;
+
+    const degradedReason = asText(metadata.reason) || asText(metadata.degraded_reason) || asText(llm.reason);
+
+    return {
+      requestedProvider: asText(llm.requested_provider) || asText(metadata.requested_provider),
+      actualProvider: asText(llm.actual_provider) || asText(llm.provider) || asText(metadata.actual_provider),
+      requestedModel: asText(llm.requested_model) || asText(metadata.requested_model),
+      actualModel: asText(llm.actual_model) || asText(llm.model_id) || asText(metadata.actual_model),
+      runtimeEngine: asText(metadata.execution_path) || asText(llm.runtime_engine),
+      fallbackLevel: asText(llm.fallback_level),
+      correlationId: asText(metadata.correlation_id),
+      requestId: asText(metadata.request_id),
+      status: asText(metadata.status),
+      responseSource: asText(metadata.response_source) || asText(metadata.execution_path),
+      usedFallback: Boolean(llm.used_fallback || llm.is_fallback || metadata.used_fallback),
+      degradedReason,
+      showCircuitWarning: Boolean(metadata.circuit_breaker_open || metadata.dependency_degraded || degradedReason),
+    };
+  }, [messages]);
   const selectableProviders = useMemo(() => {
     return modelSettings ? getSelectableProviders(modelSettings) : [];
   }, [getSelectableProviders, modelSettings]);
@@ -1869,6 +1903,29 @@ export default function ChatInterface() {
         error={error}
         currentSession={currentSession}
         isLoading={isLoading}
+      />
+
+      <RuntimeMetadataPanel
+        requestedProvider={latestAssistantMetadata.requestedProvider}
+        actualProvider={latestAssistantMetadata.actualProvider}
+        requestedModel={latestAssistantMetadata.requestedModel}
+        actualModel={latestAssistantMetadata.actualModel}
+        runtimeEngine={latestAssistantMetadata.runtimeEngine}
+        fallbackLevel={latestAssistantMetadata.fallbackLevel}
+        correlationId={latestAssistantMetadata.correlationId}
+        requestId={latestAssistantMetadata.requestId}
+        status={latestAssistantMetadata.status}
+      />
+
+      <RuntimeReceipt
+        source={latestAssistantMetadata.responseSource}
+        usedFallback={latestAssistantMetadata.usedFallback}
+        degradedReason={latestAssistantMetadata.degradedReason}
+      />
+
+      <CircuitBreakerWarning
+        show={latestAssistantMetadata.showCircuitWarning}
+        reason={latestAssistantMetadata.degradedReason}
       />
 
       {degradedMode.active && (

--- a/src/ui_launchers/Karen-AI-Theme/src/components/chat/CircuitBreakerWarning.tsx
+++ b/src/ui_launchers/Karen-AI-Theme/src/components/chat/CircuitBreakerWarning.tsx
@@ -1,0 +1,20 @@
+import { AlertTriangle } from 'lucide-react';
+
+interface CircuitBreakerWarningProps {
+  show: boolean;
+  reason?: string;
+}
+
+export default function CircuitBreakerWarning({ show, reason }: CircuitBreakerWarningProps) {
+  if (!show) return null;
+
+  return (
+    <div className="mx-4 mb-3 rounded-md border border-amber-400/40 bg-amber-500/10 px-3 py-2 text-xs text-amber-900 dark:text-amber-200">
+      <div className="flex items-center gap-2 font-medium">
+        <AlertTriangle className="h-4 w-4" />
+        Circuit breaker or dependency degradation detected
+      </div>
+      {reason ? <div className="mt-1 opacity-90">{reason}</div> : null}
+    </div>
+  );
+}

--- a/src/ui_launchers/Karen-AI-Theme/src/components/chat/RuntimeMetadataPanel.tsx
+++ b/src/ui_launchers/Karen-AI-Theme/src/components/chat/RuntimeMetadataPanel.tsx
@@ -1,0 +1,39 @@
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+interface RuntimeMetadataPanelProps {
+  requestedProvider?: string;
+  actualProvider?: string;
+  requestedModel?: string;
+  actualModel?: string;
+  runtimeEngine?: string;
+  fallbackLevel?: string;
+  correlationId?: string;
+  requestId?: string;
+  status?: string;
+}
+
+const safe = (value?: string) => (value && value.trim() ? value : 'n/a');
+
+export default function RuntimeMetadataPanel(props: RuntimeMetadataPanelProps) {
+  return (
+    <Card className="mx-4 mb-3 border-primary/20 bg-card/70">
+      <CardHeader className="pb-2">
+        <CardTitle className="text-sm font-semibold">Runtime Metadata</CardTitle>
+      </CardHeader>
+      <CardContent className="grid gap-2 text-xs sm:grid-cols-2 lg:grid-cols-4">
+        <div><span className="text-muted-foreground">Requested Provider:</span> <strong>{safe(props.requestedProvider)}</strong></div>
+        <div><span className="text-muted-foreground">Actual Provider:</span> <strong>{safe(props.actualProvider)}</strong></div>
+        <div><span className="text-muted-foreground">Requested Model:</span> <strong>{safe(props.requestedModel)}</strong></div>
+        <div><span className="text-muted-foreground">Actual Model:</span> <strong>{safe(props.actualModel)}</strong></div>
+        <div><span className="text-muted-foreground">Runtime Engine:</span> <strong>{safe(props.runtimeEngine)}</strong></div>
+        <div><span className="text-muted-foreground">Fallback Level:</span> <strong>{safe(props.fallbackLevel)}</strong></div>
+        <div><span className="text-muted-foreground">Correlation ID:</span> <code>{safe(props.correlationId)}</code></div>
+        <div><span className="text-muted-foreground">Request ID:</span> <code>{safe(props.requestId)}</code></div>
+        <div className="sm:col-span-2 lg:col-span-4">
+          <Badge variant="outline">Status: {safe(props.status)}</Badge>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/ui_launchers/Karen-AI-Theme/src/components/chat/RuntimeReceipt.tsx
+++ b/src/ui_launchers/Karen-AI-Theme/src/components/chat/RuntimeReceipt.tsx
@@ -1,0 +1,19 @@
+import { Badge } from '@/components/ui/badge';
+
+interface RuntimeReceiptProps {
+  source?: string;
+  usedFallback?: boolean;
+  degradedReason?: string;
+}
+
+export default function RuntimeReceipt({ source, usedFallback, degradedReason }: RuntimeReceiptProps) {
+  return (
+    <div className="mx-4 mb-3 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+      <Badge variant="secondary">Source: {source || 'unknown'}</Badge>
+      <Badge variant={usedFallback ? 'destructive' : 'outline'}>
+        {usedFallback ? 'Fallback Used' : 'Primary Path'}
+      </Badge>
+      {degradedReason ? <Badge variant="outline">Reason: {degradedReason}</Badge> : null}
+    </div>
+  );
+}

--- a/src/ui_launchers/Karen-AI-Theme/src/lib/api.ts
+++ b/src/ui_launchers/Karen-AI-Theme/src/lib/api.ts
@@ -516,7 +516,11 @@ class ApiClient {
       localStorage.removeItem(this.TOKEN_REFRESH_ATTEMPTED_KEY);
       this.clearSessionWarningFlag();
     } catch (error) {
-      console.error('[ApiClient] Token refresh failed:', error);
+      if (this.isTransientError(error)) {
+        console.warn('[ApiClient] Token refresh temporarily unavailable:', error);
+      } else {
+        console.error('[ApiClient] Token refresh failed:', error);
+      }
       // Do not clear auth state here; callers decide how to handle 401.
       // This prevents accidental hard logout during transient refresh issues.
       throw error;

--- a/src/ui_launchers/Karen-AI-Theme/src/lib/auth.ts
+++ b/src/ui_launchers/Karen-AI-Theme/src/lib/auth.ts
@@ -287,6 +287,20 @@ class AuthService {
     return true;
   }
 
+  private isTransientAuthError(error: unknown): boolean {
+    if (!(error instanceof Error)) return false;
+    const message = error.message.toLowerCase();
+    return (
+      message.includes('502') ||
+      message.includes('503') ||
+      message.includes('504') ||
+      message.includes('fetch') ||
+      message.includes('timeout') ||
+      message.includes('database unavailable') ||
+      message.includes('session not found in memory')
+    );
+  }
+
   private async getErrorMessage(response: Response, fallback: string): Promise<string> {
     try {
       const errorData = await response.json();
@@ -472,15 +486,7 @@ class AuthService {
       console.error('Token refresh error:', error);
       
       // Don't clear auth on transient errors (like 502/503 during degraded mode)
-      if (error instanceof Error && (
-        error.message.includes('502') || 
-        error.message.includes('503') || 
-        error.message.includes('504') || 
-        error.message.includes('fetch') || 
-        error.message.includes('timeout') ||
-        error.message.includes('Database unavailable') ||
-        error.message.includes('Session not found in memory')
-      )) {
+      if (this.isTransientAuthError(error)) {
         console.warn('[AuthService] Transient error during token refresh, preserving local auth state.');
       } else {
         // Hard refresh failure should be terminal for this local session
@@ -715,6 +721,11 @@ class AuthService {
               return false;
             }
           } catch (refreshError) {
+            if (this.isTransientAuthError(refreshError) && accessToken && (currentUser || hasSessionMarker)) {
+              console.warn('[AuthService] transient refresh failure during validation; preserving local session');
+              return true;
+            }
+
             if (this.shouldPreserveFreshLoginSession()) {
               console.warn('[AuthService] preserving fresh login session despite refresh failure during validation');
               return true;


### PR DESCRIPTION
### Motivation
- Surface runtime/LLM metadata and circuit-breaker/degradation hints in the chat UI to help operators diagnose responses. 
- Avoid hard-clearing client auth or showing misleading errors when backend refresh/authorization calls fail transiently (502/503/timeout/etc.).
- Standardize admin runtime endpoints to the browser-facing `/api` prefix and sanitize noisy runtime error payloads (HTML 404 pages) for clearer operator messages.

### Description
- Added assistant runtime metadata extraction in `ChatInterface.tsx` and rendered it via three new components: `RuntimeMetadataPanel`, `RuntimeReceipt`, and `CircuitBreakerWarning` to display provider/model/runtime, source/fallback, and circuit-breaker hints. 
- Created new UI components: `src/components/chat/RuntimeMetadataPanel.tsx`, `RuntimeReceipt.tsx`, and `CircuitBreakerWarning.tsx`. 
- Enhanced `SessionWarning.tsx` to surface refresh errors with a user-friendly hint and avoid swallowing transient refresh failures. 
- Updated `MaintenancePanel.tsx` to call browser-facing admin APIs under `/api/admin/...`, added `sanitizeRuntimeError()` to detect and normalize HTML 404 or empty runtime responses, and updated toast/error handling. 
- Improved `AgentsPage.tsx` to recognize transient auth/runtime error messages and show a friendlier, temporary-unavailable message instead of immediate sign-in prompts. 
- Hardened auth/refresh logic in `src/lib/auth.ts` by introducing `isTransientAuthError()` and preserving local auth state during transient backend failures; adjusted validation/refresh flows to avoid accidental logouts. 
- Adjusted `src/lib/api.ts` refresh logging to distinguish transient refresh issues from terminal failures and avoid clearing session state on recoverable errors. 

### Testing
- Ran TypeScript type checking with `tsc --noEmit` and the build, and there were no type errors. 
- Executed linting (`eslint`) and the frontend unit tests (`yarn test`), and both suites passed. 
- Manual smoke verification was performed by loading the chat and admin panels to confirm the new metadata UI and transient error messages render as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3bcf2336483249831d211a221294c)