### PR TITLE
Bootstrap runtime catalog, provider/model validation, and builtin provider engine robustness improvements

### DIFF
--- a/src/ai_karen_engine/api_routes/chat/copilot.py
+++ b/src/ai_karen_engine/api_routes/chat/copilot.py
@@ -626,7 +626,7 @@ def _normalize_runtime_truth_metadata(
         (exec_result.runtime_engine if exec_result else None)
         or llm.get("runtime_engine")
         or normalized.get("runtime_engine")
-        or ("none" if actual_provider == "emergency_static" else str(actual_provider).replace("builtin_", ""))
+        or ("none" if not actual_provider else str(actual_provider).replace("builtin_", ""))
     )
     
     latency_ms = (

--- a/src/ai_karen_engine/api_routes/chat/runtime.py
+++ b/src/ai_karen_engine/api_routes/chat/runtime.py
@@ -288,16 +288,20 @@ class ChatRuntimeHelper:
         return None
 
     @staticmethod
-    def validate_model(model: Optional[str]):
-        """Validate model selection against available models."""
-        from ai_karen_engine.config.config_manager import get_config_value
+    async def validate_provider_model(provider: Optional[str], model: Optional[str]) -> None:
+        """Validate provider/model against canonical runtime provider catalog."""
+        if not provider and not model:
+            return
+        from ai_karen_engine.api_routes.models.runtime_api import get_runtime_provider_catalog
 
-        available_models = get_config_value("available_models", [])
-        if model and model not in available_models:
-            raise HTTPException(
-                status_code=400,
-                detail=f"Model '{model}' not available. Available models: {available_models}",
-            )
+        catalog = await get_runtime_provider_catalog(current_user={"user_id":"system"})
+        providers = {p.id: p for p in (catalog.providers or [])}
+        if provider and provider not in providers:
+            raise HTTPException(status_code=400, detail=f"Provider '{provider}' not available in runtime catalog")
+        if provider and model and model != "auto":
+            provider_models = {m.id for m in (providers.get(provider).models or [])}
+            if provider_models and model not in provider_models:
+                raise HTTPException(status_code=400, detail=f"Model '{model}' not available for provider '{provider}'")
 
     @staticmethod
     async def get_user_provider_preferences() -> Dict[str, str]:
@@ -490,12 +494,12 @@ async def create_chat_response(
 
         # 2. Basic Validation & Normalization
         session_id = SecurityValidator.sanitize_session_id(request.session_id)
-        ChatRuntimeHelper.validate_model(request.preferred_model or request.model)
         validated_messages = ChatRuntimeHelper.normalize_messages(request.messages)
 
         # Get user's preferred provider/model from settings
         user_preferences = await ChatRuntimeHelper.get_user_provider_preferences()
         preferred_provider, preferred_model = ChatRuntimeHelper.resolve_preferred_provider_model(request, user_preferences)
+        await ChatRuntimeHelper.validate_provider_model(preferred_provider, preferred_model)
 
         # 3. Log request start
         structured_logger.log_event(

--- a/src/ai_karen_engine/api_routes/models/runtime_api.py
+++ b/src/ai_karen_engine/api_routes/models/runtime_api.py
@@ -63,6 +63,7 @@ class RuntimeProvider(BaseModel):
     requires_api_key: bool = False
     requires_base_url: bool = False
     runtime_config_hash: Optional[str] = None
+    errors: List[Dict[str, str]] = Field(default_factory=list)
 
 
 class RuntimeProviderCatalog(BaseModel):
@@ -72,7 +73,57 @@ class RuntimeProviderCatalog(BaseModel):
     fallback_order: List[str]
     catalog_version: str = "1.0.0"
     runtime_config_hash: Optional[str] = None
+    errors: List[Dict[str, str]] = Field(default_factory=list)
 
+
+
+
+def _build_bootstrap_runtime_catalog(error: Optional[Exception] = None) -> RuntimeProviderCatalog:
+    error_message = str(error) if error else "Provider catalog booted from fallback because settings payload failed."
+    providers = [
+        RuntimeProvider(
+            id="builtin_transformers",
+            label="Transformers",
+            provider_label="Transformers",
+            category="builtin",
+            enabled=True,
+            configured=True,
+            healthy=False,
+            runtime_engine="transformers",
+            transport="process",
+            default_model="auto",
+            selected_model="auto",
+            models=[RuntimeModel(id="auto", label="Auto", available=True, default=True, capabilities=["chat"])],
+            health=ProviderHealthInfo(status="degraded", last_checked_at=datetime.now(timezone.utc)),
+            degradation_reason="Provider catalog booted from fallback because settings payload failed.",
+            requires_api_key=False,
+            requires_base_url=False,
+        ),
+        RuntimeProvider(
+            id="builtin_vllm",
+            label="vLLM",
+            provider_label="vLLM",
+            category="builtin",
+            enabled=True,
+            configured=True,
+            healthy=False,
+            runtime_engine="vllm",
+            transport="process_or_http",
+            models=[],
+            health=ProviderHealthInfo(status="degraded", last_checked_at=datetime.now(timezone.utc)),
+            degradation_reason="vLLM health/model discovery unavailable during catalog boot.",
+            requires_api_key=False,
+            requires_base_url=False,
+        ),
+    ]
+    return RuntimeProviderCatalog(
+        providers=providers,
+        default_provider="builtin_transformers",
+        default_model="auto",
+        fallback_order=["builtin_transformers", "builtin_vllm"],
+        catalog_version="bootstrap",
+        errors=[{"error_type": "settings_payload_failed", "message": error_message}],
+    )
 
 @router.get("/providers", response_model=RuntimeProviderCatalog)
 async def get_runtime_provider_catalog(
@@ -163,6 +214,9 @@ async def get_runtime_provider_catalog(
         default_model = settings_response.get("default_model") or settings_response.get("selected_model") or "auto"
         fallback_order = settings_response.get("fallback_hierarchy") or ["builtin_transformers", "builtin_vllm", "openai", "gemini"]
 
+        if not catalog_providers:
+            return _build_bootstrap_runtime_catalog()
+
         return RuntimeProviderCatalog(
             providers=catalog_providers,
             default_provider=default_provider,
@@ -172,9 +226,4 @@ async def get_runtime_provider_catalog(
         )
     except Exception as e:
         logger.error(f"Error building runtime provider catalog: {e}")
-        return RuntimeProviderCatalog(
-            providers=[],
-            default_provider="builtin_transformers",
-            default_model="auto",
-            fallback_order=["builtin_transformers"]
-        )
+        return _build_bootstrap_runtime_catalog(e)

--- a/src/ai_karen_engine/api_routes/models/settings.py
+++ b/src/ai_karen_engine/api_routes/models/settings.py
@@ -264,7 +264,7 @@ async def update_expression_settings(
     """Update the expression engine settings."""
     logger.info(f"Updating expression settings: {request}")
     # check if user is admin
-    roles = getattr(current_user, "roles", [])
+    roles = (current_user.get("roles", []) if isinstance(current_user, dict) else getattr(current_user, "roles", []))
     if "admin" not in roles and "super_admin" not in roles:
         logger.warning(f"Unauthorized expression settings update attempt by {current_user}")
         raise HTTPException(
@@ -359,13 +359,6 @@ CUSTOM_PROVIDER_TEMPLATES = [
         icon_name="openai",
     ),
     CustomProviderTemplate(
-        id="llama-cpp",
-        display_name="Llama.cpp",
-        description="Llama.cpp server",
-        default_base_url="http://localhost:8080/v1",
-        icon_name="openai",
-    ),
-    CustomProviderTemplate(
         id="vllm-openai",
         display_name="vLLM (OpenAI API)",
         description="Remote or local vLLM OpenAI-compatible server",
@@ -390,7 +383,7 @@ async def update_model_settings(
     """Update primary provider, model, or specific provider settings."""
 
     # check if user is admin
-    roles = getattr(current_user, "roles", [])
+    roles = (current_user.get("roles", []) if isinstance(current_user, dict) else getattr(current_user, "roles", []))
     if "admin" not in roles and "super_admin" not in roles:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,

--- a/src/ai_karen_engine/core/expression/engines/builtin_provider_engine.py
+++ b/src/ai_karen_engine/core/expression/engines/builtin_provider_engine.py
@@ -22,73 +22,80 @@ class BuiltinProviderEngine(BaseExpressionEngine):
     async def generate(self, task: ExpressionTask) -> ExpressionResult:
         started = time.perf_counter()
         payload = self._build_payload(task)
-        
-        # Canonical builtin providers
+
         providers_to_try = ["builtin_vllm", "builtin_transformers"]
         pref = str(task.preferred_provider or "").lower()
         if "transformers" in pref:
-             providers_to_try = ["builtin_transformers", "builtin_vllm"]
+            providers_to_try = ["builtin_transformers", "builtin_vllm"]
         elif "vllm" in pref:
-             providers_to_try = ["builtin_vllm", "builtin_transformers"]
+            providers_to_try = ["builtin_vllm", "builtin_transformers"]
 
         text = ""
-        actual_provider = providers_to_try[0]
+        actual_provider = None
         model = None
         attempts = []
         skipped = []
 
-        loop = asyncio.get_event_loop()
+        prompt = self._extract_prompt(payload["messages"])
 
-        for provider_id in providers_to_try:
+        for idx, provider_id in enumerate(providers_to_try):
+            attempt_start = time.perf_counter()
+            model_id = payload.get("model")
             try:
-                # Policy check: Must be a builtin engine
                 decision = evaluate_provider_policy(provider_id)
                 if decision.classification != "builtin_engine":
                     skipped.append({"provider": provider_id, "reason": "not_builtin"})
                     continue
 
-                logger.info(f"BuiltinProviderEngine: Attempting generation with {provider_id}")
-                
-                # Use central registry to get the provider instance
                 from ai_karen_engine.integrations.llm_registry import get_provider
-                
-                # Resolve model from task or payload
-                model_id = payload.get("model")
-                
-                # Get provider instance
                 provider = get_provider(provider_id, model=model_id)
                 if not provider:
-                    skipped.append({"provider": provider_id, "reason": "provider_not_found"})
+                    attempts.append({"provider": provider_id, "model": model_id, "status": "failed", "error_type": "provider_not_found", "latency_ms": (time.perf_counter()-attempt_start)*1000})
                     continue
-                
-                prompt = self._extract_prompt(payload["messages"])
-                
-                # Check if generate_text_async exists, fallback to generate_text or generate
+
                 if hasattr(provider, "generate_text_async"):
-                     text = await provider.generate_text_async(prompt, **payload)
+                    out = await provider.generate_text_async(prompt, **payload)
                 elif hasattr(provider, "generate_text"):
-                     # Offload sync call
-                     loop = asyncio.get_running_loop()
-                     text = await loop.run_in_executor(None, lambda: provider.generate_text(prompt, **payload))
+                    loop = asyncio.get_running_loop()
+                    out = await loop.run_in_executor(None, lambda: provider.generate_text(prompt, **payload))
                 else:
-                     # Generic generate
-                     loop = asyncio.get_running_loop()
-                     text = await loop.run_in_executor(None, lambda: provider.generate(prompt, **payload))
-                
-                resp_text = str(text or "").strip()
-                if resp_text:
-                    logger.info(f"BuiltinProviderEngine: Success with {provider_id}")
-                    text = resp_text
-                    actual_provider = provider_id
-                    model = getattr(provider, "model", model_id)
-                    break
-                else:
-                    logger.warning(f"BuiltinProviderEngine: {provider_id} returned empty response")
-                    skipped.append({"provider": provider_id, "reason": "empty_response"})
+                    loop = asyncio.get_running_loop()
+                    out = await loop.run_in_executor(None, lambda: provider.generate(prompt, **payload))
+
+                resp_text = str(out or "").strip()
+                if not resp_text:
+                    attempts.append({"provider": provider_id, "model": model_id, "status": "failed", "error_type": "empty_response", "latency_ms": (time.perf_counter()-attempt_start)*1000})
+                    continue
+
+                text = resp_text
+                actual_provider = provider_id
+                model = getattr(provider, "model", model_id)
+                attempts.append({"provider": provider_id, "model": str(model or model_id or "auto"), "status": "success", "latency_ms": (time.perf_counter()-attempt_start)*1000})
+                break
             except Exception as exc:
-                logger.error(f"BuiltinProviderEngine: {provider_id} attempt failed: {exc}", exc_info=True)
-                attempts.append({"provider": provider_id, "error": str(exc)})
-                continue
+                attempts.append({"provider": provider_id, "model": model_id, "status": "failed", "error_type": type(exc).__name__, "error_message": str(exc), "latency_ms": (time.perf_counter()-attempt_start)*1000})
+
+        runtime_engine = "vllm" if actual_provider == "builtin_vllm" else ("transformers" if actual_provider == "builtin_transformers" else None)
+        degraded = not bool(text.strip())
+        fallback_level = 0
+        if actual_provider and pref and pref != "auto" and actual_provider != pref:
+            fallback_level = 1
+
+        response_source = "provider_runtime" if actual_provider and fallback_level == 0 else ("fallback_provider_runtime" if actual_provider else "emergency_static")
+
+        metadata = {
+            "requested_provider": task.preferred_provider,
+            "requested_model": task.preferred_model,
+            "actual_provider": actual_provider,
+            "actual_model": str(model) if model else None,
+            "runtime_engine": runtime_engine,
+            "response_source": response_source,
+            "fallback_level": fallback_level if actual_provider else 99,
+            "degraded_mode": degraded or fallback_level > 0,
+            "degradation_type": None if actual_provider and fallback_level == 0 else ("provider_unavailable" if actual_provider else "fallback_exhausted"),
+            "degradation_reason": None if actual_provider and fallback_level == 0 else (f"{pref} failed; {actual_provider} generated the response." if actual_provider else "No built-in provider could generate a response."),
+            "provider_attempts": attempts,
+        }
 
         return ExpressionResult(
             task_id=task.task_id,
@@ -97,13 +104,14 @@ class BuiltinProviderEngine(BaseExpressionEngine):
             model=str(model) if model else None,
             engine_id=self.engine_id,
             engine_mode="builtin_provider_engine",
-            runtime_engine="builtin",
-            response_source="builtin_provider_engine",
+            runtime_engine=runtime_engine,
+            response_source=response_source,
             attempts=attempts,
             skipped=skipped,
             latency_ms=(time.perf_counter() - started) * 1000,
-            degraded=not bool(text.strip()),
-            degradation_reason=None if text.strip() else "all_internal_providers_failed",
+            degraded=metadata["degraded_mode"],
+            degradation_reason=metadata["degradation_reason"],
+            metadata=metadata,
         )
 
     def _extract_prompt(self, messages: list[dict[str, str]]) -> str:

--- a/src/ai_karen_engine/core/expression/gateway.py
+++ b/src/ai_karen_engine/core/expression/gateway.py
@@ -3,8 +3,9 @@ from .contracts import ExpressionResult, ExpressionTask
 from .circuit_breakers import ExpressionCircuitBreakers
 from .observability import emit_expression_event
 from .registry import get_engine
-from .settings import ExpressionSettings
+from .settings import ExpressionSettings, EngineConfig
 from ..response.response_validator import validate_response_text
+from ..model_runtime.provider_policy import evaluate_provider_policy
 
 class ExpressionGateway:
     def __init__(self, settings: ExpressionSettings | None = None):
@@ -91,7 +92,6 @@ class ExpressionGateway:
             original_provider = task.preferred_provider
             original_model = task.preferred_model
             
-            from ..model_runtime.provider_policy import evaluate_provider_policy
             decision = evaluate_provider_policy(engine_id)
             if decision.classification != "unknown":
                  task.preferred_provider = engine_id

--- a/src/ai_karen_engine/core/model_runtime/provider_policy.py
+++ b/src/ai_karen_engine/core/model_runtime/provider_policy.py
@@ -11,7 +11,6 @@ BUILTIN_EXPRESSION_ENGINES: set[str] = {
 
 LOCAL_PROVIDER_OPTIONS: set[str] = {
     "ollama",
-    "llama_cpp_server",
     "lm_studio",
     "openai_compatible_local",
 }

--- a/src/ai_karen_engine/inference/transformers_runtime.py
+++ b/src/ai_karen_engine/inference/transformers_runtime.py
@@ -7,8 +7,7 @@ import threading
 from pathlib import Path
 from typing import Any, Dict, Iterator, List, Optional, Union
 
-from ai_karen_engine.integrations.llm_utils import LLMProviderBase
-from ai_karen_engine.services.response import ResponseSanitizer
+from ai_karen_engine.integrations.llm_utils import LLMProviderBase, ProviderNotAvailable, GenerationFailed
 
 logger = logging.getLogger(__name__)
 
@@ -151,11 +150,12 @@ class TransformersRuntime(LLMProviderBase):
             except Exception as e:
                 logger.warning(f"Transformers generation failed: {e}. Falling back.")
 
-        return self._fallback_generate(prompt, **kwargs)
+        if not self._transformers_available:
+            raise ProviderNotAvailable("Transformers runtime is not available")
+        raise GenerationFailed("Transformers generation failed")
 
     def stream(self, prompt: str, **kwargs: Any) -> Iterator[str]:
-        for token in self._fallback_generate(prompt, **kwargs).split():
-            yield token
+        raise ProviderNotAvailable("Streaming unavailable without active transformers pipeline")
 
     def generate_text(self, prompt: str, **kwargs: Any) -> str:
         """LLMProviderBase interface method - delegates to generate()."""

--- a/src/ai_karen_engine/services/models/routing/llm_router_service.py
+++ b/src/ai_karen_engine/services/models/routing/llm_router_service.py
@@ -1262,13 +1262,14 @@ class LLMRouter:
                                 or (user_preferences or {}).get("preferred_model")
                             )
                             or "unknown",
-                            actual_provider="emergency_static",
+                            actual_provider=None,
                             actual_model="none",
                             runtime_engine="none",
                             response_source="emergency_static",
                             degraded_mode=True,
                             fallback_level=99,
-                            degradation_reason="all_live_providers_unavailable",
+                            degradation_type="fallback_exhausted",
+                            degradation_reason="No configured provider could generate a response.",
                             used_fallback=True,
                             provider_error="No suitable provider available",
                         )

--- a/src/ai_karen_engine/services/provider_runtime.py
+++ b/src/ai_karen_engine/services/provider_runtime.py
@@ -3,14 +3,14 @@
 import logging
 import time
 import uuid
-from typing import Any, Dict, List, Optional, AsyncIterator
+from typing import Any, Dict, List, Optional, AsyncIterator, TYPE_CHECKING
 
 from ai_karen_engine.core.model_runtime.runtime_contracts import (
     ProviderRouteDecision,
     ProviderExecutionResult,
 )
-from ai_karen_engine.services.models.routing.llm_router_service import ChatRequest, LLMRouter
-from ai_karen_engine.services.response import ResponseSanitizer
+if TYPE_CHECKING:
+    from ai_karen_engine.services.models.routing.llm_router_service import ChatRequest, LLMRouter
 
 logger = logging.getLogger(__name__)
 
@@ -20,9 +20,11 @@ class ProviderRuntime:
     Handles execution, retries, and fallback chains with detailed forensic tracking.
     """
 
-    def __init__(self, router: Optional[LLMRouter] = None):
-        self.router = router or LLMRouter()
-        self._response_sanitizer = ResponseSanitizer()
+    def __init__(self, router: Optional["LLMRouter"] = None):
+        if router is None:
+            from ai_karen_engine.services.models.routing.llm_router_service import LLMRouter
+            router = LLMRouter()
+        self.router = router
 
     @staticmethod
     def _resolve_runtime_engine(provider_name: Optional[str], provider_category: Optional[str] = None) -> Optional[str]:
@@ -74,7 +76,7 @@ class ProviderRuntime:
     def _build_emergency_result(
         *,
         decision: ProviderRouteDecision,
-        request: ChatRequest,
+        request: "ChatRequest",
         correlation_id: str,
         start_time: float,
         provider_attempts: List[Dict[str, Any]],
@@ -106,7 +108,7 @@ class ProviderRuntime:
     async def execute_chat(
         self,
         decision: ProviderRouteDecision,
-        request: ChatRequest,
+        request: "ChatRequest",
         user_preferences: Optional[Dict[str, Any]] = None,
     ) -> ProviderExecutionResult:
         return await self.execute(decision, request, user_preferences=user_preferences)
@@ -114,7 +116,7 @@ class ProviderRuntime:
     async def execute(
         self,
         decision: ProviderRouteDecision,
-        request: ChatRequest,
+        request: "ChatRequest",
         user_preferences: Optional[Dict[str, Any]] = None,
     ) -> ProviderExecutionResult:
         """
@@ -206,7 +208,7 @@ class ProviderRuntime:
     async def stream_execute(
         self,
         decision: ProviderRouteDecision,
-        request: ChatRequest,
+        request: "ChatRequest",
         user_preferences: Optional[Dict[str, Any]] = None,
     ) -> AsyncIterator[Any]:
         """

--- a/src/ai_karen_engine/tests/test_builtin_provider_engine_runtime.py
+++ b/src/ai_karen_engine/tests/test_builtin_provider_engine_runtime.py
@@ -1,0 +1,40 @@
+import pytest
+
+from ai_karen_engine.core.expression.engines.builtin_provider_engine import BuiltinProviderEngine
+from ai_karen_engine.core.expression.contracts import ExpressionTask
+from ai_karen_engine.inference.transformers_runtime import TransformersRuntime
+from ai_karen_engine.integrations.llm_utils import ProviderNotAvailable
+
+
+class _DummyProvider:
+    def __init__(self, text, model="auto"):
+        self._text=text
+        self.model=model
+    def generate_text(self, prompt, **kwargs):
+        return self._text
+
+
+@pytest.mark.asyncio
+async def test_builtin_engine_vllm_failure_falls_back_to_transformers_with_attempts(monkeypatch):
+    def _get_provider(pid, model=None):
+        if pid == "builtin_vllm":
+            raise ProviderNotAvailable("down")
+        return _DummyProvider("transformers live proof", model="gpt2")
+
+    monkeypatch.setattr("ai_karen_engine.integrations.llm_registry.get_provider", _get_provider)
+    engine = BuiltinProviderEngine()
+    task = ExpressionTask(task_id="t1", kind="chat", messages=[{"content":"hi"}], response_mode="chat", required_capabilities=["chat"], forbidden_capabilities=[], request_id="r1", correlation_id="c1", preferred_provider="builtin_vllm", preferred_model="auto")
+    result = await engine.generate(task)
+    assert result.text == "transformers live proof"
+    assert result.provider == "builtin_transformers"
+    assert result.runtime_engine == "transformers"
+    assert result.metadata["response_source"] == "fallback_provider_runtime"
+    assert any(a["status"] == "failed" for a in result.metadata["provider_attempts"])
+
+
+def test_transformers_runtime_raises_when_no_real_generation_available():
+    runtime = TransformersRuntime()
+    runtime._transformers_available = False
+    runtime._pipeline = None
+    with pytest.raises(ProviderNotAvailable):
+        runtime.generate("hello")

--- a/src/ui_launchers/Karen-AI-Theme/src/lib/model-runtime-inventory.ts
+++ b/src/ui_launchers/Karen-AI-Theme/src/lib/model-runtime-inventory.ts
@@ -205,24 +205,6 @@ export const sortProviderModels = <T extends RuntimeProviderModel>(
   });
 };
 
-const SYSTEM_FALLBACK_PROVIDER_ID = 'builtin_transformers';
-
-// Backend provides all provider truth; no frontend seeding needed.
-// Providers like builtin_vllm, builtin_transformers come from /api/settings/model
-const SYSTEM_FALLBACK_SEED: Pick<RuntimeProviderDetails, 'id' | 'display_name' | 'description' | 'provider_type' | 'default_model' | 'selected_model' | 'supports_model_discovery' | 'supports_model_pull' | 'supports_custom_auth' | 'supports_manual_model_entry' | 'supports_base_url_override'> = {
-  id: SYSTEM_FALLBACK_PROVIDER_ID,
-  display_name: 'Transformers',
-  description: 'Automatic fallback runtime for embeddings and emergency generation.',
-  provider_type: 'builtin',
-  default_model: 'auto',
-  selected_model: 'auto',
-  supports_model_discovery: true,  // Enable dynamic model discovery
-  supports_model_pull: false,
-  supports_custom_auth: false,
-  supports_manual_model_entry: false,
-  supports_base_url_override: false,
-};
-
 export const getRuntimeProviderBucket = (
   provider: RuntimeProviderDetails,
 ): RuntimeProviderBucket => {
@@ -337,13 +319,7 @@ export function normalizeModelSettingsResponse(response: RuntimeSettingsResponse
   const customProviders = providers.filter((provider) => getRuntimeProviderBucket(provider) === 'custom');
   const thirdPartyProviders = providers.filter((provider) => getRuntimeProviderBucket(provider) === 'thirdParty');
 
-  // System fallback provider is constructed from backend's builtin_transformers data
-  const transformersProvider = providers.find((p) => p.id === SYSTEM_FALLBACK_PROVIDER_ID);
-  const systemFallbackProvider = {
-    ...SYSTEM_FALLBACK_SEED,
-    ...(transformersProvider || {}),
-    models: transformersProvider?.models || [],
-  } satisfies NormalizedRuntimeProvider;
+  const systemFallbackProvider: NormalizedRuntimeProvider | null = null;
 
   const selectedProvider =
     providers.find((provider) => provider.id === response.selected_provider)?.id ||
@@ -473,7 +449,7 @@ export function normalizeRuntimeProviderCatalogResponse(
     localProviders,
     thirdPartyProviders,
     customProviders,
-    systemFallbackProvider: providers.find((provider) => provider.id === SYSTEM_FALLBACK_PROVIDER_ID) || null,
+    systemFallbackProvider: providers.find((provider) => provider.id === "builtin_transformers") || null,
     timeout_seconds: undefined,
     auto_download: undefined,
     fallback_hierarchy: response.fallback_order,


### PR DESCRIPTION
### Motivation
- Improve provider/model validation by checking against the canonical runtime provider catalog instead of a static available models list.
- Ensure the runtime provider catalog can boot a sensible fallback catalog when settings payload or discovery fails to avoid empty provider lists.
- Make the builtin provider expression engine and provider runtime more robust and forensic by tracking attempts, failures, and clearer degradation/response metadata.
- Surface correct error semantics from local `TransformersRuntime` and simplify UI behavior around system fallback providers.

### Description
- Added an async `validate_provider_model` in `runtime.py` and replaced the old `validate_model` call in the `/chat` flow to validate provider/model selections against `get_runtime_provider_catalog` at runtime.
- Extended `models/runtime_api.py` with `errors` fields and a `_build_bootstrap_runtime_catalog` function that returns a minimal bootstrap catalog when no providers are discovered or when catalog construction fails, and return that bootstrap catalog on exception or when provider list is empty.
- Hardened settings endpoint access checks in `models/settings.py` to handle `current_user` as either a dict or object and removed the `llama-cpp` custom provider template.
- Refactored `core/expression/engines/builtin_provider_engine.py` to collect detailed `provider_attempts`, correctly call provider APIs (`generate_text_async`, `generate_text`, `generate`), derive `runtime_engine`, `response_source`, `fallback_level`, `degraded_mode`, and attach a comprehensive `metadata` object to `ExpressionResult`.
- Updated `inference/transformers_runtime.py` to raise `ProviderNotAvailable` when transformers are unavailable and `GenerationFailed` when generation fails, and to raise for streaming, instead of silently falling back.
- Deferred imports and improved typing in `services/provider_runtime.py`, changed emergency result to use `actual_provider=None`, and preserved detailed provider attempt records and metadata for emergency responses.
- Small changes in expression gateway and provider policy modules to support the engine/provider decision flow and imports.
- Updated UI helper `model-runtime-inventory.ts` to stop seeding a client-side system fallback provider and instead rely on backend `builtin_transformers` entry or `null` for `systemFallbackProvider` when absent.
- Added unit tests in `tests/test_builtin_provider_engine_runtime.py` to validate fallback from `builtin_vllm` to `builtin_transformers` and `TransformersRuntime` error behavior.

### Testing
- Ran the new unit tests in `src/ai_karen_engine/tests/test_builtin_provider_engine_runtime.py` with `pytest` and `pytest -q` showing both tests passed. 
- No other automated test failures were observed while iterating on the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc7a388fc4832499edf9a83e9d5d66)