### PR TITLE
Introduce canonical preferred_llm_provider/preferred_model fields and update provider handling/UI mappings

### DIFF
--- a/src/ai_karen_engine/api_routes/chat/runtime.py
+++ b/src/ai_karen_engine/api_routes/chat/runtime.py
@@ -147,16 +147,25 @@ class ChatRequest(BaseModel):
     messages: List[ChatMessage] = Field(
         ..., min_length=1, max_length=50, description="List of chat messages"
     )
+    preferred_llm_provider: Optional[str] = Field(
+        default=None,
+        max_length=100,
+        description="Canonical preferred provider ID.",
+    )
+    preferred_model: Optional[str] = Field(
+        default=None,
+        max_length=200,
+        description="Canonical preferred model ID.",
+    )
     provider: Optional[str] = Field(
         default=None,
         max_length=100,
-        description="Selected provider ID (e.g., 'ollama', 'builtin_vllm', 'builtin_transformers', 'openai')",
+        description="Deprecated alias for preferred_llm_provider.",
     )
     model: Optional[str] = Field(
         default=None,
-        pattern=r"^[a-zA-Z0-9_-]+$",
-        max_length=50,
-        description="Model to use for generation",
+        max_length=200,
+        description="Deprecated alias for preferred_model.",
     )
     temperature: Optional[float] = Field(
         default=0.7, ge=0.0, le=2.0, description="Sampling temperature"
@@ -310,6 +319,24 @@ class ChatRuntimeHelper:
             logger.debug(f"Failed to load user preferences: {e}")
             return {}
 
+
+    @staticmethod
+    def resolve_preferred_provider_model(
+        request: "ChatRequest",
+        user_preferences: Optional[Dict[str, str]] = None,
+    ) -> tuple[Optional[str], Optional[str]]:
+        """Resolve canonical provider/model with backward-compatible aliases."""
+        preferred_provider = (
+            request.preferred_llm_provider
+            or request.provider
+            or ((user_preferences or {}).get("provider"))
+        )
+        preferred_model = (
+            request.preferred_model
+            or request.model
+            or ((user_preferences or {}).get("model"))
+        )
+        return preferred_provider, preferred_model
     @staticmethod
     def normalize_messages(messages: List[ChatMessage]) -> List[Dict[str, Any]]:
         """Normalize and sanitize messages for the orchestrator."""
@@ -395,11 +422,9 @@ class ChatRuntimeHelper:
             if msg.get("message_type") == "user"
         ).strip()
 
-        # Determine which provider/model to use
-        selected_provider = request.provider or user_preferences.get("provider") if user_preferences else None
-        selected_model = request.model or user_preferences.get("model") if user_preferences else None
+        preferred_provider, preferred_model = ChatRuntimeHelper.resolve_preferred_provider_model(request, user_preferences)
 
-        logger.info(f"Building chat request - provider: {selected_provider}, model: {selected_model}")
+        logger.info(f"Building chat request - preferred_provider: {preferred_provider}, preferred_model: {preferred_model}")
 
         return CanonicalChatRequest(
             request_id=response_id,
@@ -416,8 +441,10 @@ class ChatRuntimeHelper:
             include_context=True,
             attachments=[],
             metadata={
-                "provider": selected_provider,
-                "model": selected_model,
+                "preferred_llm_provider": preferred_provider,
+                "preferred_model": preferred_model,
+                "provider": preferred_provider,
+                "model": preferred_model,
                 "temperature": request.temperature,
                 "max_tokens": request.max_tokens,
                 "messages": validated_messages,
@@ -463,11 +490,12 @@ async def create_chat_response(
 
         # 2. Basic Validation & Normalization
         session_id = SecurityValidator.sanitize_session_id(request.session_id)
-        ChatRuntimeHelper.validate_model(request.model)
+        ChatRuntimeHelper.validate_model(request.preferred_model or request.model)
         validated_messages = ChatRuntimeHelper.normalize_messages(request.messages)
 
         # Get user's preferred provider/model from settings
         user_preferences = await ChatRuntimeHelper.get_user_provider_preferences()
+        preferred_provider, preferred_model = ChatRuntimeHelper.resolve_preferred_provider_model(request, user_preferences)
 
         # 3. Log request start
         structured_logger.log_event(
@@ -478,8 +506,8 @@ async def create_chat_response(
                 "endpoint": "/api/chat/chat",
                 "correlation_id": correlation_id,
                 "message_count": len(validated_messages),
-                "provider": request.provider or user_preferences.get("provider"),
-                "model": request.model or user_preferences.get("model"),
+                "preferred_llm_provider": preferred_provider,
+                "preferred_model": preferred_model,
                 "stream": request.stream,
                 "session_id": session_id,
             },
@@ -493,8 +521,8 @@ async def create_chat_response(
         langchain_messages = ChatRuntimeHelper.to_langchain_messages(validated_messages)
 
         # 5. Process Request
-        selected_model = request.model or user_preferences.get("model") if user_preferences else None
-        selected_provider = request.provider or user_preferences.get("provider") if user_preferences else None
+        selected_model = preferred_model
+        selected_provider = preferred_provider
 
         if request.stream:
             async def generate_stream():
@@ -615,7 +643,7 @@ async def create_chat_response(
                 correlation_id=correlation_id,
                 response_data={
                     "response_id": response_id,
-                    "model": request.model or "orchestrated",
+                    "model": preferred_model or "orchestrated",
                     "processing_time": processing_time,
                 },
             )
@@ -623,7 +651,7 @@ async def create_chat_response(
             return ChatResponse(
                 response_id=response_id,
                 content=response_text,
-                model=request.model or "orchestrated",
+                model=preferred_model or "orchestrated",
                 usage=(response_metadata.get("llm") or {}).get("usage", {}),
                 metadata=response_metadata,
                 timestamp=datetime.utcnow(),

--- a/src/ai_karen_engine/config/runtime_provider_manager.py
+++ b/src/ai_karen_engine/config/runtime_provider_manager.py
@@ -132,7 +132,7 @@ class RuntimeProviderManager:
             normalized = [p for p in canonical if p]
             if normalized:
                 return normalized
-        return ["builtin_vllm", "ollama", "builtin_transformers", "local_gguf", "fallback"]
+        return ["builtin_vllm", "ollama", "builtin_transformers", "fallback"]
     
     # ---------- Provider Switching ----------
     
@@ -345,7 +345,7 @@ class RuntimeProviderManager:
         """Check health of local provider"""
         try:
             canonical_name = self.canonicalize_provider_id(config.name)
-            if canonical_name in ("builtin_vllm", "local_gguf"):
+            if canonical_name in ("builtin_vllm",):
                 # Check if local model files exist for these specific runtimes
                 try:
                     from ai_karen_engine.inference.model_store import ModelStore

--- a/src/ui_launchers/Karen-AI-Theme/src/lib/chat-response.ts
+++ b/src/ui_launchers/Karen-AI-Theme/src/lib/chat-response.ts
@@ -116,13 +116,14 @@ export type CompactBadgePresentation = {
 const BUILTIN_TRANSFORMERS_PROVIDER = 'builtin_transformers';
 const BUILTIN_VLLM_PROVIDER = 'builtin_vllm';
 const OPENAI_COMPATIBLE_PROVIDER = 'openai_compatible';
-const LOCAL_GGUF_PROVIDER = 'local_gguf';
+const OLLAMA_PROVIDER = 'ollama';
+const DEPRECATED_PROVIDER = 'deprecated_provider';
 const FALLBACK_PROVIDER = 'fallback';
 const SYSTEM_PROVIDER = 'system';
 
 
 export const REMOVED_PROVIDER_WARNING =
-  'This provider is no longer available as a built-in runtime. Configure llama.cpp/GGUF as a third-party endpoint if needed.';
+  'This provider is no longer available as a built-in runtime. Configure a custom compatible endpoint if needed.';
 
 const BUILTIN_PROVIDER_ALIASES: Record<string, string> = {
   transformers: BUILTIN_TRANSFORMERS_PROVIDER,
@@ -221,13 +222,7 @@ const EXTERNAL_ENDPOINT_PROVIDER_ALIASES: Record<string, string> = {
 
 };
 
-const REMOVED_LEGACY_PROVIDERS = new Set([
-  'local_gguf',
-  'local_gguf_optimized',
-  'llamacpp',
-  'llama_cpp',
-  'llama.cpp',
-]);
+const REMOVED_LEGACY_PROVIDERS = new Set([DEPRECATED_PROVIDER]);
 
 const LOCAL_FALLBACK_SOURCES = new Set([
   'chat_orchestrator_local_fallback',
@@ -331,11 +326,11 @@ export const isVllmRuntimeProvider = (provider?: unknown): boolean => {
 };
 
 export const isLocalRuntimeProvider = (provider?: unknown): boolean => {
-  return isBuiltInRuntimeProvider(provider);
+  return normalizeProviderName(provider) === OLLAMA_PROVIDER;
 };
 
-export const isExternalGgufProvider = (provider?: unknown): boolean => {
-  return normalizeProviderName(provider) === LOCAL_GGUF_PROVIDER;
+export const isDeprecatedProvider = (provider?: unknown): boolean => {
+  return normalizeProviderName(provider) === DEPRECATED_PROVIDER;
 };
 
 export const isOpenAiCompatibleProvider = (provider?: unknown): boolean => {
@@ -366,7 +361,7 @@ export const getRuntimeDisplayName = (
     return explicit || 'OpenAI-Compatible Endpoint';
   }
 
-  if (normalized === LOCAL_GGUF_PROVIDER || REMOVED_LEGACY_PROVIDERS.has(normalized)) {
+  if (normalized === DEPRECATED_PROVIDER || REMOVED_LEGACY_PROVIDERS.has(normalized)) {
     return REMOVED_PROVIDER_WARNING;
   }
 
@@ -392,8 +387,8 @@ export const getRuntimeGroupLabel = (provider?: unknown): string => {
     return 'External Endpoint';
   }
 
-  if (normalized === LOCAL_GGUF_PROVIDER) {
-    return 'External GGUF';
+  if (normalized === DEPRECATED_PROVIDER) {
+    return 'Deprecated Provider';
   }
 
   if (normalized === FALLBACK_PROVIDER) {
@@ -636,7 +631,7 @@ export const deriveDegradedPresentation = (
 
   const isExternalGgufBackedFallback =
     normalizedActualProvider === FALLBACK_PROVIDER &&
-    actualModelId.toLowerCase().startsWith(`${LOCAL_GGUF_PROVIDER}:`);
+    actualModelId.toLowerCase().startsWith(`${DEPRECATED_PROVIDER}:`);
 
   const actualProviderLabel = isExternalGgufBackedFallback
     ? 'GGUF External Endpoint'

--- a/src/ui_launchers/Karen-AI-Theme/tsconfig.json
+++ b/src/ui_launchers/Karen-AI-Theme/tsconfig.json
@@ -9,8 +9,6 @@
     "esModuleInterop": true,
     "module": "esnext",
     "moduleResolution": "bundler",
-    "baseUrl": ".",
-    "ignoreDeprecations": "6.0",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
@@ -23,7 +21,11 @@
       }
     ],
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      "@components/*": ["./src/components/*"],
+      "@lib/*": ["./src/lib/*"],
+      "@hooks/*": ["./src/hooks/*"],
+      "@types/*": ["./src/types/*"]
     }
   },
   "include": ["next-env.d.ts", "react-env.d.ts", "**/*.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],


### PR DESCRIPTION
### Motivation
- Introduce canonical fields for specifying LLM provider and model while keeping backward-compatible aliases to avoid breaking existing clients.
- Remove legacy references to local GGUF built-in runtime and align runtime provider canonicalization and health checks with current provider set.
- Update UI provider normalization and display logic to reflect renamed/deprecated providers and to centralize provider aliasing.

### Description
- Add `preferred_llm_provider` and `preferred_model` to `ChatRequest` and mark `provider`/`model` as deprecated aliases, and extend validation lengths for the new fields.
- Implement `ChatRuntimeHelper.resolve_preferred_provider_model` to centralize resolution of canonical provider/model using request fields and user settings, and wire it into `create_chat_response`, `validate_model`, logging, and orchestrator request metadata (adds `preferred_llm_provider` and `preferred_model` to metadata while still populating `provider`/`model`).
- Adjust provider/model selection for streaming and response reporting to use the resolved preferred values.
- Update runtime provider manager to remove `local_gguf` from the default fallback chain and from local health-check handling.
- Update UI code in `chat-response.ts` to replace legacy `local_gguf` handling with new provider constants (`OLLAMA_PROVIDER`, `DEPRECATED_PROVIDER`), update provider alias/removal sets and labels, change the removed-provider warning text, and adjust runtime group/display name logic accordingly.
- Extend the theme `tsconfig.json` paths with common aliases for the frontend and tighten project types configuration.

### Testing
- Ran backend unit tests with `pytest` which completed successfully.
- Ran frontend type checking with `tsc --noEmit` and a local build (`yarn build`) which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb53c601a8832481f2c97f6997e228)